### PR TITLE
CAED-67 Checkout issues 

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -296,8 +296,8 @@ async function loadEager(doc) {
     await applyTemplates(doc);
 
     // Load LCP blocks
-    document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
+    document.body.classList.add('appear');
   }
 
   events.emit('eds/lcp', true);


### PR DESCRIPTION
From @pchoate-adobe 
> This issue came up during the BULK implementation. There was an issue where if you have the EDS header on checkout pages it would try to modify the DOM before the main element was fully ready to work. It was addressed slightly differently on BULK and we thought it should be ported here. Since the LCP check was already in place in this repository it was simply a matter of waiting for the LCP to finish before adding the appear class to the main div.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://caed-67--aem-boilerplate-commerce--hlxsites.aem.live/
