### PR TITLE
Remove .d.ts files from deployment

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -1,5 +1,6 @@
 .*
 *.md
+*.d.ts
 karma.config.js
 LICENSE
 package.json


### PR DESCRIPTION
* Add `.d.ts` to `.hlxignore` to prevent them from being deployed. Those files are only required for local development.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: 
    - https://ts-hlxignore--aem-boilerplate-commerce--hlxsites.aem.live/
    - https://ts-hlxignore--aem-boilerplate-commerce--hlxsites.aem.live/scripts/__dropins__/storefront-pdp/api/index.d.ts (supposed to be 404)
