### PR TITLE
migrate placeholders on main

### DIFF
--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -136,40 +136,7 @@ export default async function decorate(block) {
 
   const langDefinitions = {
     default: {
-      PDP: {
-        Product: {
-          Incrementer: { label: placeholders.pdpProductIncrementer },
-          OutOfStock: { label: placeholders.pdpProductOutofstock },
-          AddToCart: { label: placeholders.pdpProductAddtocart },
-          Details: { label: placeholders.pdpProductDetails },
-          RegularPrice: { label: placeholders.pdpProductRegularprice },
-          SpecialPrice: { label: placeholders.pdpProductSpecialprice },
-          PriceRange: {
-            From: { label: placeholders.pdpProductPricerangeFrom },
-            To: { label: placeholders.pdpProductPricerangeTo },
-          },
-          Image: { label: placeholders.pdpProductImage },
-        },
-        Swatches: {
-          Required: { label: placeholders.pdpSwatchesRequired },
-        },
-        Carousel: {
-          label: placeholders.pdpCarousel,
-          Next: { label: placeholders.pdpCarouselNext },
-          Previous: { label: placeholders.pdpCarouselPrevious },
-          Slide: { label: placeholders.pdpCarouselSlide },
-          Controls: {
-            label: placeholders.pdpCarouselControls,
-            Button: { label: placeholders.pdpCarouselControlsButton },
-          },
-        },
-        Overlay: {
-          Close: { label: placeholders.pdpOverlayClose },
-        },
-      },
-      Custom: {
-        AddingToCart: { label: placeholders.pdpCustomAddingtocart },
-      },
+      ...placeholders,
     },
   };
 

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -511,11 +511,17 @@ async function fetchPlaceholders(prefix = 'default') {
         })
         .then((json) => {
           const placeholders = {};
-          json.data
-            .filter((placeholder) => placeholder.Key)
-            .forEach((placeholder) => {
-              placeholders[toCamelCase(placeholder.Key)] = placeholder.Text;
-            });
+          json.data.forEach(({ Key, Value }) => {
+            if (Key) {
+              const keys = Key.split('.');
+              const lastKey = keys.pop();
+              const target = keys.reduce((obj, key) => {
+                obj[key] = obj[key] || {};
+                return obj[key];
+              }, placeholders);
+              target[lastKey] = Value;
+            }
+          });
           window.placeholders[prefix] = placeholders;
           resolve(window.placeholders[prefix]);
         })


### PR DESCRIPTION
The Placeholder Spreadsheet property name changed for a one to one mapping of key - values used by all drop-ins. This PR migrates the existing PDP integration in the `main` branch.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/hollister-backyard-sweatshirt/MH05
- After: https://placeholders-fix--aem-boilerplate-commerce--hlxsites.aem.live/products/hollister-backyard-sweatshirt/MH05