### PR TITLE
Fix enrichment bug

### DIFF
--- a/blocks/enrichment/enrichment.js
+++ b/blocks/enrichment/enrichment.js
@@ -43,7 +43,8 @@ export default async function decorate(block) {
       if (section) {
         block.closest('.section').classList.add(...section.classList);
         const wrapper = block.closest('.enrichment-wrapper');
-        section.childNodes.forEach((child) => wrapper.parentNode.insertBefore(child, wrapper));
+        Array.from(section.children)
+          .forEach((child) => wrapper.parentNode.insertBefore(child, wrapper));
       }
     });
 

--- a/blocks/enrichment/enrichment.js
+++ b/blocks/enrichment/enrichment.js
@@ -39,12 +39,21 @@ export default async function decorate(block) {
   (await Promise.all(matchingFragments.map((path) => loadFragment(path))))
     .filter((fragment) => fragment)
     .forEach((fragment) => {
-      const section = fragment.querySelector(':scope .section');
-      if (section) {
-        block.closest('.section').classList.add(...section.classList);
+      const sections = fragment.querySelectorAll(':scope .section');
+
+      // If only single section, replace enrichment block with content of section
+      if (sections.length === 1) {
+        block.closest('.section').classList.add(...sections[0].classList);
         const wrapper = block.closest('.enrichment-wrapper');
-        Array.from(section.children)
+        Array.from(sections[0].children)
           .forEach((child) => wrapper.parentNode.insertBefore(child, wrapper));
+      } else if (sections.length > 1) {
+        // If multiple section, append them to current section
+        const blockSection = block.closest('.section');
+        Array.from(sections)
+          .reverse()
+          .forEach((section) => blockSection
+            .parentNode.insertBefore(section, blockSection.nextSibling));
       }
     });
 

--- a/blocks/enrichment/enrichment.js
+++ b/blocks/enrichment/enrichment.js
@@ -41,14 +41,14 @@ export default async function decorate(block) {
     .forEach((fragment) => {
       const sections = fragment.querySelectorAll(':scope .section');
 
-      // If only single section, replace enrichment block with content of section
+      // If only single section, replace block with content of section
       if (sections.length === 1) {
         block.closest('.section').classList.add(...sections[0].classList);
         const wrapper = block.closest('.enrichment-wrapper');
         Array.from(sections[0].children)
           .forEach((child) => wrapper.parentNode.insertBefore(child, wrapper));
       } else if (sections.length > 1) {
-        // If multiple section, append them to current section
+        // If multiple sections, insert them after section of block
         const blockSection = block.closest('.section');
         Array.from(sections)
           .reverse()


### PR DESCRIPTION
* Enrichments would break if there are `#text` elements returned by `section.childNodes`. So instead `section.children` is used.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.hlx.live/
- After: 
    - https://enrichment-fix--aem-boilerplate-commerce--hlxsites.hlx.live/
    - https://enrichment-fix--aem-boilerplate-commerce--hlxsites.hlx.live/products/crown-summit-backpack/24-MB03
    - https://enrichment-fix--aem-boilerplate-commerce--hlxsites.hlx.live/products/endurance-watch/24-MG01 (multiple sections)
    - https://enrichment-fix--aem-boilerplate-commerce--hlxsites.hlx.live/products/rival-field-messenger/24-MB06 (single section)
    - https://enrichment-fix--aem-boilerplate-commerce--hlxsites.hlx.live/gear
