### PR TITLE
USF-1783 - Disable viewport auto-zoom

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,4 @@
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1 maximum-scale=1" />
 <!--
   Domain Verification for Adobe Commerce Security Scan
   https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/security-scan

--- a/head.html
+++ b/head.html
@@ -1,4 +1,4 @@
-<meta name="viewport" content="width=device-width, initial-scale=1 maximum-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <!--
   Domain Verification for Adobe Commerce Security Scan
   https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/security-scan


### PR DESCRIPTION
Occurs on Safari in iOS: when a user enters text within the checkout page, the page zooms in on the text field and de-centers content within the checkout container. Even when deselecting the text field or finishing filling out the fields, the page remains slightly zoomed and uncenters the page, cutting off minor elements in the header as well as in the shown container.

Solution https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone

Test URLs:

- Before: https://develop--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://usf-1783--aem-boilerplate-commerce--hlxsites.aem.live/