### PR TITLE
Add cypress test for cart event

### DIFF
--- a/cypress/src/tests/e2eTests/events/shopping-cart-view.spec.js
+++ b/cypress/src/tests/e2eTests/events/shopping-cart-view.spec.js
@@ -1,0 +1,33 @@
+import { products } from "../../../fixtures";
+import { expectsEventWithContext } from "../../../assertions";
+/**
+ * https://github.com/adobe/commerce-events/blob/main/examples/events/shopping-cart-view.md
+ *
+ * Required Contexts: page, storefront, shoppingCart
+ */
+
+it("is sent on view cart button click", () => {
+  cy.visit(products.configurable.urlPathWithOptions);
+  // add to cart
+  cy.get(".product-details__buttons__add-to-cart button")
+    .should("be.visible")
+    .click();
+  // click the minicart toggle
+  cy.get('button[data-count="1"]').should("be.visible").click();
+  // click the view cart button
+  cy.get('#nav div.cart-mini-cart a[href="/cart"]')
+    .should("be.visible")
+    .click();
+
+  cy.waitForResource("commerce-events-collector.js").then(() => {
+    cy.window()
+      .its("adobeDataLayer")
+      .then((adobeDataLayer) => {
+        expectsEventWithContext(
+          "shopping-cart-view",
+          ["pageContext", "storefrontInstanceContext", "shoppingCartContext"],
+          adobeDataLayer
+        );
+      });
+  });
+});


### PR DESCRIPTION
Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://USF-1652--aem-boilerplate-commerce--hlxsites.aem.live/
