### PR TITLE
Update recommendationsContext and productContext to include only required data

### DIFF
--- a/blocks/product-details-custom/product-details-custom.js
+++ b/blocks/product-details-custom/product-details-custom.js
@@ -13,7 +13,9 @@ import {
   performCatalogServiceQuery,
   refineProductQuery,
   setJsonLd,
-  loadErrorPage, variantsQuery,
+  loadErrorPage,
+  variantsQuery,
+  mapProductAcdl,
 } from '../../scripts/commerce.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 
@@ -164,12 +166,10 @@ class ProductDetailPage extends Component {
     if (!loading && product) {
       setJsonLdProduct(product);
       document.title = product.name;
+      console.log('product', product);
       window.adobeDataLayer.push((dl) => {
         dl.push({
-          productContext: {
-            productId: parseInt(product.externalId, 10) || 0,
-            ...product,
-          },
+          productContext: mapProductAcdl(product),
         });
         // TODO: Remove eventInfo once collector is updated
         dl.push({ event: 'product-page-view', eventInfo: { ...dl.getState() } });

--- a/blocks/product-details-custom/product-details-custom.js
+++ b/blocks/product-details-custom/product-details-custom.js
@@ -166,7 +166,6 @@ class ProductDetailPage extends Component {
     if (!loading && product) {
       setJsonLdProduct(product);
       document.title = product.name;
-      console.log('product', product);
       window.adobeDataLayer.push((dl) => {
         dl.push({
           productContext: mapProductAcdl(product),

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -27,10 +27,10 @@ const recommendationsQuery = `query GetRecommendations(
       productsView {
         name
         sku
-        url
         images {
           url
         }
+        urlKey
         externalId
         __typename
       }
@@ -60,7 +60,6 @@ function renderPlaceholder(block) {
 }
 
 function renderItem(unitId, product) {
-  const urlKey = product.url.split('/').pop().replace('.html', '');
   let image = product.images[0]?.url;
   image = image.replace('http://', '//');
 
@@ -71,7 +70,7 @@ function renderItem(unitId, product) {
   };
 
   const item = document.createRange().createContextualFragment(`<div class="product-grid-item">
-    <a href="/products/${urlKey}/${product.sku}">
+    <a href="/products/${product.urlKey}/${product.sku}">
       <picture>
         <source type="image/webp" srcset="${image}?width=300&format=webply&optimize=medium" />
         <img loading="lazy" alt="${product.name}" width="300" height="375" src="${image}?width=300&format=jpg&optimize=medium" />
@@ -121,21 +120,33 @@ function renderItems(block, results) {
   inViewObserver.observe(block);
 }
 
+const mapProduct = (product, index) => ({
+  rank: index,
+  score: 0,
+  sku: product.sku,
+  name: product.name,
+  productId: parseInt(product.externalId, 10) || 0,
+  type: product.__typename,
+  visibility: undefined,
+  categories: [],
+  weight: 0,
+  image: product.images.length > 0 ? product.images[0].url : undefined,
+  url: new URL(`/products/${product.urlKey}/${product.sku}`, window.location.origin).toString(),
+  queryType: 'primary',
+});
+
 const mapUnit = (unit) => ({
-  ...unit,
+  unitId: unit.unitId,
+  unitName: unit.unitName,
   unitType: 'primary',
   searchTime: 0,
+  totalProducts: unit.totalProducts,
   primaryProducts: unit.totalProducts,
   backupProducts: 0,
-  products: unit.productsView.map((product, index) => ({
-    ...product,
-    rank: index,
-    score: 0,
-    productId: parseInt(product.externalId, 10) || 0,
-    type: product.__typename,
-    queryType: 'primary',
-  })),
+  products: unit.productsView.map(mapProduct),
   pagePlacement: '',
+  typeId: unit.typeId,
+
 });
 
 async function loadRecommendation(block, context, visibility, filters) {

--- a/blocks/product-teaser/product-teaser.js
+++ b/blocks/product-teaser/product-teaser.js
@@ -1,11 +1,12 @@
 import { readBlockConfig } from '../../scripts/aem.js';
-import { performCatalogServiceQuery, renderPrice } from '../../scripts/commerce.js';
+import { performCatalogServiceQuery, renderPrice, mapProductAcdl } from '../../scripts/commerce.js';
 
 const productTeaserQuery = `query productTeaser($sku: String!) {
   products(skus: [$sku]) {
     sku
     urlKey
     name
+    externalId
     addToCartAllowed
     __typename
     images(roles: ["small_image"]) {
@@ -123,7 +124,7 @@ function renderProduct(product, config, block) {
     addToCartButton.addEventListener('click', async () => {
       const { cartApi } = await import('../../scripts/minicart/api.js');
       // TODO: productId not exposed by catalog service as number
-      window.adobeDataLayer.push({ productContext: { productId: 0, ...product } });
+      window.adobeDataLayer.push({ productContext: mapProductAcdl(product) });
       cartApi.addToCart(product.sku, [], 1, 'product-teaser');
     });
   }

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -387,8 +387,9 @@ export function mapProductAcdl(product) {
     || product?.price?.regular?.amount.value || 0;
   const specialPrice = product?.priceRange?.minimum?.final?.amount.value
     || product?.price?.final?.amount.value;
+  // storefront-events-collector will use storefrontInstanceContext.storeViewCurrencyCode if undefined, no default value is necessary.
   const currencyCode = product?.priceRange?.minimum?.final?.amount.currency
-    || product?.price?.final?.amount.currency || 'USD';
+    || product?.price?.final?.amount.currency || undefined;
   const minimalPrice = product?.priceRange ? regularPrice : undefined;
   const maximalPrice = product?.priceRange
     ? product?.priceRange?.maximum?.regular?.amount.value : undefined;

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -381,3 +381,31 @@ export async function loadErrorPage(code = 404) {
       document.head.appendChild(newScript);
     });
 }
+
+export function mapProductAcdl(product) {
+  const regularPrice = product?.priceRange?.minimum?.regular?.amount.value
+    || product?.price?.regular?.amount.value || 0;
+  const specialPrice = product?.priceRange?.minimum?.final?.amount.value
+    || product?.price?.final?.amount.value;
+  const currencyCode = product?.priceRange?.minimum?.final?.amount.currency
+    || product?.price?.final?.amount.currency || 'USD';
+  const minimalPrice = product?.priceRange ? regularPrice : undefined;
+  const maximalPrice = product?.priceRange
+    ? product?.priceRange?.maximum?.regular?.amount.value : undefined;
+
+  return {
+    productId: parseInt(product.externalId, 10) || 0,
+    name: product?.name,
+    sku: product?.variantSku || product?.sku,
+    topLevelSku: product?.sku,
+    pricing: {
+      regularPrice,
+      minimalPrice,
+      maximalPrice,
+      specialPrice,
+      currencyCode,
+    },
+    canonicalUrl: new URL(`/products/${product.urlKey}/${product.sku}`, window.location.origin).toString(),
+    mainImageUrl: product?.images?.[0]?.url,
+  };
+}

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -261,7 +261,7 @@ export function renderPrice(product, format, html = (strings, ...values) => stri
 
     if (finalMin.amount.value !== regularMin.amount.value) {
       return html`<${Fragment}>
-      <span class="price-final">${format(finalMin.amount.value)} - ${format(regularMin.amount.value)}</span> 
+      <span class="price-final">${format(finalMin.amount.value)} - ${format(regularMin.amount.value)}</span>
     </${Fragment}>`;
     }
 
@@ -387,7 +387,8 @@ export function mapProductAcdl(product) {
     || product?.price?.regular?.amount.value || 0;
   const specialPrice = product?.priceRange?.minimum?.final?.amount.value
     || product?.price?.final?.amount.value;
-  // storefront-events-collector will use storefrontInstanceContext.storeViewCurrencyCode if undefined, no default value is necessary.
+  // storefront-events-collector will use storefrontInstanceContext.storeViewCurrencyCode
+  // if undefined, no default value is necessary.
   const currencyCode = product?.priceRange?.minimum?.final?.amount.currency
     || product?.price?.final?.amount.currency || undefined;
   const minimalPrice = product?.priceRange ? regularPrice : undefined;


### PR DESCRIPTION
* Reduce amount of data stored in `recommendationsContext` and `productContext` in ACDL.
* Use `urlKey` from Catalog Service instead parsing it from the product URL.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: 
    - https://prex-event--aem-boilerplate-commerce--hlxsites.aem.live/
    - https://prex-event--aem-boilerplate-commerce--hlxsites.aem.live/drafts/mabecker/product-details-custom
    - https://prex-event--aem-boilerplate-commerce--hlxsites.aem.live/drafts/mabecker/product-teaser
