### PR TITLE
Improve product recommendations

### DIFF
--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -200,22 +200,22 @@ export default async function decorate(block) {
   let visibility = false;
 
   function handleProductChanges({ productContext }) {
-    context.currentSku = productContext.sku;
+    context.currentSku = productContext?.sku;
     loadRecommendation(block, context, visibility, filters);
   }
 
   function handleCategoryChanges({ categoryContext }) {
-    context.category = categoryContext.name;
+    context.category = categoryContext?.name;
     loadRecommendation(block, context, visibility, filters);
   }
 
   function handlePageTypeChanges({ pageContext }) {
-    context.pageType = pageContext.pageType;
+    context.pageType = pageContext?.pageType;
     loadRecommendation(block, context, visibility, filters);
   }
 
   function handleCartChanges({ shoppingCartContext }) {
-    context.cartSkus = shoppingCartContext.items.map(({ product }) => product.sku);
+    context.cartSkus = shoppingCartContext?.items?.map(({ product }) => product.sku);
     loadRecommendation(block, context, visibility, filters);
   }
 

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import { readBlockConfig } from '../../scripts/aem.js';
 import { performCatalogServiceQuery } from '../../scripts/commerce.js';
 import { getConfigValue } from '../../scripts/configs.js';
 
@@ -41,7 +42,7 @@ const recommendationsQuery = `query GetRecommendations(
   }
 }`;
 
-let recommendationsPromise;
+let unitsPromise;
 
 function renderPlaceholder(block) {
   block.innerHTML = `<h2></h2>
@@ -81,9 +82,9 @@ function renderItem(unitId, product) {
   return item;
 }
 
-function renderItems(block, recommendations) {
+function renderItems(block, results) {
   // Render only first recommendation
-  const [recommendation] = recommendations.results;
+  const [recommendation] = results;
   if (!recommendation) {
     // Hide block content if no recommendations are available
     block.textContent = '';
@@ -134,7 +135,12 @@ const mapUnit = (unit) => ({
   })),
 });
 
-async function loadRecommendation(block, context) {
+async function loadRecommendation(block, context, visibility, filters) {
+  // Only load once the recommendation becomes visible
+  if (!visibility) {
+    return;
+  }
+
   // Only proceed if all required data is available
   if (!context.pageType
     || (context.pageType === 'Product' && !context.currentSku)
@@ -143,67 +149,74 @@ async function loadRecommendation(block, context) {
     return;
   }
 
-  if (recommendationsPromise) {
-    return;
+  if (!unitsPromise) {
+    const storeViewCode = await getConfigValue('commerce-store-view-code');
+    // Get product view history
+    try {
+      const viewHistory = window.localStorage.getItem(`${storeViewCode}:productViewHistory`) || '[]';
+      context.userViewHistory = JSON.parse(viewHistory);
+    } catch (e) {
+      window.localStorage.removeItem('productViewHistory');
+      console.error('Error parsing product view history', e);
+    }
+
+    // Get purchase history
+    try {
+      const purchaseHistory = window.localStorage.getItem(`${storeViewCode}:purchaseHistory`) || '[]';
+      context.userPurchaseHistory = JSON.parse(purchaseHistory);
+    } catch (e) {
+      window.localStorage.removeItem('purchaseHistory');
+      console.error('Error parsing purchase history', e);
+    }
+
+    window.adobeDataLayer.push((dl) => {
+      dl.push({ event: 'recs-api-request-sent', eventInfo: { ...dl.getState() } });
+    });
+
+    unitsPromise = performCatalogServiceQuery(recommendationsQuery, context);
+    const { recommendations } = await unitsPromise;
+
+    window.adobeDataLayer.push((dl) => {
+      dl.push({ recommendationsContext: { units: recommendations.results.map(mapUnit) } });
+      dl.push({ event: 'recs-api-response-received', eventInfo: { ...dl.getState() } });
+    });
   }
 
-  const storeViewCode = await getConfigValue('commerce-store-view-code');
-  // Get product view history
-  try {
-    const viewHistory = window.localStorage.getItem(`${storeViewCode}:productViewHistory`) || '[]';
-    context.userViewHistory = JSON.parse(viewHistory);
-  } catch (e) {
-    window.localStorage.removeItem('productViewHistory');
-    console.error('Error parsing product view history', e);
-  }
+  let { results } = (await unitsPromise).recommendations;
+  results = results.filter((unit) => (filters.typeId ? unit.typeId === filters.typeId : true));
 
-  // Get purchase history
-  try {
-    const purchaseHistory = window.localStorage.getItem(`${storeViewCode}:purchaseHistory`) || '[]';
-    context.userPurchaseHistory = JSON.parse(purchaseHistory);
-  } catch (e) {
-    window.localStorage.removeItem('purchaseHistory');
-    console.error('Error parsing purchase history', e);
-  }
-
-  window.adobeDataLayer.push((dl) => {
-    dl.push({ event: 'recs-api-request-sent', eventInfo: { ...dl.getState() } });
-  });
-
-  recommendationsPromise = performCatalogServiceQuery(recommendationsQuery, context);
-  const { recommendations } = await recommendationsPromise;
-
-  window.adobeDataLayer.push((dl) => {
-    dl.push({ recommendationsContext: { units: recommendations.results.map(mapUnit) } });
-    dl.push({ event: 'recs-api-response-received', eventInfo: { ...dl.getState() } });
-  });
-
-  renderItems(block, recommendations);
+  renderItems(block, results);
 }
 
 export default async function decorate(block) {
+  const config = readBlockConfig(block);
+  const filters = {};
+  if (config.typeid) {
+    filters.typeId = config.typeid;
+  }
   renderPlaceholder(block);
 
   const context = {};
+  let visibility = false;
 
   function handleProductChanges({ productContext }) {
     context.currentSku = productContext.sku;
-    loadRecommendation(block, context);
+    loadRecommendation(block, context, visibility, filters);
   }
 
   function handleCategoryChanges({ categoryContext }) {
     context.category = categoryContext.name;
-    loadRecommendation(block, context);
+    loadRecommendation(block, context, visibility, filters);
   }
 
   function handlePageTypeChanges({ pageContext }) {
     context.pageType = pageContext.pageType;
-    loadRecommendation(block, context);
+    loadRecommendation(block, context, visibility, filters);
   }
 
   function handleCartChanges({ shoppingCartContext }) {
     context.cartSkus = shoppingCartContext.items.map(({ product }) => product.sku);
-    loadRecommendation(block, context);
+    loadRecommendation(block, context, visibility, filters);
   }
 
   window.adobeDataLayer.push((dl) => {
@@ -212,4 +225,16 @@ export default async function decorate(block) {
     dl.addEventListener('adobeDataLayer:change', handleCategoryChanges, { path: 'categoryContext' });
     dl.addEventListener('adobeDataLayer:change', handleCartChanges, { path: 'shoppingCartContext' });
   });
+
+  const section = block.closest('.section');
+  const inViewObserver = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        visibility = true;
+        loadRecommendation(block, context, visibility, filters);
+        inViewObserver.disconnect();
+      }
+    });
+  });
+  inViewObserver.observe(section);
 }

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -3,6 +3,8 @@ import { readBlockConfig } from '../../scripts/aem.js';
 import { performCatalogServiceQuery } from '../../scripts/commerce.js';
 import { getConfigValue } from '../../scripts/configs.js';
 
+const isMobile = window.matchMedia('only screen and (max-width: 900px)').matches;
+
 const recommendationsQuery = `query GetRecommendations(
   $pageType: PageType!
   $category: String
@@ -197,7 +199,7 @@ export default async function decorate(block) {
   renderPlaceholder(block);
 
   const context = {};
-  let visibility = false;
+  let visibility = !isMobile;
 
   function handleProductChanges({ productContext }) {
     context.currentSku = productContext?.sku;
@@ -226,15 +228,17 @@ export default async function decorate(block) {
     dl.addEventListener('adobeDataLayer:change', handleCartChanges, { path: 'shoppingCartContext' });
   });
 
-  const section = block.closest('.section');
-  const inViewObserver = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        visibility = true;
-        loadRecommendation(block, context, visibility, filters);
-        inViewObserver.disconnect();
-      }
+  if (isMobile) {
+    const section = block.closest('.section');
+    const inViewObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          visibility = true;
+          loadRecommendation(block, context, visibility, filters);
+          inViewObserver.disconnect();
+        }
+      });
     });
-  });
-  inViewObserver.observe(section);
+    inViewObserver.observe(section);
+  }
 }

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -253,6 +253,9 @@ export async function trackHistory() {
   const storeViewCode = await getConfigValue('commerce-store-view-code');
   window.adobeDataLayer.push((dl) => {
     dl.addEventListener('adobeDataLayer:change', (event) => {
+      if (!event.productContext) {
+        return;
+      }
       const key = `${storeViewCode}:productViewHistory`;
       let viewHistory = JSON.parse(window.localStorage.getItem(key) || '[]');
       viewHistory = viewHistory.filter((item) => item.sku !== event.productContext.sku);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -247,9 +247,9 @@ async function loadLazy(doc) {
     loadFooter(doc.querySelector('footer')),
     loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`),
     loadFonts(),
+    import('./acdl/adobe-client-data-layer.min.js'),
   ]);
 
-  await import('./acdl/adobe-client-data-layer.min.js');
   if (sessionStorage.getItem('acdl:debug')) {
     import('./acdl/validate.js');
   }


### PR DESCRIPTION
* Improve loading of ACDL to create a larger gap to delayed.js
* Add support for filtering by `typeId` to product recommendations block for use cases where there is more than one unit on a single page.
* Recommendations block is now only rendered when the section it's contained in is in view (mobile only).
* Added checks when reading from ACDL as MSE SDK might set those contexts to `null`.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.hlx.live/
- After:
  - https://improve-recs--aem-boilerplate-commerce--hlxsites.hlx.live/
  - https://improve-recs--aem-boilerplate-commerce--hlxsites.hlx.live/products/crown-summit-backpack/24-MB03
  - https://improve-recs--aem-boilerplate-commerce--hlxsites.hlx.live/products/hollister-backyard-sweatshirt/MH05
