### PR TITLE
USF-1701 Update order confirmation URL

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -812,19 +812,21 @@ export default async function decorate(block) {
   };
 
   const handleCheckoutOrder = async (orderData) => {
-    // clear address form data
+    // Clear address form data
     sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
     sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
 
     const token = getUserTokenCookie();
     const orderRef = token ? orderData.number : orderData.token;
+    const orderNumber = orderData.number;
     const encodedOrderRef = encodeURIComponent(orderRef);
+    const encodedOrderNumber = encodeURIComponent(orderNumber);
 
-    window.history.pushState(
-      {},
-      '',
-      `/order-details?orderRef=${encodedOrderRef}`,
-    );
+    const url = token
+      ? `/order-details?orderRef=${encodedOrderRef}`
+      : `/order-details?orderRef=${encodedOrderRef}&orderNumber=${encodedOrderNumber}`;
+
+    window.history.pushState({}, '', url);
 
     // TODO cleanup checkout containers
     await displayOrderConfirmation(orderData);


### PR DESCRIPTION
## Description

Update order confirmation to align with the requirements for handling `orderRef` and `orderNumber` parameters:
- Signed-in users: Use `orderRef` with order number in the URL.
- Guest users: Use `orderRef` with order token and include `orderNumber` as a separate parameter in the URL.

## Test URLs
- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/
- After:  https://checkout-order-url--aem-boilerplate-commerce--hlxsites.aem.live/
