### PR TITLE
fix: prevent soft 404 errors in search engine indexing

### DIFF
--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -304,6 +304,15 @@ export async function loadErrorPage(code = 404) {
   document.body.innerHTML = doc.body.innerHTML;
   document.head.innerHTML = doc.head.innerHTML;
 
+  // https://developers.google.com/search/docs/crawling-indexing/javascript/fix-search-javascript
+  // Point 2. prevent soft 404 errors
+  if (code === 404) {
+    const metaRobots = document.createElement('meta');
+    metaRobots.name = 'robots';
+    metaRobots.content = 'noindex';
+    document.head.appendChild(metaRobots);
+  }
+
   // When moving script tags via innerHTML, they are not executed. They need to be re-created.
   const notImportMap = (c) => c.textContent && c.type !== 'importmap';
   Array.from(document.head.querySelectorAll('script'))


### PR DESCRIPTION
Fix #88 

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.hlx.live/products/invalid-product1234
- After: https://prevent-soft-404-google--aem-boilerplate-commerce--hlxsites.hlx.live/products/invalid-product1234
