### PR TITLE
Await Initializers

### DIFF
--- a/scripts/initializers/account.js
+++ b/scripts/initializers/account.js
@@ -3,7 +3,7 @@ import { initialize } from '@dropins/storefront-account/api.js';
 import { initializeDropin } from './index.js';
 import { fetchPlaceholders } from '../aem.js';
 
-initializeDropin(async () => {
+await initializeDropin(async () => {
   const labels = await fetchPlaceholders();
 
   const langDefinitions = {
@@ -12,5 +12,5 @@ initializeDropin(async () => {
     },
   };
 
-  await initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions });
 })();

--- a/scripts/initializers/auth.js
+++ b/scripts/initializers/auth.js
@@ -4,7 +4,7 @@ import { initialize } from '@dropins/storefront-auth/api.js';
 import { initializeDropin } from './index.js';
 import { fetchPlaceholders } from '../aem.js';
 
-initializeDropin(async () => {
+await initializeDropin(async () => {
   const labels = await fetchPlaceholders();
 
   const langDefinitions = {
@@ -13,5 +13,5 @@ initializeDropin(async () => {
     },
   };
 
-  await initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions });
 })();

--- a/scripts/initializers/cart.js
+++ b/scripts/initializers/cart.js
@@ -4,7 +4,7 @@ import { initialize } from '@dropins/storefront-cart/api.js';
 import { initializeDropin } from './index.js';
 import { fetchPlaceholders } from '../aem.js';
 
-initializeDropin(async () => {
+await initializeDropin(async () => {
   const labels = await fetchPlaceholders();
 
   const langDefinitions = {
@@ -13,5 +13,5 @@ initializeDropin(async () => {
     },
   };
 
-  await initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions });
 })();

--- a/scripts/initializers/checkout.js
+++ b/scripts/initializers/checkout.js
@@ -3,7 +3,7 @@ import { initialize } from '@dropins/storefront-checkout/api.js';
 import { initializeDropin } from './index.js';
 import { fetchPlaceholders } from '../aem.js';
 
-initializeDropin(async () => {
+await initializeDropin(async () => {
   const labels = await fetchPlaceholders();
 
   const langDefinitions = {
@@ -12,5 +12,5 @@ initializeDropin(async () => {
     },
   };
 
-  await initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions });
 })();

--- a/scripts/initializers/order-confirmation.js
+++ b/scripts/initializers/order-confirmation.js
@@ -3,7 +3,7 @@ import { initialize } from '@dropins/storefront-order-confirmation/api.js';
 import { initializeDropin } from './index.js';
 import { fetchPlaceholders } from '../aem.js';
 
-initializeDropin(async () => {
+await initializeDropin(async () => {
   const labels = await fetchPlaceholders();
 
   const langDefinitions = {
@@ -12,5 +12,5 @@ initializeDropin(async () => {
     },
   };
 
-  await initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions });
 })();

--- a/scripts/initializers/order.js
+++ b/scripts/initializers/order.js
@@ -15,7 +15,7 @@ import {
   CUSTOMER_PATH,
 } from '../constants.js';
 
-initializeDropin(async () => {
+await initializeDropin(async () => {
   const { pathname, searchParams } = new URL(window.location.href);
   const isAccountPage = pathname.includes(CUSTOMER_PATH);
   const orderRef = searchParams.get('orderRef');

--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -41,7 +41,7 @@ await initializeDropin(async () => {
   };
 
   // Initialize Dropins
-  await initializers.mountImmediately(initialize, {
+  return initializers.mountImmediately(initialize, {
     langDefinitions,
     models,
   });


### PR DESCRIPTION
Fix Issue:

Initializers are not being awaited, triggering renders before the drop-in has fully initialized. This may cause issues where the `initialData` or `langDefinitiones` are needed before rendering. 

Note: PDP was already _awaited_. so there is no need to apply on `main` This PR fixes it for the rest of the drop-ins in `develop`

Test URLs:
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://await-initializers--aem-boilerplate-commerce--hlxsites.aem.live/
- https://await-initializers--aem-boilerplate-commerce--hlxsites.aem.live/products/crown-summit-backpack/24-MB03