### PR TITLE
Fix invalid storefront events

### DIFF
--- a/blocks/product-list-page-custom/ProductList.js
+++ b/blocks/product-list-page-custom/ProductList.js
@@ -8,6 +8,7 @@ import {
 } from '../../scripts/commerce.js';
 
 const html = htm.bind(h);
+const searchUnitId = 'livesearch-plp';
 
 class ProductCard extends Component {
   constructor(props) {
@@ -49,7 +50,7 @@ class ProductCard extends Component {
   onProductClick(product) {
     window.adobeDataLayer.push((dl) => {
       // TODO: Remove eventInfo once collector is updated
-      dl.push({ event: 'search-product-click', eventInfo: { ...dl.getState(), searchUnitId: 'searchUnitId', sku: product.sku } });
+      dl.push({ event: 'search-product-click', eventInfo: { ...dl.getState(), searchUnitId, sku: product.sku } });
     });
   }
 

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -132,9 +132,10 @@ const mapUnit = (unit) => ({
     rank: index,
     score: 0,
     productId: parseInt(product.externalId, 10) || 0,
-    type: '?',
-    queryType: product.__typename,
+    type: product.__typename,
+    queryType: 'primary',
   })),
+  pagePlacement: '',
 });
 
 async function loadRecommendation(block, context, visibility, filters) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -201,6 +201,9 @@ async function loadEager(doc) {
       minXOffset: 0,
       minYOffset: 0,
     },
+    shoppingCartContext: {
+      totalQuantity: 0,
+    },
   });
   if (pageType !== 'Product') {
     window.adobeDataLayer.push((dl) => {


### PR DESCRIPTION
While checking the storefronts events emitted to Snowplow by the boilerplate I noticed the following two errors which are fixed by this PR:

* Recommendations unit context is missing a placement. 
    * As we do not know the placement, setting it to an empty string makes the event valid according to the schema.
  ```json
  {
    "schemaKey": "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",
    "error": {
      "error": "ValidationError",
      "dataReports": [
        {
          "message": "$.placement: is missing but it is required",
          "path": "$",
          "keyword": "required",
          "targets": [
            "placement"
          ]
        }
      ]
    }
  }
  ```
* Product page view event requires a shopping cart context.
    * Trivial solution for this problem is to initialise the shopping cart context to an empty cart and let the minicart or cart implementation set the full context once available.
  ```json
  {
      "schemaKey": "iglu:com.adobe.magento.entity/shopping-cart/jsonschema/2-0-0",
      "error": {
        "error": "ValidationError",
        "dataReports": [
          {
            "message": "$.itemsCount: is missing but it is required",
            "path": "$",
            "keyword": "required",
            "targets": [
              "itemsCount"
            ]
          }
        ]
      }
  }
  ```
* Product click event in the context of PLP and search did not properly send the search results context.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.hlx.live/
- After: 
    - https://acdl-bugs--aem-boilerplate-commerce--hlxsites.hlx.live/
    - https://acdl-bugs--aem-boilerplate-commerce--hlxsites.hlx.live/products/crown-summit-backpack/24-MB03
    - https://acdl-bugs--aem-boilerplate-commerce--hlxsites.hlx.live/drafts/mabecker/product-list-custom
