### PR TITLE
Add null check for product recommendation image

### DIFF
--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -61,7 +61,9 @@ function renderPlaceholder(block) {
 
 function renderItem(unitId, product) {
   let image = product.images[0]?.url;
-  image = image.replace('http://', '//');
+  if (image) {
+    image = image.replace('http://', '//');
+  }
 
   const clickHandler = () => {
     window.adobeDataLayer.push((dl) => {


### PR DESCRIPTION
* Prevents exception for products in product recommendation block without images.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: 
    - https://usf-1779--aem-boilerplate-commerce--hlxsites.aem.live/
    - https://usf-1779--aem-boilerplate-commerce--hlxsites.aem.live/products/crown-summit-backpack/24-MB03
