### PR TITLE
add custom label

### DIFF
--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -31,9 +31,6 @@ await initializeDropin(async () => {
   const langDefinitions = {
     default: {
       ...labels,
-      Custom: {
-        AddingToCart: { label: labels.pdpCustomAddingtocart },
-      },
     },
   };
 


### PR DESCRIPTION
I fixed the reference for the custom label used in placeholders. This is an example of how to add and use your placeholder labels within drop-ins, as demonstrated on the custom "Adding to Cart" label used in the boilerplate.

The `labels.pdpCustomAddingtocart` reference from the previous integrations is no longer used since it's replaced with the JSON object returned using the `fetchPlaceholders` method.

Test URLs:

- https://custom-label--aem-boilerplate-commerce--hlxsites.aem.live/