### PR TITLE
improve product recommendations events

### DIFF
--- a/blocks/product-recommendations/product-recommendations.css
+++ b/blocks/product-recommendations/product-recommendations.css
@@ -31,27 +31,12 @@ main .section>div.product-recommendations-wrapper {
     text-decoration: none;
 }
 
-.product-recommendations .product-grid .product-grid-item span {
+.product-recommendations .product-grid .product-grid-item a span {
     overflow: hidden;
     box-sizing: border-box;
     margin: 0;
     padding: .5rem 1rem 0 0;
     display: inline-block;
-}
-
-.product-recommendations .product-grid  .product-grid-item button {
-  border-radius: var(--shape-border-radius-3);
-  border:none;
-  padding: var(--spacing-xsmall) var(--spacing-medium);
-  cursor:pointer;
-  font: var(--type-button-2-font);
-  letter-spacing: var(--type-button-2-letter-spacing);
-  background: var(--color-brand-500) 0 0% no-repeat padding-box;
-  color: var(--color-neutral-50);
-}
-
-.product-recommendations .product-grid  .product-grid-item button:hover {
-  background-color: var(--color-button-hover);
 }
 
 .product-recommendations .product-grid picture {

--- a/blocks/product-recommendations/product-recommendations.css
+++ b/blocks/product-recommendations/product-recommendations.css
@@ -31,17 +31,27 @@ main .section>div.product-recommendations-wrapper {
     text-decoration: none;
 }
 
-.product-recommendations .product-grid .product-grid-item a:hover,
-.product-recommendations .product-grid .product-grid-item a:focus {
-    text-decoration: underline;
-}
-
 .product-recommendations .product-grid .product-grid-item span {
     overflow: hidden;
     box-sizing: border-box;
     margin: 0;
     padding: .5rem 1rem 0 0;
     display: inline-block;
+}
+
+.product-recommendations .product-grid  .product-grid-item button {
+  border-radius: var(--shape-border-radius-3);
+  border:none;
+  padding: var(--spacing-xsmall) var(--spacing-medium);
+  cursor:pointer;
+  font: var(--type-button-2-font);
+  letter-spacing: var(--type-button-2-letter-spacing);
+  background: var(--color-brand-500) 0 0% no-repeat padding-box;
+  color: var(--color-neutral-50);
+}
+
+.product-recommendations .product-grid  .product-grid-item button:hover {
+  background-color: var(--color-button-hover);
 }
 
 .product-recommendations .product-grid picture {

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { addProductsToCart } from '@dropins/storefront-cart/api.js';
+import { Button, provider as UI } from '@dropins/tools/components.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 import { performCatalogServiceQuery } from '../../scripts/commerce.js';
 import { getConfigValue } from '../../scripts/configs.js';
@@ -101,10 +102,14 @@ function renderItem(unitId, product) {
       </picture>
       <span>${product.name}</span>
     </a>
-    <button>${ctaText}</button>
+    <span class="product-grid-cta"></span>
   </div>`);
   item.querySelector('a').addEventListener('click', clickHandler);
-  item.querySelector('button').addEventListener('click', addToCartHandler);
+  const buttonEl = item.querySelector('.product-grid-cta');
+  UI.render(Button, {
+    children: ctaText,
+    onClick: addToCartHandler,
+  })(buttonEl);
   return item;
 }
 

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -138,7 +138,6 @@ function renderItems(block, results) {
         window.adobeDataLayer.push((dl) => {
           dl.push({ event: 'recs-unit-view', eventInfo: { ...dl.getState(), unitId: recommendation.unitId } });
         });
-        inViewObserver.disconnect();
       }
     });
   }, { threshold: 0.5 });

--- a/cypress/src/assertions/adobeDataLayer.js
+++ b/cypress/src/assertions/adobeDataLayer.js
@@ -1,0 +1,18 @@
+/**
+ *
+ * @param {string} targetEvent a string representing the event name.
+ * @param {string[]} targetContexts an array of strings representing the contexts which should exist in the acdl
+ * @param {[]} adobeDataLayer a copy of the current ACDL under test
+ */
+export const expectsEventWithContext = (targetEvent, targetContexts, adobeDataLayer = []) => {
+  if (targetEvent) {
+    const targetEventIndex = adobeDataLayer.findIndex(data => data?.event === targetEvent);
+    expect(targetEventIndex, targetEvent).to.be.greaterThan(-1);
+  }
+  if (targetContexts?.length) {
+    targetContexts.forEach((targetContext) => {
+      const contextIndex = adobeDataLayer.findIndex(data => !!data[targetContext]);
+      expect(contextIndex, targetContext).to.be.greaterThan(-1);
+    });
+  }
+}

--- a/cypress/src/assertions/index.js
+++ b/cypress/src/assertions/index.js
@@ -169,3 +169,6 @@ export const assertAuthUser = (sign_up) => {
   // cy.contains(sign_up.lastName).should("be.visible");
   // cy.contains(sign_up.email).should("be.visible");
 };
+
+// imports and re-exports the functions from ./adobeDataLayer.js
+export * from './adobeDataLayer';

--- a/cypress/src/tests/e2eTests/events/initialization.spec.js
+++ b/cypress/src/tests/e2eTests/events/initialization.spec.js
@@ -1,11 +1,7 @@
-const baselineContexts = (adobeDataLayer) => {
-  const pageContextIndex = adobeDataLayer.findIndex(event => !!event?.pageContext);
-  const storefrontInstanceContextIndex = adobeDataLayer.findIndex(event => !!event?.storefrontInstanceContext);
-  const eventForwardingContextIndex = adobeDataLayer.findIndex(event => !!event?.eventForwardingContext);
+import { expectsEventWithContext } from "../../../assertions";
 
-  expect(pageContextIndex).to.be.greaterThan(-1);
-  expect(storefrontInstanceContextIndex).to.be.greaterThan(-1);
-  expect(eventForwardingContextIndex).to.be.greaterThan(-1);
+const baselineContexts = (adobeDataLayer) => {
+  expectsEventWithContext(null, ['pageContext', 'storefrontInstanceContext', 'eventForwardingContext'], adobeDataLayer)
 };
 
 it('has baseline contexts on homepage', () => {

--- a/cypress/src/tests/e2eTests/events/initiate-checkout.spec.js
+++ b/cypress/src/tests/e2eTests/events/initiate-checkout.spec.js
@@ -27,7 +27,7 @@ it("is sent on mini cart Checkout button click", () => {
     cy.window().then((win) => {
       cy.spy(win.adobeDataLayer, "push").as("adl");
       // add to cart
-      cy.get("span:contains('Add to Cart')").should("be.visible").click();
+      cy.get(".pdp-product__buttons span:contains('Add to Cart')").should("be.visible").click();
       // click the minicart toggle
       cy.get('button[data-count="1"]').should("be.visible").click();
       // click the checkout button
@@ -56,7 +56,7 @@ it("is sent on cart page Checkout button click", () => {
     products.configurable.urlPathWithOptions
   );
   // add to cart
-  cy.get("span:contains('Add to Cart')").should("be.visible").click();
+  cy.get(".pdp-product__buttons span:contains('Add to Cart')").should("be.visible").click();
   // after mini cart count updates, go to /cart page
   cy.get('button[data-count="1"]').should("be.visible");
   cy.visit("/cart");

--- a/cypress/src/tests/e2eTests/events/product-page-view.spec.js
+++ b/cypress/src/tests/e2eTests/events/product-page-view.spec.js
@@ -1,3 +1,4 @@
+import { expectsEventWithContext } from '../../../assertions';
 import { products } from '../../../fixtures';
 /**
  * https://github.com/adobe/commerce-events/blob/main/examples/events/product-page-view.md
@@ -9,18 +10,7 @@ it('is sent on product page view/render', () => {
   cy.waitForResource('commerce-events-collector.js')
     .then(() => {
       cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
-        const targetEventIndex = adobeDataLayer.findIndex(event => event?.event === 'product-page-view');
-        const pageContextIndex = adobeDataLayer.findIndex(event => !!event?.pageContext);
-        const storefrontInstanceContextIndex = adobeDataLayer.findIndex(event => !!event?.storefrontInstanceContext);
-        const productContextIndex = adobeDataLayer.findIndex(event => !!event?.productContext);
-        const shoppingCartContextIndex = adobeDataLayer.findIndex(event => !!event?.shoppingCartContext);
-
-        // expected contexts and event are in ACDL
-        expect(targetEventIndex).to.be.greaterThan(-1);
-        expect(pageContextIndex).to.be.greaterThan(-1);
-        expect(storefrontInstanceContextIndex).to.be.greaterThan(-1);
-        expect(productContextIndex).to.be.greaterThan(-1);
-        expect(shoppingCartContextIndex).to.be.greaterThan(-1);
+        expectsEventWithContext('product-page-view', ['pageContext', 'storefrontInstanceContext', 'productContext', 'shoppingCartContext'], adobeDataLayer);
       });
     });
 });

--- a/cypress/src/tests/e2eTests/events/recs.spec.js
+++ b/cypress/src/tests/e2eTests/events/recs.spec.js
@@ -1,3 +1,4 @@
+import { expectsEventWithContext } from "../../../assertions";
 /**
  * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-request-sent.md
  *   required contexts: page, storefront
@@ -11,19 +12,9 @@
  *
  */
 
-function expectsEventWithContext(event, contexts, adobeDataLayer) {
-  const targetEventIndex = adobeDataLayer.findIndex(data => data?.event === event);
-  expect(targetEventIndex, event).to.be.greaterThan(-1);
-  contexts.forEach((context) => {
-    const contextIndex = adobeDataLayer.findIndex(data => !!data[context]);
-    expect(contextIndex, context).to.be.greaterThan(-1);
-  });
-}
-
 it('api-request-sent, api-response-received, unit-impression-render', () => {
   cy.visit('/products/crown-summit-backpack/24-MB03');
-  cy.waitForResource('commerce-events-collector.js')
-  .then(() => {
+  cy.waitForResource('commerce-events-collector.js').then(() => {
     cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
       expectsEventWithContext(
         'recs-api-request-sent',
@@ -46,8 +37,7 @@ it('api-request-sent, api-response-received, unit-impression-render', () => {
 
 it('recs-unit-view', () => {
   cy.visit('/products/crown-summit-backpack/24-MB03');
-  cy.waitForResource('commerce-events-collector.js')
-  .then(() => {
+  cy.waitForResource('commerce-events-collector.js').then(() => {
     cy.get('.product-recommendations-wrapper').scrollIntoView({ duration: 1000 });
     cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
       expectsEventWithContext(

--- a/cypress/src/tests/e2eTests/events/recs.spec.js
+++ b/cypress/src/tests/e2eTests/events/recs.spec.js
@@ -55,6 +55,16 @@ it('recs-unit-view', () => {
         ['pageContext', 'storefrontInstanceContext', 'recommendationsContext'],
         adobeDataLayer,
       );
+
+      return adobeDataLayer;
+    }).then(adobeDataLayer => {
+      // triggers a second view when scrolled again
+      cy.get('.pdp-product__title').scrollIntoView({ duration: 50 }).then(() => {
+        cy.get('.product-recommendations-wrapper').scrollIntoView({ duration: 50 }).then(() => {
+          const eventCount = adobeDataLayer.filter(data => data?.event === 'recs-unit-view');
+          expect(eventCount).to.have.lengthOf(2);
+        });
+      });
     });
   });
 });

--- a/cypress/src/tests/e2eTests/events/recs.spec.js
+++ b/cypress/src/tests/e2eTests/events/recs.spec.js
@@ -1,0 +1,124 @@
+/**
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-request-sent.md
+ *   required contexts: page, storefront
+ *
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-response-received.md
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-unit-render.md
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-unit-view.md
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-item-click.md
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/recs-item-add-to-cart.md
+ *  required contexts: page, storefront, recommendations
+ *
+ */
+
+function expectsEventWithContext(event, contexts, adobeDataLayer) {
+  const targetEventIndex = adobeDataLayer.findIndex(data => data?.event === event);
+  expect(targetEventIndex, event).to.be.greaterThan(-1);
+  contexts.forEach((context) => {
+    const contextIndex = adobeDataLayer.findIndex(data => !!data[context]);
+    expect(contextIndex, context).to.be.greaterThan(-1);
+  });
+}
+
+it('api-request-sent, api-response-received, unit-impression-render', () => {
+  cy.visit('/products/crown-summit-backpack/24-MB03');
+  cy.waitForResource('commerce-events-collector.js')
+  .then(() => {
+    cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
+      expectsEventWithContext(
+        'recs-api-request-sent',
+        ['pageContext', 'storefrontInstanceContext'],
+        adobeDataLayer,
+      );
+      expectsEventWithContext(
+        'recs-api-response-received',
+        ['pageContext', 'storefrontInstanceContext', 'recommendationsContext'],
+        adobeDataLayer,
+      );
+      expectsEventWithContext(
+        'recs-unit-impression-render',
+        ['pageContext', 'storefrontInstanceContext', 'recommendationsContext'],
+        adobeDataLayer,
+      );
+    });
+  });
+});
+
+it('recs-unit-view', () => {
+  cy.visit('/products/crown-summit-backpack/24-MB03');
+  cy.waitForResource('commerce-events-collector.js')
+  .then(() => {
+    cy.get('.product-recommendations-wrapper').scrollIntoView({ duration: 1000 });
+    cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
+      expectsEventWithContext(
+        'recs-unit-view',
+        ['pageContext', 'storefrontInstanceContext', 'recommendationsContext'],
+        adobeDataLayer,
+      );
+    });
+  });
+});
+
+it('recs-item-click', () => {
+  cy.visit('/products/crown-summit-backpack/24-MB03');
+  cy.waitForResource("commerce-events-collector.js").then(() => {
+    cy.window().then((win) => {
+      cy.spy(win.adobeDataLayer, "push").as("adl");
+      cy.get('.product-grid-item')
+        .first()
+        .click()
+        .then(() => {
+          cy.get("@adl", { timeout: 2000 }).should((adobeDataLayerPush) => {
+            const targetEventIndex = adobeDataLayerPush.args.findIndex(
+              (event) => event[0]?.event === "recs-item-click"
+            );
+            const pageContextIndex = adobeDataLayerPush.args.findIndex(
+              (event) => !!event[0]?.eventInfo?.pageContext
+            );
+            const storefrontInstanceContextIndex = adobeDataLayerPush.args.findIndex(
+              (event) => !!event[0]?.eventInfo?.storefrontInstanceContext
+            );
+            const recommendationsContextIndex = adobeDataLayerPush.args.findIndex(
+              (event) => !!event[0]?.eventInfo?.recommendationsContext
+            );
+            expect(targetEventIndex, 'recs-item-click').to.be.greaterThan(-1);
+            expect(pageContextIndex, 'pageContext').to.be.greaterThan(-1);
+            expect(storefrontInstanceContextIndex, 'storefrontInstanceContext').to.be.greaterThan(-1);
+            expect(recommendationsContextIndex, 'recommendationsContext').to.be.greaterThan(-1);
+          });
+        });
+    });
+  });
+});
+
+it('reqs-item-add-to-cart', () => {
+  cy.visit('/products/crown-summit-backpack/24-MB03');
+  cy.waitForResource("commerce-events-collector.js").then(() => {
+    cy.window().then((win) => {
+      cy.spy(win.adobeDataLayer, "push").as("adl");
+      cy.get('.product-grid-item button')
+        .first()
+        .click()
+        .then(() => {
+          cy.get("@adl", { timeout: 2000 }).should((adobeDataLayerPush) => {
+            const targetEventIndex = adobeDataLayerPush.args.findIndex(
+              (event) => event[0]?.event === "recs-item-add-to-cart"
+            );
+            const pageContextIndex = adobeDataLayerPush.args.findIndex(
+              (event) => !!event[0]?.eventInfo?.pageContext
+            );
+            const storefrontInstanceContextIndex = adobeDataLayerPush.args.findIndex(
+              (event) => !!event[0]?.eventInfo?.storefrontInstanceContext
+            );
+            const recommendationsContextIndex = adobeDataLayerPush.args.findIndex(
+              (event) => !!event[0]?.eventInfo?.recommendationsContext
+            );
+            expect(targetEventIndex, 'recs-item-click').to.be.greaterThan(-1);
+            expect(pageContextIndex, 'pageContext').to.be.greaterThan(-1);
+            expect(storefrontInstanceContextIndex, 'storefrontInstanceContext').to.be.greaterThan(-1);
+            expect(recommendationsContextIndex, 'recommendationsContext').to.be.greaterThan(-1);
+          });
+        });
+    });
+  });
+});

--- a/cypress/src/tests/e2eTests/events/search-request-sent.spec.js
+++ b/cypress/src/tests/e2eTests/events/search-request-sent.spec.js
@@ -1,3 +1,4 @@
+import { expectsEventWithContext } from "../../../assertions";
 /**
  * https://github.com/adobe/commerce-events/blob/main/examples/events/search-request-sent.md
  *
@@ -11,16 +12,7 @@ it('is sent on search bar view/render', () => {
   cy.waitForResource('commerce-events-collector.js')
     .then(() => {
       cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
-        const targetEventIndex = adobeDataLayer.findIndex(event => event?.event === 'search-request-sent');
-        const pageContextIndex = adobeDataLayer.findIndex(event => !!event?.pageContext);
-        const storefrontInstanceContextIndex = adobeDataLayer.findIndex(event => !!event?.storefrontInstanceContext);
-        const searchInputContextIndex = adobeDataLayer.findIndex(event => !!event?.searchInputContext);
-
-        // expected contexts and event are in ACDL
-        expect(targetEventIndex).to.be.greaterThan(-1);
-        expect(pageContextIndex).to.be.greaterThan(-1);
-        expect(storefrontInstanceContextIndex).to.be.greaterThan(-1);
-        expect(searchInputContextIndex).to.be.greaterThan(-1);
+        expectsEventWithContext('search-request-sent', ['pageContext', 'storefrontInstanceContext', 'searchInputContext'], adobeDataLayer);
       });
     });
 });
@@ -29,16 +21,7 @@ it('is sent on search results page on view/render', () => {
   cy.visit('/search?q=test');
   cy.waitForResource('commerce-events-collector.js').then(() => {
     cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
-      const targetEventIndex = adobeDataLayer.findIndex(event => event?.event === 'search-request-sent');
-      const pageContextIndex = adobeDataLayer.findIndex(event => !!event?.pageContext);
-      const storefrontInstanceContextIndex = adobeDataLayer.findIndex(event => !!event?.storefrontInstanceContext);
-      const searchInputContextIndex = adobeDataLayer.findIndex(event => !!event?.searchInputContext);
-
-      // expected contexts and event are in ACDL
-      expect(targetEventIndex).to.be.greaterThan(-1);
-      expect(pageContextIndex).to.be.greaterThan(-1);
-      expect(storefrontInstanceContextIndex).to.be.greaterThan(-1);
-      expect(searchInputContextIndex).to.be.greaterThan(-1);
+      expectsEventWithContext('search-request-sent', ['pageContext', 'storefrontInstanceContext', 'searchInputContext'], adobeDataLayer);
     });
   });
 });

--- a/cypress/src/tests/e2eTests/events/search-results-view.spec.js
+++ b/cypress/src/tests/e2eTests/events/search-results-view.spec.js
@@ -1,3 +1,4 @@
+import { expectsEventWithContext } from "../../../assertions";
 /**
  * https://github.com/adobe/commerce-events/blob/main/examples/events/search-results-view.md
  *
@@ -11,16 +12,7 @@ it('is sent on search bar view/render', () => {
   cy.waitForResource('commerce-events-collector.js')
     .then(() => {
       cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
-        const targetEventIndex = adobeDataLayer.findIndex(event => event?.event === 'search-results-view');
-        const pageContextIndex = adobeDataLayer.findIndex(event => !!event?.pageContext);
-        const searchResultsContextIndex = adobeDataLayer.findIndex(event => !!event?.searchResultsContext);
-        const storefrontInstanceContextIndex = adobeDataLayer.findIndex(event => !!event?.storefrontInstanceContext);
-
-        // expected contexts and event are in ACDL
-        expect(targetEventIndex).to.be.greaterThan(-1);
-        expect(pageContextIndex).to.be.greaterThan(-1);
-        expect(storefrontInstanceContextIndex).to.be.greaterThan(-1);
-        expect(searchResultsContextIndex).to.be.greaterThan(-1);
+        expectsEventWithContext('search-results-view', ['pageContext', 'storefrontInstanceContext', 'searchResultsContext'], adobeDataLayer);
       });
     });
 });
@@ -29,16 +21,7 @@ it('is sent on search results page on view/render', () => {
   cy.visit('/search?q=test');
   cy.waitForResource('commerce-events-collector.js').then(() => {
     cy.window().its('adobeDataLayer').then((adobeDataLayer) => {
-      const targetEventIndex = adobeDataLayer.findIndex(event => event?.event === 'search-results-view');
-      const pageContextIndex = adobeDataLayer.findIndex(event => !!event?.pageContext);
-      const storefrontInstanceContextIndex = adobeDataLayer.findIndex(event => !!event?.storefrontInstanceContext);
-      const searchResultsContextIndex = adobeDataLayer.findIndex(event => !!event?.searchResultsContext);
-
-      // expected contexts and event are in ACDL
-      expect(targetEventIndex).to.be.greaterThan(-1);
-      expect(pageContextIndex).to.be.greaterThan(-1);
-      expect(storefrontInstanceContextIndex).to.be.greaterThan(-1);
-      expect(searchResultsContextIndex).to.be.greaterThan(-1);
+      expectsEventWithContext('search-results-view', ['pageContext', 'storefrontInstanceContext', 'searchResultsContext'], adobeDataLayer);
     });
   });
 });


### PR DESCRIPTION
This PR:

1. Adds an "add to cart" button to product recs implementation. The button copy is conditional depending on productType.
2. Triggers "add-to-cart" when that button is clicked, regardless of productType
3. removes observer.disconnect so that product recs scroll out and in to view will re-trigger view event.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://prex-events--aem-boilerplate-commerce--hlxsites.aem.live/
