### PR TITLE
only initialize event collection when not prerendering

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -3,39 +3,49 @@ import { getConfigValue } from './configs.js';
 import { getUserTokenCookie } from './initializers/index.js';
 import { getConsent } from './scripts.js';
 
-// Load Commerce events SDK and collector
-if (getConsent('commerce-collection')) {
-  const config = {
-    environmentId: await getConfigValue('commerce-environment-id'),
-    environment: await getConfigValue('commerce-environment'),
-    storeUrl: await getConfigValue('commerce-store-url'),
-    websiteId: parseInt(await getConfigValue('commerce-website-id'), 10),
-    websiteCode: await getConfigValue('commerce-website-code'),
-    storeId: parseInt(await getConfigValue('commerce-store-id'), 10),
-    storeCode: await getConfigValue('commerce-store-code'),
-    storeViewId: parseInt(await getConfigValue('commerce-store-view-id'), 10),
-    storeViewCode: await getConfigValue('commerce-store-view-code'),
-    websiteName: await getConfigValue('commerce-website-name'),
-    storeName: await getConfigValue('commerce-store-name'),
-    storeViewName: await getConfigValue('commerce-store-view-name'),
-    baseCurrencyCode: await getConfigValue('commerce-base-currency-code'),
-    storeViewCurrencyCode: await getConfigValue('commerce-base-currency-code'),
-    storefrontTemplate: 'EDS',
-  };
+async function initAnalytics() {
+  // Load Commerce events SDK and collector
+  if (getConsent('commerce-collection')) {
+    const config = {
+      environmentId: await getConfigValue('commerce-environment-id'),
+      environment: await getConfigValue('commerce-environment'),
+      storeUrl: await getConfigValue('commerce-store-url'),
+      websiteId: parseInt(await getConfigValue('commerce-website-id'), 10),
+      websiteCode: await getConfigValue('commerce-website-code'),
+      storeId: parseInt(await getConfigValue('commerce-store-id'), 10),
+      storeCode: await getConfigValue('commerce-store-code'),
+      storeViewId: parseInt(await getConfigValue('commerce-store-view-id'), 10),
+      storeViewCode: await getConfigValue('commerce-store-view-code'),
+      websiteName: await getConfigValue('commerce-website-name'),
+      storeName: await getConfigValue('commerce-store-name'),
+      storeViewName: await getConfigValue('commerce-store-view-name'),
+      baseCurrencyCode: await getConfigValue('commerce-base-currency-code'),
+      storeViewCurrencyCode: await getConfigValue('commerce-base-currency-code'),
+      storefrontTemplate: 'EDS',
+    };
 
-  window.adobeDataLayer.push(
-    { storefrontInstanceContext: config },
-    { eventForwardingContext: { commerce: true, aep: false } },
-    {
-      shopperContext: {
-        shopperId: getUserTokenCookie() ? 'logged-in' : 'guest',
+    window.adobeDataLayer.push(
+      { storefrontInstanceContext: config },
+      { eventForwardingContext: { commerce: true, aep: false } },
+      {
+        shopperContext: {
+          shopperId: getUserTokenCookie() ? 'logged-in' : 'guest',
+        },
       },
-    },
-  );
+    );
 
-  // Load events SDK and collector
-  import('./commerce-events-sdk.js');
-  import('./commerce-events-collector.js');
+    // Load events SDK and collector
+    import('./commerce-events-sdk.js');
+    import('./commerce-events-collector.js');
+  }
+}
+
+if (document.prerendering) {
+  document.addEventListener('prerenderingchange', initAnalytics, {
+    once: true,
+  });
+} else {
+  initAnalytics();
 }
 
 // add delayed functionality here


### PR DESCRIPTION
Speculation rules have preload but hide hovered links, such as those for product recommendations.

This means events/analytics were being triggered on that preloaded page, causing things like page views to be counted when the user was only hovering on a product image.

There is a simple solution which is sourced from MDN.

To verify, load the links below, open dev tools and snowplow debugger.
Then hover over a product image in the prex div.
For the Before url, you'll see page views from the product page.
For the After url, you won't see these. When you then click the image and go to the page, you should then see the product page view event.

Test URLs:
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://prerender-events--aem-boilerplate-commerce--hlxsites.aem.live/
