### PR TITLE
POC – Templates

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -437,56 +437,6 @@ main .section.highlight {
   z-index: 2;
 }
 
-/* Layout: Columns */
-body.columns main {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  max-width: 1264px;
-  margin: 0 auto;
-  padding: var(--spacing-large) var(--spacing-small);
-  box-sizing: border-box;
-  gap: var(--grid-4-gutters);
-}
-
-body.columns main > .section {
-  flex: 1;
-  flex-basis: 100%;
-  max-width: unset;
-  margin: unset;
-  padding: unset;
-}
-
-body.columns main > .section > div {
-  max-width: unset;
-  padding: unset;
-}
-
-body.columns main > .section > div:not(:last-child) {
-  margin-bottom: var(--gap, unset);
-}
-
-body.columns main > .section:empty {
-  display: none;
-}
-
-@media (width >= 600px) {
-  body.columns main {
-      padding: var(--spacing-large) var(--spacing-big);
-  }
-}
-
-@media (width >= 900px) {
-  body.columns main {
-    flex-direction: row;
-  }
-
-  body.columns main > .section {
-    flex: 1;
-    flex-basis: var(--column-width, auto);
-  }
-}
-
 /**
 * Reset main element visibility
 * https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden

--- a/templates/columns/columns.css
+++ b/templates/columns/columns.css
@@ -1,0 +1,49 @@
+/* Layout: Columns */
+body.columns main {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 1264px;
+    margin: 0 auto;
+    padding: var(--spacing-large) var(--spacing-small);
+    box-sizing: border-box;
+    gap: var(--grid-4-gutters);
+}
+
+body.columns main > .section {
+    flex: 1;
+    flex-basis: 100%;
+    max-width: unset;
+    margin: unset;
+    padding: unset;
+}
+
+body.columns main > .section > div {
+    max-width: unset;
+    padding: unset;
+}
+
+body.columns main > .section > div:not(:last-child) {
+    margin-bottom: var(--gap, unset);
+}
+
+body.columns main > .section:empty {
+    display: none;
+}
+
+@media (width >= 600px) {
+    body.columns main {
+        padding: var(--spacing-large) var(--spacing-big);
+    }
+}
+
+@media (width >= 900px) {
+    body.columns main {
+        flex-direction: row;
+    }
+
+    body.columns main > .section {
+        flex: 1;
+        flex-basis: var(--column-width, auto);
+    }
+}

--- a/templates/columns/columns.js
+++ b/templates/columns/columns.js
@@ -1,0 +1,18 @@
+export default function buildTemplateColumns(doc) {
+  const columns = doc.querySelectorAll('main > div.section[data-column-width]');
+
+  columns.forEach((column) => {
+    const columnWidth = column.getAttribute('data-column-width');
+    const gap = column.getAttribute('data-gap');
+
+    if (columnWidth) {
+      column.style.setProperty('--column-width', columnWidth);
+      column.removeAttribute('data-column-width');
+    }
+
+    if (gap) {
+      column.style.setProperty('--gap', `var(--spacing-${gap.toLocaleLowerCase()})`);
+      column.removeAttribute('data-gap');
+    }
+  });
+}

--- a/templates/order-details/order-details.js
+++ b/templates/order-details/order-details.js
@@ -1,0 +1,62 @@
+import { initializers } from '@dropins/tools/initializer.js';
+import { events } from '@dropins/tools/event-bus.js';
+import * as Order from '@dropins/storefront-order/api.js';
+import {
+  CUSTOMER_ORDER_DETAILS_PATH,
+  CUSTOMER_ORDERS_PATH,
+  ORDER_DETAILS_PATH,
+  ORDER_STATUS_PATH,
+  CUSTOMER_PATH,
+} from '../../scripts/constants.js';
+import { checkIsAuthenticated } from '../../scripts/configs.js';
+
+export default function buildTemplateOrderDetails() {
+  const initializeOrderApi = (orderRef) => {
+    initializers.register(Order.initialize, {
+      orderRef,
+    });
+  };
+
+  const currentUrl = new URL(window.location.href);
+  const isAccountPage = currentUrl.pathname.includes(CUSTOMER_PATH);
+  const orderRef = currentUrl.searchParams.get('orderRef');
+  const isTokenProvided = orderRef && orderRef.length > 20;
+
+  let targetPath = null;
+  if (currentUrl.pathname.includes(CUSTOMER_ORDERS_PATH)) {
+    return;
+  }
+
+  if (checkIsAuthenticated()) {
+    if (!orderRef) {
+      targetPath = CUSTOMER_ORDERS_PATH;
+    } else if (isAccountPage) {
+      targetPath = isTokenProvided
+        ? `${ORDER_DETAILS_PATH}?orderRef=${orderRef}`
+        : null;
+    } else {
+      targetPath = isTokenProvided
+        ? null
+        : `${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderRef}`;
+    }
+  } else {
+    targetPath = !orderRef ? ORDER_STATUS_PATH : null;
+  }
+
+  if (targetPath) {
+    window.location.href = targetPath;
+  } else {
+    initializeOrderApi(orderRef);
+  }
+
+  // Events
+  events.on('order/error', () => {
+    if (checkIsAuthenticated()) {
+      window.location.href = CUSTOMER_ORDERS_PATH;
+    } else if (isTokenProvided) {
+      window.location.href = ORDER_STATUS_PATH;
+    } else {
+      window.location.href = `${ORDER_STATUS_PATH}?orderRef=${orderRef}`;
+    }
+  });
+}


### PR DESCRIPTION
We still have a couple of pages that get composed at the document level that we need to solve for My Account and Order Details.

The more I look at these pages, the more I think they work fine. It's a simple setup, and the Blocks used don't depend on each other; hence, there's no risk of an "author breaking the page."

However, there's currently no proper place in the EDS structure to apply JS and CSS at a "Template" level; thus, these drop-ins must be initialized conditionally on drop-ins.js.

I toyed around with a solution that introduces JS/CSS for Templates to EDS for Commerce. This solution could be used for use cases like these and others merchants might develop.

What are your thoughts? Could something like this be leveraged in EDS, or is it considered an anti-pattern? Should we refactor Account and Order Details to a single Block integration? If so, how would that work in the case of Account since it's multiple pages? A Block per page?

## Documents
- Account dashboard - [https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%[…]EE%7D&file=account.docx&action=default&mobileredirect=true](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7BAF22A452-765B-4144-AB4F-BC6F71A31FEE%7D&file=account.docx&action=default&mobileredirect=true)
- Account order details - [https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%[…]file=order-details.docx&action=default&mobileredirect=true](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B20E734B1-BC0E-45CA-9C02-0D945A5D65F2%7D&file=order-details.docx&action=default&mobileredirect=true)
- Guest order details - [https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%[…]file=order-details.docx&action=default&mobileredirect=true](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7BF4080433-3F5F-44DC-93EF-A2BC2B6D4F60%7D&file=order-details.docx&action=default&mobileredirect=true)

Test URLs:
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/order-details?orderRef=0%3A3%3Ah%2FQSKc2eZage4%2FoXt6wpnYkLEiQzV1faZG7kwmrcwbSZYi%2FVQNkvCH9RNRTD4PR7ZlNq5jskQjWj79Uxyw%3D%3D
- After: https://poc-templates--aem-boilerplate-commerce--hlxsites.aem.live/order-details?orderRef=0%3A3%3Ah%2FQSKc2eZage4%2FoXt6wpnYkLEiQzV1faZG7kwmrcwbSZYi%2FVQNkvCH9RNRTD4PR7ZlNq5jskQjWj79Uxyw%3D%3D
