### PR TITLE
Add getConsent method

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,6 +1,7 @@
-// eslint-disable-next-line import/no-cycle
+/* eslint-disable import/no-cycle */
 import { sampleRUM } from './aem.js';
 import { getConfigValue } from './configs.js';
+import { getConsent } from './scripts.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
@@ -8,29 +9,31 @@ sampleRUM('cwv');
 // add more delayed functionality here
 
 // Load Commerce events SDK and collector
-const config = {
-  environmentId: await getConfigValue('commerce-environment-id'),
-  environment: await getConfigValue('commerce-environment') === 'Production' ? 'prod' : 'non-prod',
-  storeUrl: await getConfigValue('commerce-store-url'),
-  websiteId: parseInt(await getConfigValue('commerce-website-id'), 10),
-  websiteCode: await getConfigValue('commerce-website-code'),
-  storeId: parseInt(await getConfigValue('commerce-store-id'), 10),
-  storeCode: await getConfigValue('commerce-store-code'),
-  storeViewId: parseInt(await getConfigValue('commerce-store-view-id'), 10),
-  storeViewCode: await getConfigValue('commerce-store-view-code'),
-  websiteName: await getConfigValue('commerce-website-name'),
-  storeName: await getConfigValue('commerce-store-name'),
-  storeViewName: await getConfigValue('commerce-store-view-name'),
-  baseCurrencyCode: await getConfigValue('commerce-base-currency-code'),
-  storeViewCurrencyCode: await getConfigValue('commerce-base-currency-code'),
-  storefrontTemplate: 'Franklin',
-};
+if (getConsent('commerce-collection')) {
+  const config = {
+    environmentId: await getConfigValue('commerce-environment-id'),
+    environment: await getConfigValue('commerce-environment') === 'Production' ? 'prod' : 'non-prod',
+    storeUrl: await getConfigValue('commerce-store-url'),
+    websiteId: parseInt(await getConfigValue('commerce-website-id'), 10),
+    websiteCode: await getConfigValue('commerce-website-code'),
+    storeId: parseInt(await getConfigValue('commerce-store-id'), 10),
+    storeCode: await getConfigValue('commerce-store-code'),
+    storeViewId: parseInt(await getConfigValue('commerce-store-view-id'), 10),
+    storeViewCode: await getConfigValue('commerce-store-view-code'),
+    websiteName: await getConfigValue('commerce-website-name'),
+    storeName: await getConfigValue('commerce-store-name'),
+    storeViewName: await getConfigValue('commerce-store-view-name'),
+    baseCurrencyCode: await getConfigValue('commerce-base-currency-code'),
+    storeViewCurrencyCode: await getConfigValue('commerce-base-currency-code'),
+    storefrontTemplate: 'Franklin',
+  };
 
-window.adobeDataLayer.push(
-  { storefrontInstanceContext: config },
-  { eventForwardingContext: { commerce: true, aep: false } },
-);
+  window.adobeDataLayer.push(
+    { storefrontInstanceContext: config },
+    { eventForwardingContext: { commerce: true, aep: false } },
+  );
 
-// Load events SDK and collector
-import('./commerce-events-sdk.js');
-import('./commerce-events-collector.js');
+  // Load events SDK and collector
+  import('./commerce-events-sdk.js');
+  import('./commerce-events-collector.js');
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -226,6 +226,17 @@ export async function loadFragment(path) {
   return null;
 }
 
+/**
+ * Check if consent was given for a specific topic.
+ * @param {*} topic Topic identifier
+ * @returns {boolean} True if consent was given
+ */
+// eslint-disable-next-line no-unused-vars
+export function getConsent(topic) {
+  console.warn('getConsent not implemented');
+  return true;
+}
+
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);


### PR DESCRIPTION
* Add common `getConsent` method which is used by Commerce functionality to check if a shopper has given consent for certain topics of data collection
* Add warning console output to ensure the method is implemented during projects
* Added consent checks for:
    * Storefront events collector
    * Product view history
    * Purchase history

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.hlx.live/
- After: https://consent-check--aem-boilerplate-commerce--hlxsites.hlx.live/
