### PR TITLE
Experimentation Plugin must load before Drop-ins initialization

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -168,15 +168,6 @@ async function loadEager(doc) {
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
 
-  // Instrument experimentation plugin
-  if (getMetadata('experiment')
-    || Object.keys(getAllMetadata('campaign')).length
-    || Object.keys(getAllMetadata('audience')).length) {
-    // eslint-disable-next-line import/no-relative-packages
-    const { loadEager: runEager } = await import('../plugins/experimentation/src/index.js');
-    await runEager(document, { audiences: AUDIENCES }, pluginContext);
-  }
-
   window.adobeDataLayer = window.adobeDataLayer || [];
 
   let pageType = 'CMS';
@@ -368,6 +359,15 @@ export function getConsent(topic) {
 }
 
 async function loadPage() {
+  // Instrument experimentation plugin
+  if (getMetadata('experiment')
+    || Object.keys(getAllMetadata('campaign')).length
+    || Object.keys(getAllMetadata('audience')).length) {
+    // eslint-disable-next-line import/no-relative-packages
+    const { loadEager: runEager } = await import('../plugins/experimentation/src/index.js');
+    await runEager(document, { audiences: AUDIENCES }, pluginContext);
+  }
+
   await initializeDropins();
   await loadEager(document);
   await loadLazy(document);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -168,6 +168,17 @@ async function loadEager(doc) {
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
 
+  // Instrument experimentation plugin
+  if (getMetadata('experiment')
+    || Object.keys(getAllMetadata('campaign')).length
+    || Object.keys(getAllMetadata('audience')).length) {
+    // eslint-disable-next-line import/no-relative-packages
+    const { loadEager: runEager } = await import('../plugins/experimentation/src/index.js');
+    await runEager(document, { audiences: AUDIENCES }, pluginContext);
+  }
+
+  await initializeDropins();
+
   window.adobeDataLayer = window.adobeDataLayer || [];
 
   let pageType = 'CMS';
@@ -359,16 +370,6 @@ export function getConsent(topic) {
 }
 
 async function loadPage() {
-  // Instrument experimentation plugin
-  if (getMetadata('experiment')
-    || Object.keys(getAllMetadata('campaign')).length
-    || Object.keys(getAllMetadata('audience')).length) {
-    // eslint-disable-next-line import/no-relative-packages
-    const { loadEager: runEager } = await import('../plugins/experimentation/src/index.js');
-    await runEager(document, { audiences: AUDIENCES }, pluginContext);
-  }
-
-  await initializeDropins();
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();


### PR DESCRIPTION
In this PR, I moved the Experiment Plugin's initialization code to execute before the drop-ins' initialization so that drop-ins have an experiment variant and then execute.

Test URLs:
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://experimentation-plugin-load--aem-boilerplate-commerce--hlxsites.aem.live/
