### PR TITLE
fix: set body to display:none initially

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -180,7 +180,7 @@ body {
 }
 
 body:not(.appear) {
-  visibility: hidden;
+  display: none;
 }
 
 header {


### PR DESCRIPTION
Instead of using `display:none` on the body during the early eager phase, the commerce boilerplate uses `visibility: hidden`. Content that is hidden that way will still be layouted by the browser and this causes the browser to change the loading priority of images from `low` to `high` which loads images immediately even below the fold before LCP.


develop (breakpoint at scripts.js line 373 before any decoration happens)
![Screenshot 2024-10-31 at 15 28 34](https://github.com/user-attachments/assets/8a1fc4b6-0389-44ab-be7c-1f1f97e4520e)

visibility-fix (same breakpoint)
<img width="2144" alt="Screenshot 2024-10-31 at 15 44 02" src="https://github.com/user-attachments/assets/659b227f-0904-4464-a686-542e4686cd97">

Test URLs:
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://visibility-fix--aem-boilerplate-commerce--hlxsites.aem.live/
