### PR TITLE
Fix PRex on cart page

### DIFF
--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -237,7 +237,9 @@ export default async function decorate(block) {
   }
 
   function handleCartChanges({ shoppingCartContext }) {
-    context.cartSkus = shoppingCartContext?.items?.map(({ product }) => product.sku);
+    context.cartSkus = shoppingCartContext?.totalQuantity === 0
+      ? []
+      : shoppingCartContext?.items?.map(({ product }) => product.sku);
     loadRecommendation(block, context, visibility, filters);
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -182,20 +182,24 @@ async function loadEager(doc) {
     pageType = 'Checkout';
   }
 
-  window.adobeDataLayer.push({
-    pageContext: {
-      pageType,
-      pageName: document.title,
-      eventType: 'visibilityHidden',
-      maxXOffset: 0,
-      maxYOffset: 0,
-      minXOffset: 0,
-      minYOffset: 0,
+  window.adobeDataLayer.push(
+    {
+      pageContext: {
+        pageType,
+        pageName: document.title,
+        eventType: 'visibilityHidden',
+        maxXOffset: 0,
+        maxYOffset: 0,
+        minXOffset: 0,
+        minYOffset: 0,
+      },
     },
-    shoppingCartContext: {
-      totalQuantity: 0,
+    {
+      shoppingCartContext: {
+        totalQuantity: 0,
+      },
     },
-  });
+  );
   window.adobeDataLayer.push((dl) => {
     dl.push({ event: 'page-view', eventInfo: { ...dl.getState() } });
   });


### PR DESCRIPTION
* Ensure that the `shoppingCartContext` is properly detected by the product recommendations block.
* Ensure that the product recommendations block can also handle an empty `shoppingCartContext`.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: 
    - https://prex-cart--aem-boilerplate-commerce--hlxsites.aem.live/
    - https://prex-cart--aem-boilerplate-commerce--hlxsites.aem.live/cart
