### PR TITLE
Remove catalog service preconnect tags

### DIFF
--- a/head.html
+++ b/head.html
@@ -29,6 +29,3 @@
 <link rel="modulepreload" href="/scripts/__dropins__/tools/initializer.js" />
 
 <link rel="stylesheet" href="/styles/styles.css" />
-
-<link rel="preconnect" href="https://catalog-service-sandbox.adobe.io" crossorigin="" />
-<link rel="preconnect" href="https://catalog-service.adobe.io" crossorigin="" />


### PR DESCRIPTION
* Remove `preconnect` tags for Catalog Service as Catalog Service should be proxied via CDN on the same hostname.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: 
    - https://remove-preconnect--aem-boilerplate-commerce--hlxsites.aem.live/
    - https://remove-preconnect--aem-boilerplate-commerce--hlxsites.aem.live/gear
    - https://remove-preconnect--aem-boilerplate-commerce--hlxsites.aem.live/products/hollister-backyard-sweatshirt/MH05
