### PR TITLE
Remove case changes from product SKUs

### DIFF
--- a/blocks/product-details-custom/product-details-custom.js
+++ b/blocks/product-details-custom/product-details-custom.js
@@ -23,7 +23,7 @@ async function getVariantDetails(variantIds, sku) {
   const result = await performCatalogServiceQuery(
     refineProductQuery,
     {
-      sku: sku.toUpperCase(),
+      sku,
       variantIds,
     },
   );
@@ -57,9 +57,9 @@ async function setJsonLdProduct(product) {
       '@type': 'Brand',
       name: brand?.value,
     },
-    url: new URL(`/products/${urlKey}/${sku.toLowerCase()}`, window.location),
+    url: new URL(`/products/${urlKey}/${sku}`, window.location),
     sku,
-    '@id': new URL(`/products/${urlKey}/${sku.toLowerCase()}`, window.location),
+    '@id': new URL(`/products/${urlKey}/${sku}`, window.location),
   }, 'product');
 }
 

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -48,9 +48,9 @@ async function setJsonLdProduct(product) {
       '@type': 'Brand',
       name: brand?.value,
     },
-    url: new URL(`/products/${urlKey}/${sku.toLowerCase()}`, window.location),
+    url: new URL(`/products/${urlKey}/${sku}`, window.location),
     sku,
-    '@id': new URL(`/products/${urlKey}/${sku.toLowerCase()}`, window.location),
+    '@id': new URL(`/products/${urlKey}/${sku}`, window.location),
   }, 'product');
 }
 
@@ -99,10 +99,6 @@ function setMetaTags(product) {
   createMetaTag('og:image:secure_url', metaImage, 'property');
   createMetaTag('og:product:price:amount', price.value, 'property');
   createMetaTag('og:product:price:currency', price.currency, 'property');
-
-  createMetaTag('twitter:card', product.shortDescription, 'name');
-  createMetaTag('twitter:title', product.metaTitle, 'name');
-  createMetaTag('twitter:image', metaImage, 'name');
 }
 
 export default async function decorate(block) {

--- a/blocks/product-list-page-custom/ProductList.js
+++ b/blocks/product-list-page-custom/ProductList.js
@@ -79,12 +79,12 @@ class ProductCard extends Component {
     return html`
       <li index=${index} ref=${secondLastProduct}>
         <div class="picture">
-          <a onClick=${() => this.onProductClick(product)} href="/products/${product.urlKey}/${product.sku.toLowerCase()}">
+          <a onClick=${() => this.onProductClick(product)} href="/products/${product.urlKey}/${product.sku}">
             ${this.renderImage(index < numberOfEagerImages ? 'eager' : 'lazy')}
           </a>
         </div>
         <div class="name">
-          <a onClick=${() => this.onProductClick(product)} href="/products/${product.urlKey}/${product.sku.toLowerCase()}" dangerouslySetInnerHTML=${{__html: product.name}} />
+          <a onClick=${() => this.onProductClick(product)} href="/products/${product.urlKey}/${product.sku}" dangerouslySetInnerHTML=${{__html: product.name}} />
         </div>
         <div class="price">${renderPrice(product, this.formatter.format, html, Fragment)}</div>
       </li>`;

--- a/blocks/product-list-page-custom/product-list-page-custom.js
+++ b/blocks/product-list-page-custom/product-list-page-custom.js
@@ -411,7 +411,7 @@ class ProductListPage extends Component {
           products: this.state.products.items.map((p, index) => ({
             name: p.name,
             sku: p.sku,
-            url: new URL(`/products/${p.urlKey}/${p.sku.toLowerCase()}`, window.location).toString(),
+            url: new URL(`/products/${p.urlKey}/${p.sku}`, window.location).toString(),
             imageUrl: p.images?.length ? p.images[0].url : '',
             price: p.price?.final?.amount?.value ?? p.priceRange?.minimum?.final?.amount?.value,
             rank: index,

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -71,7 +71,7 @@ function renderItem(unitId, product) {
   };
 
   const item = document.createRange().createContextualFragment(`<div class="product-grid-item">
-    <a href="/products/${urlKey}/${product.sku.toLowerCase()}">
+    <a href="/products/${urlKey}/${product.sku}">
       <picture>
         <source type="image/webp" srcset="${image}?width=300&format=webply&optimize=medium" />
         <img loading="lazy" alt="${product.name}" width="300" height="375" src="${image}?width=300&format=jpg&optimize=medium" />

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -230,8 +230,6 @@ export function getSkuFromUrl() {
 
 const productsCache = {};
 export async function getProduct(sku) {
-  // eslint-disable-next-line no-param-reassign
-  sku = sku.toUpperCase();
   if (productsCache[sku]) {
     return productsCache[sku];
   }

--- a/scripts/minicart/Minicart.js
+++ b/scripts/minicart/Minicart.js
@@ -92,10 +92,10 @@ class ProductCard extends Component {
     return html`<li>
       <div class="minicart-product">
         <div class="image">
-          <a href=${`/products/${product.url_key}/${product.sku.toLowerCase()}`}>${ProductCard.renderImage(item)}</a>
+          <a href=${`/products/${product.url_key}/${product.sku}`}>${ProductCard.renderImage(item)}</a>
         </div>
         <div class="info">
-          <div class="name"><a href=${`/products/${product.url_key}/${product.sku.toLowerCase()}`} dangerouslySetInnerHTML=${{ __html: product.name }} /></div>
+          <div class="name"><a href=${`/products/${product.url_key}/${product.sku}`} dangerouslySetInnerHTML=${{ __html: product.name }} /></div>
           ${configurable_options && (html`<div class="options">
             <input type="checkbox" id="see-options-${index}" />
             <label for="see-options-${index}">See Details</label>

--- a/tools/pdp-metadata/pdp-metadata.js
+++ b/tools/pdp-metadata/pdp-metadata.js
@@ -84,13 +84,12 @@ const getProducts = async (config, pageNumber) => {
         productView: {
           ...item.productView,
           image: baseImageUrl,
-          path: `/products/${urlKey}/${sku.toLowerCase()}`,
+          path: `/products/${urlKey}/${sku}`,
           meta_keyword: (metaKeyword !== null) ? metaKeyword : '',
           meta_title: he.decode((metaTitle !== '') ? metaTitle : name),
           meta_description: finalDescription,
           'og:image': baseImageUrl,
           'og:image:secure_url': baseImageUrl,
-          'twitter:image': baseImageUrl,
         },
       };
     }));
@@ -131,9 +130,6 @@ const getProducts = async (config, pageNumber) => {
       'og:url',
       'og:image',
       'og:image:secure_url',
-      'twitter:card',
-      'twitter:title',
-      'twitter:image'
     ],
   ];
   products.forEach(({ productView: metaData }) => {
@@ -149,9 +145,6 @@ const getProducts = async (config, pageNumber) => {
         `${basePath}${metaData.path}`, // og:url
         metaData['og:image'], // og:image
         metaData['og:image:secure_url'], // og:image:secure_url
-        metaData.meta_description, // twitter:card
-        metaData.meta_title, // twitter:title
-        metaData['twitter:image'], // twitter:image
       ],
     );
   });


### PR DESCRIPTION
* Remove case changes for product SKUs. Now they are consistently used as they are returned by the API.
* Removed explicit `twitter:_` meta tags as these are generated automatically and Twitter/X also uses OpenGraph (`og:_`) tags as fallback.
* Server-side generated meta tags from #72 are now available for all PDPs.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.hlx.live/
- After: 
    - https://sku-lowercase--aem-boilerplate-commerce--hlxsites.hlx.live/
    - https://sku-lowercase--aem-boilerplate-commerce--hlxsites.hlx.live/gear
    - https://sku-lowercase--aem-boilerplate-commerce--hlxsites.hlx.live/products/hollister-backyard-sweatshirt/MH05
    - https://sku-lowercase--aem-boilerplate-commerce--hlxsites.hlx.live/drafts/mabecker/product-list-custom
    - https://sku-lowercase--aem-boilerplate-commerce--hlxsites.hlx.live/drafts/mabecker/product-details-custom
