### PR TITLE
Fixed PREX (width) layout

### DIFF
--- a/blocks/product-recommendations/product-recommendations.css
+++ b/blocks/product-recommendations/product-recommendations.css
@@ -1,10 +1,3 @@
-main .section>div.product-recommendations-wrapper {
-    max-width: 100%;
-    padding: 0;
-    text-align: left;
-    margin: 0 0 5rem;
-}
-
 .product-recommendations {
     overflow: hidden;
     min-height: 512px;


### PR DESCRIPTION
Fixes the max width of PREX on page.

<img width="1621" alt="image" src="https://github.com/user-attachments/assets/b5b094cb-ed4b-4e6c-886f-43e92d660f8a">


Test URLs:
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/products/hollister-backyard-sweatshirt/MH05
- After: https://prex-width--aem-boilerplate-commerce--hlxsites.aem.live/products/hollister-backyard-sweatshirt/MH05
