### PR TITLE
USF-1871 Include checkout demo blocks in the Boilerplate demos

### DIFF
--- a/blocks/commerce-checkout-bopis/README.md
+++ b/blocks/commerce-checkout-bopis/README.md
@@ -1,0 +1,119 @@
+# Adding Buy Online, Pickup In-Store (BOPIS) to Checkout
+
+This guide will walk you through the steps to extend the Checkout to support the Buy Online, Pickup In-Store (BOPIS) functionality.
+
+## Step-by-Step Process:
+
+### 1. Update Content Fragment
+
+For the new section, we need to add additional DOM elements, which can be done by modifying the contextual fragment.
+
+```html
+<div class="checkout__delivery-method">
+  <h2 class="checkout-delivery-method__title">Delivery Method</h2>
+  <div class="checkout-delivery-method__toggle-buttons">
+    <div class="checkout-delivery-method__delivery-button"></div>
+    <div class="checkout-delivery-method__in-store-pickup-button"></div>
+  </div>
+</div>
+<div class="checkout__in-store-pickup"></div>
+```
+
+We will also need to add new selectors, allowing us to use them later to render the required components and content.
+
+```javascript
+export const $deliveryButton = fragment.querySelector('.checkout-delivery-method__delivery-button');
+export const $inStorePickupButton = fragment.querySelector('.checkout-delivery-method__in-store-pickup-button');
+export const $inStorePickup = fragment.querySelector('.checkout__in-store-pickup');
+```
+
+### 2. UI Components for Delivery and In-Store Pickup
+
+During the initialization, two buttons are rendered: one for Delivery and one for In-Store Pickup. These buttons allow users to toggle between the two options.
+
+```javascript
+UI.render(ToggleButton, {
+  label: 'Delivery',
+  onChange: () => onToggle('delivery'),
+})($deliveryButton)
+
+UI.render(ToggleButton, {
+  label: 'In-store Pickup',
+  onChange: () => onToggle('in-store-pickup'),
+})($inStorePickupButton)
+```
+
+### 3. Toggle Between Delivery and In-Store Pickup
+
+The `onToggle` function manages switching between delivery and in-store pickup. It updates the selected state of the buttons and toggles the visibility of the corresponding forms.
+
+```javascript
+async function onToggle(type) {
+  if (type === 'delivery') {
+    deliveryButton.setProps((prev) => ({ ...prev, selected: true }));
+    inStorePickupButton.setProps((prev) => ({ ...prev, selected: false }));
+    $shippingForm.removeAttribute('hidden');
+    $shippingMethods.removeAttribute('hidden');
+    $inStorePickup.setAttribute('hidden', '');
+  } else {
+    inStorePickupButton.setProps((prev) => ({ ...prev, selected: true }));
+    deliveryButton.setProps((prev) => ({ ...prev, selected: false }));
+    $shippingForm.setAttribute('hidden', '');
+    $shippingMethods.setAttribute('hidden', '');
+    $inStorePickup.removeAttribute('hidden');
+  }
+}
+```
+
+### 4. Fetching Pickup Locations
+
+The function `fetchPickupLocations` retrieves the list of available pickup locations using a GraphQL query. These locations will be displayed for the user to choose where they'd like to pick up their order.
+
+```javascript
+async function fetchPickupLocations() {
+  return checkoutApi
+    .fetchGraphQl(
+      `query pickupLocations {
+        pickupLocations {
+          items {
+            name
+            pickup_location_code
+          }
+          total_count
+        }
+      }`,
+      { method: 'GET', cache: 'no-cache' }
+    )
+    .then((res) => res.data.pickupLocations.items);
+}
+```
+
+### 5. Rendering the Pickup Location Options
+
+Once the pickup locations are fetched, they are rendered as radio buttons. The user can select a location, which updates the shipping address with the corresponding pickup location code.
+
+```javascript
+const pickupLocations = await fetchPickupLocations();
+
+pickupLocations.forEach((location) => {
+  const { name, pickup_location_code } = location;
+  const locationRadiobutton = document.createElement('div');
+
+  UI.render(RadioButton, {
+    label: name,
+    value: name,
+    onChange: () => {
+      checkoutApi.setShippingAddress({
+        address: {},
+        pickupLocationCode: pickup_location_code,
+      });
+    },
+  })(locationRadiobutton);
+
+  $inStorePickup.appendChild(locationRadiobutton);
+});
+```
+
+### 6. Finalizing the BOPIS Flow
+
+Once the user selects "In-store Pickup" and chooses a location, the form for pickup is shown, while the shipping form is hidden. This provides a clear and seamless way for users to choose how they want to receive their order.

--- a/blocks/commerce-checkout-bopis/commerce-checkout-bopis.css
+++ b/blocks/commerce-checkout-bopis/commerce-checkout-bopis.css
@@ -1,0 +1,198 @@
+/* stylelint-disable selector-class-pattern */
+
+.checkout__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-big) 0;
+}
+
+.checkout__shipping-form:empty,
+.checkout__shipping-methods:has(> div:empty),
+.checkout__bill-to-shipping-address:has(> div:empty) {
+  display: none;
+}
+
+.checkout__main {
+  display: grid;
+  row-gap: var(--spacing-xbig);
+  margin-top: var(--spacing-medium);
+}
+
+.checkout__aside {
+  display: grid;
+  gap: var(--spacing-xbig);
+}
+
+.checkout__block.checkout__heading .dropin-header-container {
+  gap: var(--spacing-xsmall);
+}
+
+.checkout__place-order {
+  grid-column: unset;
+  justify-items: unset;
+  margin-top: calc(var(--spacing-big) * -1);
+}
+
+.checkout__heading .dropin-divider {
+  margin: 0;
+}
+
+/* To add into the cart dropin **/
+.cart-order-summary__taxes.dropin-accordion .dropin-divider {
+  margin: var(--spacing-medium) auto;
+}
+
+/* CartSummaryList */
+
+.cart-summary-list {
+  padding: var(--spacing-medium);
+  background-color: var(--color-neutral-200);
+}
+
+.cart-summary-list__heading {
+  display: flex;
+  justify-content: space-between;
+}
+
+.cart-summary-list__heading-text {
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+.cart-cart-summary-list__heading {
+  row-gap: var(--spacing-small);
+  padding-top: 0;
+}
+
+.cart-cart-summary-list__heading-text {
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+.cart-summary-list__edit {
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+}
+
+/* BOPIS specific styles */
+
+.checkout__in-store-pickup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+.checkout__in-store-pickup[hidden] {
+  display:none;
+}
+
+.checkout-delivery-method__title {
+  color: var(--color-neutral-800);
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  margin: 0 0 var(--spacing-medium) 0;
+}
+
+.checkout-delivery-method__toggle-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-big);
+}
+
+@media only screen and (width >= 320px) and (width <= 768px) {
+    .checkout__main,
+    .checkout__aside {
+        display: contents;
+    }
+
+    .checkout__block {
+        order: 3;
+    }
+
+    .checkout__heading {
+        order: 1;
+    }
+
+    .checkout__cart-summary {
+        order: 2;
+    }
+
+    .checkout__place-order {
+        order: 4;
+    }
+
+    .order-confirmation {
+        grid-template-columns: repeat(var(--grid-1-columns), 1fr);
+        padding-top: 0;
+    }
+
+    .order-confirmation__main,
+    .order-confirmation__aside {
+        grid-row-gap: var(--spacing-medium);
+    }
+
+    .order-confirmation > div {
+        grid-column: 1 / span 4;
+    }
+
+    .order-confirmation__block .dropin-card {
+        border: 0;
+    }
+}
+
+@media only screen and (width >= 768px) {
+    .checkout__content {
+        display: grid;
+        align-items: start;
+        grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+        gap: var(--spacing-big) var(--grid-4-gutters);
+    }
+
+    .checkout__content--error,
+    .checkout__content--empty {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+
+    .checkout__main {
+        grid-column: 1 / span 7;
+        row-gap: var(--spacing-xbig);
+    }
+
+    .checkout__aside {
+        grid-column: 9 / span 4;
+        gap: var(--spacing-xbig);
+    }
+
+    .checkout__error-banner,
+    .checkout__merged-cart-banner {
+        display: grid;
+        grid-column: 1 / span 12;
+    }
+
+    .checkout__place-order {
+        margin-top: 0;
+    }
+}
+
+/* Extra small devices (phones, 600px and down) */
+
+/* @media only screen and (max-width: 600px) { } */
+
+/* Small devices (portrait tablets and large phones, 600px and up) */
+
+/* @media only screen and (min-width: 600px) { } */
+
+/* Medium devices (landscape tablets, 768px and up) */
+
+/* @media only screen and (min-width: 768px) { } */
+
+/* Large devices (laptops/desktops, 992px and up) */
+
+/* @media only screen and (min-width: 992px) { } */
+
+/* Extra large devices (large laptops and desktops, 1200px and up) */
+
+/* @media only screen and (min-width: 1200px) { } */

--- a/blocks/commerce-checkout-bopis/commerce-checkout-bopis.js
+++ b/blocks/commerce-checkout-bopis/commerce-checkout-bopis.js
@@ -1,0 +1,291 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-shadow */
+/* eslint-disable no-use-before-define */
+/* eslint-disable prefer-const */
+/* eslint-disable camelcase */
+/* eslint-disable max-len */
+
+// Dropin Tools
+import {
+  provider as UI,
+  RadioButton,
+  Header,
+  ToggleButton,
+} from '@dropins/tools/components.js';
+import { events } from '@dropins/tools/event-bus.js';
+import { debounce } from '@dropins/tools/lib.js';
+
+// Cart Dropin Modules
+import CartSummaryList from '@dropins/storefront-cart/containers/CartSummaryList.js';
+import { OrderSummary } from '@dropins/storefront-cart/containers/OrderSummary.js';
+import { render as cartProvider } from '@dropins/storefront-cart/render.js';
+
+// Order Dropin Modules
+import * as orderApi from '@dropins/storefront-order/api.js';
+
+// Checkout Dropin Modules
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import LoginForm from '@dropins/storefront-checkout/containers/LoginForm.js';
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import PlaceOrder from '@dropins/storefront-checkout/containers/PlaceOrder.js';
+import ShippingMethods from '@dropins/storefront-checkout/containers/ShippingMethods.js';
+import { render as checkoutProvider } from '@dropins/storefront-checkout/render.js';
+
+// Account Dropin Modules
+import AddressForm from '@dropins/storefront-account/containers/AddressForm.js';
+import { render as accountProvider } from '@dropins/storefront-account/render.js';
+
+const DEBOUNCE_TIME = 1000;
+const LOGIN_FORM_NAME = 'login-form';
+const SHIPPING_FORM_NAME = 'selectedShippingAddress';
+const BILLING_FORM_NAME = 'selectedBillingAddress';
+
+// Step 1: Update Content Fragment
+const fragment = document.createRange().createContextualFragment(`
+  <div class="checkout__content">
+    <div class="checkout__main">
+      <div class="checkout__block checkout__heading"></div>
+      <div class="checkout__login"></div>
+      <div class="checkout__delivery-method">
+        <h2 class="checkout-delivery-method__title">Delivery Method</h2>
+        <div class="checkout-delivery-method__toggle-buttons">
+          <div class="checkout-delivery-method__delivery-button"></div>
+          <div class="checkout-delivery-method__in-store-pickup-button"></div>
+        </div>
+      </div>
+      <div class="checkout__in-store-pickup"></div>
+      <div class="checkout__shipping-form"></div>
+      <div class="checkout__shipping-methods"></div>
+      <div class="checkout__payment-methods"></div>
+      <div class="checkout__billing-form"></div>
+      <div class="checkout__place-order"></div>
+    </div>
+    <div class="checkout__aside">
+      <div class="checkout__order-summary"></div>
+      <div class="cart-summary-list"></div>
+    </div>
+  </div>
+`);
+
+export const $root = fragment.querySelector('.checkout__content');
+export const $heading = fragment.querySelector('.checkout__heading');
+export const $main = fragment.querySelector('.checkout__main');
+export const $login = fragment.querySelector('.checkout__login');
+// Step 1: Update Content Fragment
+export const $deliveryButton = fragment.querySelector('.checkout-delivery-method__delivery-button');
+export const $inStorePickupButton = fragment.querySelector('.checkout-delivery-method__in-store-pickup-button');
+export const $inStorePickup = fragment.querySelector('.checkout__in-store-pickup');
+export const $shippingForm = fragment.querySelector('.checkout__shipping-form');
+export const $billToShippingAddress = fragment.querySelector(
+  '.checkout__bill-to-shipping-address',
+);
+export const $shippingMethods = fragment.querySelector(
+  '.checkout__shipping-methods',
+);
+export const $paymentMethods = fragment.querySelector(
+  '.checkout__payment-methods',
+);
+export const $billingForm = fragment.querySelector('.checkout__billing-form');
+export const $aside = fragment.querySelector('.checkout__aside');
+export const $orderSummary = fragment.querySelector('.checkout__order-summary');
+export const $cartSummaryList = fragment.querySelector('.cart-summary-list');
+export const $placeOrder = fragment.querySelector('.checkout__place-order');
+
+function setAddressOnCart(values, setAddressApi) {
+  const { data, isDataValid } = values;
+  const isNewAddress = !data?.id;
+
+  if (!isDataValid) return;
+
+  const customAttributes = data.customAttributes
+    ? Object.entries(data.customAttributes).map(([code, value]) => ({
+      code,
+      value: value.toString(),
+    }))
+    : [];
+
+  const address = !isNewAddress
+    ? { customerAddressId: data.id }
+    : {
+      saveInAddressBook: data.saveAddressBook,
+      address: {
+        city: data.city,
+        company: data?.company,
+        countryCode: data.countryCode,
+        customAttributes,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        postcode: data.postcode,
+        region: data?.region?.regionCode,
+        regionId: data?.region?.regionId,
+        street: data.street,
+        telephone: data.telephone,
+        vatId: data.vatId,
+        prefix: data.prefix,
+        suffix: data.suffix,
+        middleName: data.middleName,
+        fax: data.fax,
+      },
+    };
+
+  setAddressApi(address);
+}
+
+// Step 4: Fetching Pickup Locations
+async function fetchPickupLocations() {
+  return checkoutApi
+    .fetchGraphQl(
+      `query pickupLocations {
+        pickupLocations {
+          items {
+            name
+            pickup_location_code
+          }
+          total_count
+        }
+      }`,
+      { method: 'GET', cache: 'no-cache' },
+    )
+    .then((res) => res.data.pickupLocations.items);
+}
+
+// Define the renderHeader function
+async function renderHeader() {
+  await UI.render(Header, {
+    title: 'BOPIS Checkout',
+    size: 'large',
+    divider: true,
+  })($heading);
+}
+
+renderHeader();
+
+export default async function decorate(block) {
+  // Initializers
+  import('../../scripts/initializers/account.js');
+  import('../../scripts/initializers/checkout.js');
+
+  events.on('checkout/initialized', async (checkoutData) => {
+    const [
+      _login,
+      // Step 2: UI Components for Delivery and In-Store Pickup
+      deliveryButton,
+      inStorePickupButton,
+      _shippingForm,
+      _billingForm,
+      _shippingMethods,
+      _paymentMethods,
+      _orderSummary,
+      _cartSummary,
+      _placeOrder,
+    ] = await Promise.all([
+      checkoutProvider.render(LoginForm, { name: LOGIN_FORM_NAME })($login),
+
+      // Step 2: UI Components for Delivery and In-Store Pickup
+      UI.render(ToggleButton, {
+        label: 'Delivery',
+        onChange: () => onToggle('delivery'),
+      })($deliveryButton),
+
+      UI.render(ToggleButton, {
+        label: 'In-store Pickup',
+        onChange: () => onToggle('in-store-pickup'),
+      })($inStorePickupButton),
+
+      accountProvider.render(AddressForm, {
+        addressesFormTitle: 'Shipping address',
+        className: 'checkout-shipping-form__address-form',
+        formName: SHIPPING_FORM_NAME,
+        hideActionFormButtons: true,
+        isOpen: true,
+        showBillingCheckBox: false,
+        showShippingCheckBox: false,
+        onChange: debounce((values) => {
+          setAddressOnCart(values, checkoutApi.setShippingAddress);
+
+          const hasCartShippingAddress = Boolean(
+            checkoutData.shippingAddresses?.[0],
+          );
+          const { data, isDataValid } = values;
+
+          if (hasCartShippingAddress || isDataValid) return;
+
+          const criteria = {
+            country_code: data.countryCode,
+            region_name: String(data.region.regionCode || ''),
+            region_id: String(data.region.regionId || ''),
+          };
+          checkoutApi.estimateShippingMethods({ criteria });
+        }, DEBOUNCE_TIME),
+      })($shippingForm),
+
+      accountProvider.render(AddressForm, {
+        addressesFormTitle: 'Billing address',
+        className: 'checkout-billing-form__address-form',
+        formName: BILLING_FORM_NAME,
+        hideActionFormButtons: true,
+        isOpen: true,
+        showBillingCheckBox: false,
+        showShippingCheckBox: false,
+        onChange: debounce((values) => {
+          setAddressOnCart(values, checkoutApi.setBillingAddress);
+        }, DEBOUNCE_TIME),
+      })($billingForm),
+
+      checkoutProvider.render(ShippingMethods)($shippingMethods),
+      checkoutProvider.render(PaymentMethods)($paymentMethods),
+      cartProvider.render(OrderSummary)($orderSummary),
+      cartProvider.render(CartSummaryList)($cartSummaryList),
+      checkoutProvider.render(PlaceOrder, {
+        handlePlaceOrder: async ({ cartId }) => {
+          orderApi.placeOrder(cartId).catch(console.error);
+        },
+      })($placeOrder),
+    ]);
+
+    // Step 3: Toggle Functionality
+    async function onToggle(type) {
+      if (type === 'delivery') {
+        deliveryButton.setProps((prev) => ({ ...prev, selected: true }));
+        inStorePickupButton.setProps((prev) => ({ ...prev, selected: false }));
+        $shippingForm.removeAttribute('hidden');
+        $shippingMethods.removeAttribute('hidden');
+        $inStorePickup.setAttribute('hidden', '');
+      } else {
+        inStorePickupButton.setProps((prev) => ({ ...prev, selected: true }));
+        deliveryButton.setProps((prev) => ({ ...prev, selected: false }));
+        $shippingForm.setAttribute('hidden', '');
+        $shippingMethods.setAttribute('hidden', '');
+        $inStorePickup.removeAttribute('hidden');
+      }
+    }
+
+    onToggle('delivery');
+
+    // Step 5: Rendering Pickup Options
+    const pickupLocations = await fetchPickupLocations();
+
+    pickupLocations.forEach((location) => {
+      const { name, pickup_location_code } = location;
+      const locationRadiobutton = document.createElement('div');
+
+      UI.render(RadioButton, {
+        label: name,
+        name: 'pickup-location',
+        value: name,
+        onChange: () => {
+          checkoutApi.setShippingAddress({
+            pickupLocationCode: pickup_location_code,
+          });
+        },
+      })(locationRadiobutton);
+
+      $inStorePickup.appendChild(locationRadiobutton);
+    });
+
+    $root.style.display = 'grid';
+  });
+
+  block.appendChild(fragment);
+}

--- a/blocks/commerce-checkout-braintree/README.md
+++ b/blocks/commerce-checkout-braintree/README.md
@@ -1,0 +1,107 @@
+# Integrating Braintree Payment Method in Checkout
+
+This guide will walk you through the steps to integrate the Braintree payment method into the Checkout.
+
+## Step-by-Step Process:
+
+### 1. Import Braintree
+
+Include the Braintree Drop-in library in your project:
+
+```html
+<script src="https://js.braintreegateway.com/web/dropin/1.43.0/js/dropin.min.js"></script>
+```
+
+Or directly in the `commerce-checkout.js` block file:
+```js
+import 'https://js.braintreegateway.com/web/dropin/1.43.0/js/dropin.min.js';
+```
+
+### 2. Create `braintreeInstance` Variable and Add Braintree Handler to Payment Methods Container
+
+Define a `braintreeInstance` variable to manage the Braintree Drop-in instance. Update the `PaymentMethods` container to include a custom handler for the Braintree payment method and set `setOnChange` to `false` to prevent automatic calls to `setPaymentMethod` mutation on change.
+
+```js
+let braintreeInstance;
+```
+
+```js
+CheckoutProvider.render(PaymentMethods, {
+  setOnChange: {
+    braintree: false,
+  },
+  slots: {
+    Handlers: {
+      braintree: async (ctx) => {
+        const container = document.createElement('div');
+
+        window.braintree.dropin.create({
+          authorization: 'sandbox_g42y39zw_348pk9cgf3bgyw2b',
+          container,
+        }, (err, dropinInstance) => {
+          if (err) {
+            console.error(err);
+          }
+
+          braintreeInstance = dropinInstance;
+        });
+
+        ctx.replaceHTML(container);
+      },
+    },
+  },
+})($paymentMethods)
+```
+
+### 3. Handle Braintree Payment Method in `PlaceOrder` Container
+
+Implement the Braintree payment logic in the `PlaceOrder` container within the `onPlaceOrder` handler. This includes processing the payment with the Braintree nonce.
+
+```js
+CheckoutProvider.render(PlaceOrder, {
+  handleValidation: () => {
+    // validation handlers skipped
+  },
+  onPlaceOrder: async (ctx) => {
+    await displayOverlaySpinner();
+
+    const paymentMethodCode = ctx.code;
+
+    try {
+      switch (paymentMethodCode) {
+        case 'braintree': {
+          braintreeInstance.requestPaymentMethod(async (err, payload) => {
+            if (err) {
+              removeOverlaySpinner();
+              console.error(err);
+              return;
+            }
+
+            await checkoutApi.setPaymentMethod({
+              code: 'braintree',
+              braintree: {
+                is_active_payment_token_enabler: false,
+                payment_method_nonce: payload.nonce,
+              },
+            });
+
+            await checkoutApi.placeOrder();
+
+            removeOverlaySpinner();
+          });
+
+          break;
+        }
+
+        default: {
+          await checkoutApi.placeOrder();
+          removeOverlaySpinner();
+        }
+      }
+    } catch (error) {
+      removeOverlaySpinner();
+      throw error;
+    }
+  },
+})($placeOrder)
+```

--- a/blocks/commerce-checkout-braintree/commerce-checkout-braintree.css
+++ b/blocks/commerce-checkout-braintree/commerce-checkout-braintree.css
@@ -1,0 +1,331 @@
+/* stylelint-disable selector-class-pattern */
+.checkout__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-big) 0;
+}
+
+.checkout__main {
+  display: grid;
+  row-gap: var(--spacing-xbig);
+  margin-top: var(--spacing-medium);
+}
+
+.checkout__aside {
+  display: grid;
+  gap: var(--spacing-xbig);
+}
+
+/* Block dividers */
+.checkout__block.checkout__heading .dropin-header-container {
+  gap: var(--spacing-xsmall);
+}
+
+.checkout__shipping-form {
+  padding-top: var(--spacing-xbig);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+.checkout__payment-methods {
+  padding-top: var(--spacing-xbig);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+/* Hide empty blocks */
+.checkout__block:empty {
+  display: none;
+}
+
+/* Hide blocks with empty divs */
+.checkout__server-error:has(> :empty),
+.checkout__out-of-stock:has(> :empty),
+.checkout__delivery:has(> :empty),
+.checkout__bill-to-shipping:has(> :empty) {
+  display: none;
+}
+
+/* Hide main containers when the cart is empty or there is a server error */
+.checkout__content--error .checkout__out-of-stock,
+.checkout__content--error .checkout__login,
+.checkout__content--error .checkout__shipping-form,
+.checkout__content--error .checkout__bill-to-shipping,
+.checkout__content--error .checkout__delivery,
+.checkout__content--error .checkout__payment-methods,
+.checkout__content--error .checkout__billing-form,
+.checkout__content--empty .checkout__server-error,
+.checkout__content--empty .checkout__out-of-stock,
+.checkout__content--empty .checkout__login,
+.checkout__content--empty .checkout__shipping-form,
+.checkout__content--empty .checkout__bill-to-shipping,
+.checkout__content--empty .checkout__delivery,
+.checkout__content--empty .checkout__payment-methods,
+.checkout__content--empty .checkout__billing-form {
+  display: none !important;
+}
+
+/* Hide aside containers when the cart is empty or there is a server error */
+.checkout__content--error .checkout__aside,
+.checkout__content--empty .checkout__aside {
+  display: none;
+}
+
+/* Integrate place order button into Order Summary - mobile */
+.checkout__place-order {
+  grid-column: unset;
+  justify-items: unset;
+  margin-top: calc(var(--spacing-big) * -1);
+}
+
+/* Hide the place order button when the cart is empty or there is a server error */
+.checkout__content--error .checkout__place-order,
+.checkout__content--empty .checkout__place-order {
+  display: none;
+}
+
+.checkout__loader {
+  align-items: center;
+  background: var(--color-neutral-50);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 9999;
+}
+
+.checkout__loader:empty {
+  display: none;
+}
+
+.checkout__error-banner,
+.checkout__merged-cart-banner {
+  grid-column: 1;
+}
+
+/* remove margin from the heading divider */
+.checkout__heading .dropin-divider {
+  margin: 0;
+}
+
+/* Cart Summary */
+.checkout__block .cart-cart-summary-list {
+  padding: var(--spacing-medium);
+}
+
+/* Order Summary Coupon */
+.dropin-accordion-section__heading {
+  margin: var(--spacing-medium) auto;
+}
+
+.cart-coupons__accordion {
+  margin-top: var(--spacing-xsmall);
+}
+
+/* temporary fix to hide the default cart heading */
+[data-testid='default-cart-heading'] {
+  display: none;
+}
+
+.cart-summary-list__heading {
+  display: flex;
+  justify-content: space-between;
+}
+
+.cart-summary-list__heading-text {
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+.cart-cart-summary-list__heading {
+  row-gap: var(--spacing-small);
+  padding-top: 0;
+}
+
+.cart-cart-summary-list__heading-text {
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+.cart-summary-list__edit {
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+}
+
+.checkout__block
+  .cart-cart-summary-list
+  .cart-cart-summary-list__footer-divider {
+  margin: var(--spacing-small) 0;
+}
+
+/* Sign-in modal */
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2;
+}
+
+#modal-form {
+  width: 800px;
+}
+
+/* Address form */
+.checkout__shipping-form .account-address-form-wrapper__title,
+.checkout__shipping-form .dropin-header-container__title,
+.checkout__billing-form .account-address-form-wrapper__title,
+.checkout__billing-form .dropin-header-container__title {
+  font: var(--type-headline-2-default-font);
+  letter-spacing: var(--type-headline-2-default-letter-spacing);
+  color: var(--color-neutral-800);
+  margin: 0 0 var(--spacing-medium) 0;
+}
+
+.checkout__shipping-form .dropin-header-container .dropin-divider,
+.checkout__billing-form .dropin-header-container .dropin-divider {
+  display: none;
+}
+
+/* Order confirmation */
+.order-confirmation {
+  display: grid;
+  align-items: start;
+  grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+  grid-template-areas: 'main aside';
+  grid-column-gap: var(--grid-4-gutters);
+  margin-bottom: var(--spacing-xbig);
+  padding-top: var(--spacing-xxlarge);
+}
+
+.order-confirmation__main {
+  display: grid;
+  grid-row-gap: var(--spacing-xbig);
+  grid-column: 1 / span 7;
+}
+
+.order-confirmation__aside {
+  display: grid;
+  grid-row-gap: var(--spacing-xbig);
+  grid-column: 9 / span 4;
+}
+
+.order-confirmation__footer {
+  display: grid;
+  gap: var(--spacing-small);
+  text-align: center;
+}
+
+.order-confirmation__footer p {
+  margin: 0;
+}
+
+.order-confirmation__footer .order-confirmation-footer__continue-button {
+  margin: 0 auto;
+  text-align: center;
+  display: inline-block;
+}
+
+.order-confirmation-footer__contact-support {
+  font: var(--type-body-2-default-font);
+  letter-spacing: var(--type-body-2-default-letter-spacing);
+  color: var(--color-neutral-700);
+}
+
+.order-confirmation-footer__contact-support a {
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+  color: var(--color-brand-500);
+  cursor: pointer;
+}
+
+/* Hide empty blocks */
+.order-confirmation__block:empty {
+  display: none;
+}
+
+@media only screen and (width >= 320px) and (width <= 768px) {
+  .checkout__main,
+  .checkout__aside {
+    display: contents;
+  }
+
+  .checkout__block {
+    order: 3;
+  }
+
+  .checkout__heading {
+    order: 1;
+  }
+
+  .checkout__cart-summary {
+    order: 2;
+  }
+
+  .checkout__place-order {
+    order: 4;
+  }
+
+  .order-confirmation {
+    grid-template-columns: repeat(var(--grid-1-columns), 1fr);
+    padding-top: 0;
+  }
+
+  .order-confirmation__main,
+  .order-confirmation__aside {
+    grid-row-gap: var(--spacing-medium);
+  }
+
+  .order-confirmation > div {
+    grid-column: 1 / span 4;
+  }
+
+  .order-confirmation__block .dropin-card {
+    border: 0;
+  }
+}
+
+@media only screen and (width >= 768px) {
+  .checkout__content {
+    display: grid;
+    align-items: start;
+    grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+    gap: var(--spacing-big) var(--grid-4-gutters);
+  }
+
+  .checkout__content--error,
+  .checkout__content--empty {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .checkout__main {
+    grid-column: 1 / span 7;
+    row-gap: var(--spacing-xbig);
+  }
+
+  .checkout__aside {
+    grid-column: 9 / span 4;
+    gap: var(--spacing-xbig);
+  }
+
+  .checkout__error-banner,
+  .checkout__merged-cart-banner {
+    display: grid;
+    grid-column: 1 / span 12;
+  }
+
+  .checkout__place-order {
+    display: grid;
+    margin-top: 0;
+  }
+}

--- a/blocks/commerce-checkout-braintree/commerce-checkout-braintree.js
+++ b/blocks/commerce-checkout-braintree/commerce-checkout-braintree.js
@@ -1,0 +1,899 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-shadow */
+/* eslint-disable no-use-before-define */
+/* eslint-disable prefer-const */
+
+// Dropin Tools
+import { events } from '@dropins/tools/event-bus.js';
+import { initializers } from '@dropins/tools/initializer.js';
+
+// Dropin Components
+import {
+  Button,
+  Header,
+  ProgressSpinner,
+  provider as UI,
+} from '@dropins/tools/components.js';
+
+// Auth Dropin
+import * as authApi from '@dropins/storefront-auth/api.js';
+import AuthCombine from '@dropins/storefront-auth/containers/AuthCombine.js';
+import SignUp from '@dropins/storefront-auth/containers/SignUp.js';
+import { render as AuthProvider } from '@dropins/storefront-auth/render.js';
+
+// Account Dropin
+import Addresses from '@dropins/storefront-account/containers/Addresses.js';
+import AddressForm from '@dropins/storefront-account/containers/AddressForm.js';
+import { render as AccountProvider } from '@dropins/storefront-account/render.js';
+
+// Cart Dropin
+import * as cartApi from '@dropins/storefront-cart/api.js';
+import CartSummaryList from '@dropins/storefront-cart/containers/CartSummaryList.js';
+import Coupons from '@dropins/storefront-cart/containers/Coupons.js';
+import EmptyCart from '@dropins/storefront-cart/containers/EmptyCart.js';
+import OrderSummary from '@dropins/storefront-cart/containers/OrderSummary.js';
+import { render as CartProvider } from '@dropins/storefront-cart/render.js';
+
+// Checkout Dropin
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import BillToShippingAddress from '@dropins/storefront-checkout/containers/BillToShippingAddress.js';
+import EstimateShipping from '@dropins/storefront-checkout/containers/EstimateShipping.js';
+import LoginForm from '@dropins/storefront-checkout/containers/LoginForm.js';
+import MergedCartBanner from '@dropins/storefront-checkout/containers/MergedCartBanner.js';
+import OutOfStock from '@dropins/storefront-checkout/containers/OutOfStock.js';
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import PlaceOrder from '@dropins/storefront-checkout/containers/PlaceOrder.js';
+import ServerError from '@dropins/storefront-checkout/containers/ServerError.js';
+import ShippingMethods from '@dropins/storefront-checkout/containers/ShippingMethods.js';
+
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+// Order Dropin Modules
+import * as orderApi from '@dropins/storefront-order/api.js';
+import CustomerDetails from '@dropins/storefront-order/containers/CustomerDetails.js';
+import OrderCostSummary from '@dropins/storefront-order/containers/OrderCostSummary.js';
+import OrderHeader from '@dropins/storefront-order/containers/OrderHeader.js';
+import OrderProductList from '@dropins/storefront-order/containers/OrderProductList.js';
+import OrderStatus from '@dropins/storefront-order/containers/OrderStatus.js';
+import ShippingStatus from '@dropins/storefront-order/containers/ShippingStatus.js';
+import { render as OrderProvider } from '@dropins/storefront-order/render.js';
+import { getUserTokenCookie } from '../../scripts/initializers/index.js';
+
+import 'https://js.braintreegateway.com/web/dropin/1.43.0/js/dropin.min.js';
+
+// Block-level
+import createModal from '../modal/modal.js';
+
+import {
+  estimateShippingCost, getCartAddress,
+  scrollToElement,
+  setAddressOnCart,
+} from '../../scripts/checkout.js';
+
+function createMetaTag(property, content, type) {
+  if (!property || !type) {
+    return;
+  }
+  let meta = document.head.querySelector(`meta[${type}="${property}"]`);
+  if (meta) {
+    if (!content) {
+      meta.remove();
+      return;
+    }
+    meta.setAttribute(type, property);
+    meta.setAttribute('content', content);
+    return;
+  }
+  if (!content) {
+    return;
+  }
+  meta = document.createElement('meta');
+  meta.setAttribute(type, property);
+  meta.setAttribute('content', content);
+  document.head.appendChild(meta);
+}
+
+function setMetaTags(dropin) {
+  createMetaTag('title', dropin);
+  createMetaTag('description', dropin);
+  createMetaTag('keywords', dropin);
+
+  createMetaTag('og:description', dropin);
+  createMetaTag('og:title', dropin);
+  createMetaTag('og:url', window.location.href, 'property');
+}
+
+export default async function decorate(block) {
+  // Initializers
+  import('../../scripts/initializers/account.js');
+  import('../../scripts/initializers/checkout.js');
+
+  setMetaTags('Checkout');
+  document.title = 'Checkout';
+
+  events.on('order/placed', () => {
+    setMetaTags('Order Confirmation');
+    document.title = 'Order Confirmation';
+  });
+
+  const DEBOUNCE_TIME = 1000;
+  const LOGIN_FORM_NAME = 'login-form';
+  const SHIPPING_FORM_NAME = 'selectedShippingAddress';
+  const BILLING_FORM_NAME = 'selectedBillingAddress';
+  const SHIPPING_ADDRESS_DATA_KEY = `${SHIPPING_FORM_NAME}_addressData`;
+  const BILLING_ADDRESS_DATA_KEY = `${BILLING_FORM_NAME}_addressData`;
+
+  // Define the Layout for the Checkout
+  const checkoutFragment = document.createRange().createContextualFragment(`
+    <div class="checkout__wrapper">
+      <div class="checkout__loader"></div>
+      <div class="checkout__merged-cart-banner"></div>
+      <div class="checkout__content">
+        <div class="checkout__main">
+          <div class="checkout__block checkout__heading"></div>
+          <div class="checkout__block checkout__empty-cart"></div>
+          <div class="checkout__block checkout__server-error"></div>
+          <div class="checkout__block checkout__out-of-stock"></div>
+          <div class="checkout__block checkout__login"></div>
+          <div class="checkout__block checkout__shipping-form"></div>
+          <div class="checkout__block checkout__bill-to-shipping"></div>
+          <div class="checkout__block checkout__delivery"></div>
+          <div class="checkout__block checkout__payment-methods"></div>
+          <div class="checkout__block checkout__billing-form"></div>
+          <div class="checkout__block checkout__place-order"></div>
+        </div>
+        <div class="checkout__aside">
+          <div class="checkout__block checkout__order-summary"></div>
+          <div class="checkout__block checkout__cart-summary"></div>
+        </div>
+      </div>
+    </div>
+  `);
+
+  const $content = checkoutFragment.querySelector('.checkout__content');
+  const $loader = checkoutFragment.querySelector('.checkout__loader');
+  const $mergedCartBanner = checkoutFragment.querySelector(
+    '.checkout__merged-cart-banner',
+  );
+
+  const $heading = checkoutFragment.querySelector('.checkout__heading');
+  const $emptyCart = checkoutFragment.querySelector('.checkout__empty-cart');
+  const $serverError = checkoutFragment.querySelector(
+    '.checkout__server-error',
+  );
+  const $outOfStock = checkoutFragment.querySelector('.checkout__out-of-stock');
+  const $login = checkoutFragment.querySelector('.checkout__login');
+  const $shippingForm = checkoutFragment.querySelector(
+    '.checkout__shipping-form',
+  );
+  const $billToShipping = checkoutFragment.querySelector(
+    '.checkout__bill-to-shipping',
+  );
+  const $delivery = checkoutFragment.querySelector('.checkout__delivery');
+  const $paymentMethods = checkoutFragment.querySelector(
+    '.checkout__payment-methods',
+  );
+  const $billingForm = checkoutFragment.querySelector(
+    '.checkout__billing-form',
+  );
+  const $orderSummary = checkoutFragment.querySelector(
+    '.checkout__order-summary',
+  );
+  const $cartSummary = checkoutFragment.querySelector(
+    '.checkout__cart-summary',
+  );
+  const $placeOrder = checkoutFragment.querySelector('.checkout__place-order');
+
+  block.appendChild(checkoutFragment);
+
+  // Render main containers
+  let shippingFormRef = { current: null };
+  let billingFormRef = { current: null };
+
+  let loader;
+  const displayOverlaySpinner = async () => {
+    if (loader) return;
+
+    loader = await UI.render(ProgressSpinner, {
+      className: '.checkout__overlay-spinner',
+    })($loader);
+  };
+
+  const removeOverlaySpinner = () => {
+    if (!loader) return;
+
+    loader.remove();
+    loader = null;
+    $loader.innerHTML = '';
+  };
+
+  let modal;
+  const showModal = async (content) => {
+    modal = await createModal([content]);
+    modal.showModal();
+  };
+
+  const removeModal = () => {
+    if (!modal) return;
+    modal.removeModal();
+    modal = null;
+  };
+
+  let braintreeInstance;
+
+  const [
+    _mergedCartBanner,
+    _heading,
+    _serverError,
+    _outOfStock,
+    _login,
+    shippingFormSkeleton,
+    _billToShipping,
+    _delivery,
+    _paymentMethods,
+    billingFormSkeleton,
+    _orderSummary,
+    _cartSummary,
+    placeOrder,
+  ] = await Promise.all([
+    CheckoutProvider.render(MergedCartBanner)($mergedCartBanner),
+
+    UI.render(Header, {
+      title: 'Braintree Checkout',
+      size: 'large',
+      divider: true,
+    })($heading),
+
+    CheckoutProvider.render(ServerError, {
+      onRetry: () => {
+        $content.classList.remove('checkout__content--error');
+      },
+      onServerError: () => {
+        $content.classList.add('checkout__content--error');
+      },
+    })($serverError),
+
+    CheckoutProvider.render(OutOfStock, {
+      routeCart: () => '/cart',
+      onCartProductsUpdate: (items) => {
+        cartApi.updateProductsFromCart(items).catch(console.error);
+      },
+    })($outOfStock),
+
+    CheckoutProvider.render(LoginForm, {
+      name: LOGIN_FORM_NAME,
+      onSignInClick: async (initialEmailValue) => {
+        const signInForm = document.createElement('div');
+
+        AuthProvider.render(AuthCombine, {
+          signInFormConfig: {
+            renderSignUpLink: true,
+            initialEmailValue,
+            onSuccessCallback: () => {
+              displayOverlaySpinner();
+            },
+          },
+          signUpFormConfig: {},
+          resetPasswordFormConfig: {},
+        })(signInForm);
+
+        showModal(signInForm);
+      },
+      onSignOutClick: () => {
+        authApi.revokeCustomerToken();
+      },
+    })($login),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($shippingForm),
+
+    CheckoutProvider.render(BillToShippingAddress, {
+      hideOnVirtualCart: true,
+      onChange: (checked) => {
+        $billingForm.style.display = checked ? 'none' : 'block';
+        if (!checked && billingFormRef?.current) {
+          const { formData, isDataValid } = billingFormRef.current;
+
+          setAddressOnCart(
+            { data: formData, isDataValid },
+            checkoutApi.setBillingAddress,
+          );
+        }
+      },
+    })($billToShipping),
+
+    CheckoutProvider.render(ShippingMethods, {
+      hideOnVirtualCart: true,
+    })($delivery),
+
+    CheckoutProvider.render(PaymentMethods, {
+      setOnChange: {
+        braintree: false,
+      },
+      slots: {
+        Handlers: {
+          braintree: async (ctx) => {
+            const container = document.createElement('div');
+
+            window.braintree.dropin.create({
+              authorization: 'sandbox_cstz6tw9_sbj9bzvx2ngq77n4',
+              container,
+            }, (err, dropinInstance) => {
+              if (err) {
+                console.error(err);
+              }
+
+              braintreeInstance = dropinInstance;
+            });
+
+            ctx.replaceHTML(container);
+          },
+        },
+      },
+    })($paymentMethods),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($billingForm),
+
+    CartProvider.render(OrderSummary, {
+      slots: {
+        EstimateShipping: (esCtx) => {
+          const estimateShippingForm = document.createElement('div');
+          CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+          esCtx.appendChild(estimateShippingForm);
+        },
+        Coupons: (ctx) => {
+          const coupons = document.createElement('div');
+
+          CartProvider.render(Coupons)(coupons);
+
+          ctx.appendChild(coupons);
+        },
+      },
+    })($orderSummary),
+
+    CartProvider.render(CartSummaryList, {
+      variant: 'secondary',
+      slots: {
+        Heading: (headingCtx) => {
+          const title = 'Your Cart ({count})';
+
+          const cartSummaryListHeading = document.createElement('div');
+          cartSummaryListHeading.classList.add('cart-summary-list__heading');
+
+          const cartSummaryListHeadingText = document.createElement('div');
+          cartSummaryListHeadingText.classList.add(
+            'cart-summary-list__heading-text',
+          );
+
+          cartSummaryListHeadingText.innerText = title.replace(
+            '({count})',
+            headingCtx.count ? `(${headingCtx.count})` : '',
+          );
+          const editCartLink = document.createElement('a');
+          editCartLink.classList.add('cart-summary-list__edit');
+          editCartLink.href = '/cart';
+          editCartLink.rel = 'noreferrer';
+          editCartLink.innerText = 'Edit';
+
+          cartSummaryListHeading.appendChild(cartSummaryListHeadingText);
+          cartSummaryListHeading.appendChild(editCartLink);
+          headingCtx.appendChild(cartSummaryListHeading);
+
+          headingCtx.onChange((nextHeadingCtx) => {
+            cartSummaryListHeadingText.innerText = title.replace(
+              '({count})',
+              nextHeadingCtx.count ? `(${nextHeadingCtx.count})` : '',
+            );
+          });
+        },
+      },
+    })($cartSummary),
+
+    CheckoutProvider.render(PlaceOrder, {
+      handleValidation: () => {
+        let success = true;
+        const { forms } = document;
+
+        const loginForm = forms[LOGIN_FORM_NAME];
+
+        if (loginForm) {
+          success = loginForm.checkValidity();
+          if (!success) scrollToElement($login);
+        }
+
+        const shippingForm = forms[SHIPPING_FORM_NAME];
+
+        if (
+          success
+          && shippingFormRef.current
+          && shippingForm
+          && shippingForm.checkVisibility()
+        ) {
+          success = shippingFormRef.current.handleValidationSubmit(false);
+        }
+
+        const billingForm = forms[BILLING_FORM_NAME];
+
+        if (
+          success
+          && billingFormRef.current
+          && billingForm
+          && billingForm.checkVisibility()
+        ) {
+          success = billingFormRef.current.handleValidationSubmit(false);
+        }
+
+        return success;
+      },
+      handlePlaceOrder: async (ctx) => {
+        await displayOverlaySpinner();
+
+        const cart = ctx.cartId;
+        const paymentMethodCode = ctx.code;
+
+        try {
+          switch (paymentMethodCode) {
+            case 'braintree': {
+              braintreeInstance.requestPaymentMethod(async (err, payload) => {
+                if (err) {
+                  removeOverlaySpinner();
+                  console.error(err);
+                  return;
+                }
+
+                await checkoutApi.setPaymentMethod({
+                  code: 'braintree',
+                  braintree: {
+                    is_active_payment_token_enabler: false,
+                    payment_method_nonce: payload.nonce,
+                  },
+                });
+
+                await orderApi.placeOrder(cart);
+
+                removeOverlaySpinner();
+              });
+
+              break;
+            }
+
+            default: {
+              await orderApi.placeOrder(cart);
+              removeOverlaySpinner();
+            }
+          }
+        } catch (error) {
+          removeOverlaySpinner();
+          throw error;
+        }
+      },
+    })($placeOrder),
+  ]);
+
+  let emptyCart;
+  const displayEmptyCart = async () => {
+    if (emptyCart) return;
+
+    emptyCart = await CartProvider.render(EmptyCart, {
+      routeCTA: () => '/',
+    })($emptyCart);
+
+    $content.classList.add('checkout__content--empty');
+  };
+
+  const removeEmptyCart = () => {
+    if (!emptyCart) return;
+
+    emptyCart.remove();
+    emptyCart = null;
+    $emptyCart.innerHTML = '';
+
+    $content.classList.remove('checkout__content--empty');
+  };
+
+  let shippingForm;
+  let billingForm;
+  const displayGuestAddressForms = async (data) => {
+    if (data.isVirtual) {
+      shippingForm?.remove();
+      shippingForm = null;
+      $shippingForm.innerHTML = '';
+    } else if (!shippingForm) {
+      const cartShippingAddress = getCartAddress(data, 'shipping');
+
+      const shippingAddressCache = sessionStorage.getItem(
+        SHIPPING_ADDRESS_DATA_KEY,
+      );
+
+      if (cartShippingAddress && shippingAddressCache) {
+        sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+      }
+
+      shippingFormSkeleton.remove();
+
+      let isFirstRenderShipping = true;
+      const hasCartShippingAddress = Boolean(data.shippingAddresses?.[0]);
+
+      const setShippingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setShippingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      const estimateShippingCostOnCart = estimateShippingCost({
+        api: checkoutApi.estimateShippingMethods,
+        debounceMs: DEBOUNCE_TIME,
+      });
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      shippingForm = await AccountProvider.render(AddressForm, {
+        addressesFormTitle: 'Shipping address',
+        className: 'checkout-shipping-form__address-form',
+        formName: SHIPPING_FORM_NAME,
+        forwardFormRef: shippingFormRef,
+        hideActionFormButtons: true,
+        inputsDefaultValueSet: cartShippingAddress ?? {
+          countryCode: storeConfig.defaultCountry,
+        },
+        isOpen: true,
+        onChange: (values) => {
+          const syncAddress = !isFirstRenderShipping || !hasCartShippingAddress;
+          if (syncAddress) setShippingAddressOnCart(values);
+          if (!hasCartShippingAddress) estimateShippingCostOnCart(values);
+          if (isFirstRenderShipping) isFirstRenderShipping = false;
+        },
+        showBillingCheckBox: false,
+        showFormLoader: false,
+        showShippingCheckBox: false,
+      })($shippingForm);
+    }
+
+    if (!billingForm) {
+      const cartBillingAddress = getCartAddress(data, 'billing');
+
+      const billingAddressCache = sessionStorage.getItem(
+        BILLING_ADDRESS_DATA_KEY,
+      );
+
+      if (cartBillingAddress && billingAddressCache) {
+        sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+      }
+
+      billingFormSkeleton.remove();
+
+      let isFirstRenderBilling = true;
+      const hasCartBillingAddress = Boolean(data.billingAddress);
+
+      const setBillingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setBillingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      billingForm = await AccountProvider.render(AddressForm, {
+        addressesFormTitle: 'Billing address',
+        className: 'checkout-billing-form__address-form',
+        formName: BILLING_FORM_NAME,
+        forwardFormRef: billingFormRef,
+        hideActionFormButtons: true,
+        inputsDefaultValueSet: cartBillingAddress ?? {
+          countryCode: storeConfig.defaultCountry,
+        },
+        isOpen: true,
+        onChange: (values) => {
+          const canSetBillingAddressOnCart = !isFirstRenderBilling || !hasCartBillingAddress;
+          if (canSetBillingAddressOnCart) setBillingAddressOnCart(values);
+          if (isFirstRenderBilling) isFirstRenderBilling = false;
+        },
+        showBillingCheckBox: false,
+        showFormLoader: false,
+        showShippingCheckBox: false,
+      })($billingForm);
+    }
+  };
+
+  let shippingAddresses;
+  let billingAddresses;
+  const displayCustomerAddressForms = async (data) => {
+    if (data.isVirtual) {
+      shippingAddresses?.remove();
+      shippingAddresses = null;
+      $shippingForm.innerHTML = '';
+    } else if (!shippingAddresses) {
+      shippingForm?.remove();
+      shippingForm = null;
+      shippingFormRef = { current: null };
+
+      const cartShippingAddress = getCartAddress(data, 'shipping');
+
+      const shippingAddressId = cartShippingAddress
+        ? (cartShippingAddress?.id ?? 0)
+        : undefined;
+
+      const shippingAddressCache = sessionStorage.getItem(
+        SHIPPING_ADDRESS_DATA_KEY,
+      );
+
+      // clear persisted shipping address if cart has a shipping address
+      if (cartShippingAddress && shippingAddressCache) {
+        sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+      }
+
+      // when shipping address form is empty
+      if (!cartShippingAddress) {
+        checkoutApi.estimateShippingMethods();
+        events.emit('checkout/estimate-shipping-address', {
+          address: {},
+          isValid: false,
+        });
+      }
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      const inputsDefaultValueSet = cartShippingAddress && cartShippingAddress.id === undefined
+        ? cartShippingAddress
+        : { countryCode: storeConfig.defaultCountry };
+
+      const hasCartShippingAddress = Boolean(data.shippingAddresses?.[0]);
+      let isFirstRenderShipping = true;
+
+      const setShippingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setShippingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      shippingAddresses = await AccountProvider.render(Addresses, {
+        addressFormTitle: 'Deliver to new address',
+        defaultSelectAddressId: shippingAddressId,
+        formName: SHIPPING_FORM_NAME,
+        forwardFormRef: shippingFormRef,
+        inputsDefaultValueSet,
+        minifiedView: false,
+        onAddressData: (values) => {
+          const canSetShippingAddressOnCart = !isFirstRenderShipping || !hasCartShippingAddress;
+          if (canSetShippingAddressOnCart) setShippingAddressOnCart(values);
+          if (isFirstRenderShipping) isFirstRenderShipping = false;
+        },
+        selectable: true,
+        selectShipping: true,
+        showBillingCheckBox: false,
+        showSaveCheckBox: true,
+        showShippingCheckBox: false,
+        title: 'Shipping address',
+      })($shippingForm);
+    }
+
+    if (!billingAddresses) {
+      billingForm?.remove();
+      billingForm = null;
+      billingFormRef = { current: null };
+
+      const cartBillingAddress = getCartAddress(data, 'billing');
+
+      const billingAddressId = cartBillingAddress
+        ? (cartBillingAddress?.id ?? 0)
+        : undefined;
+
+      const billingAddressCache = sessionStorage.getItem(
+        BILLING_ADDRESS_DATA_KEY,
+      );
+
+      // clear persisted billing address if cart has a billing address
+      if (cartBillingAddress && billingAddressCache) {
+        sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+      }
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      const inputsDefaultValueSet = cartBillingAddress && cartBillingAddress.id === undefined
+        ? cartBillingAddress
+        : { countryCode: storeConfig.defaultCountry };
+
+      const hasCartBillingAddress = Boolean(data.billingAddress);
+      let isFirstRenderBilling = true;
+
+      const setBillingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setBillingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      billingAddresses = await AccountProvider.render(Addresses, {
+        addressFormTitle: 'Bill to new address',
+        defaultSelectAddressId: billingAddressId,
+        formName: BILLING_FORM_NAME,
+        forwardFormRef: billingFormRef,
+        inputsDefaultValueSet,
+        minifiedView: false,
+        onAddressData: (values) => {
+          const canSetBillingAddressOnCart = !isFirstRenderBilling || !hasCartBillingAddress;
+          if (canSetBillingAddressOnCart) setBillingAddressOnCart(values);
+          if (isFirstRenderBilling) isFirstRenderBilling = false;
+        },
+        selectable: true,
+        selectBilling: true,
+        showBillingCheckBox: false,
+        showSaveCheckBox: true,
+        showShippingCheckBox: false,
+        title: 'Billing address',
+      })($billingForm);
+    }
+  };
+
+  // Define the Layout for the Order Confirmation
+  const displayOrderConfirmation = async (orderData) => {
+    // Scroll to the top of the page
+    window.scrollTo(0, 0);
+
+    const orderConfirmationFragment = document.createRange()
+      .createContextualFragment(`
+      <div class="order-confirmation">
+        <div class="order-confirmation__main">
+          <div class="order-confirmation__block order-confirmation__header"></div>
+          <div class="order-confirmation__block order-confirmation__order-status"></div>
+          <div class="order-confirmation__block order-confirmation__shipping-status"></div>
+          <div class="order-confirmation__block order-confirmation__customer-details"></div>
+        </div>
+        <div class="order-confirmation__aside">
+          <div class="order-confirmation__block order-confirmation__order-cost-summary"></div>
+          <div class="order-confirmation__block order-confirmation__order-product-list"></div>
+          <div class="order-confirmation__block order-confirmation__footer"></div>
+        </div>
+      </div>
+  `);
+
+    // Order confirmation elements
+    const $orderConfirmationHeader = orderConfirmationFragment.querySelector(
+      '.order-confirmation__header',
+    );
+    const $orderStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-status',
+    );
+    const $shippingStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__shipping-status',
+    );
+    const $customerDetails = orderConfirmationFragment.querySelector(
+      '.order-confirmation__customer-details',
+    );
+    const $orderCostSummary = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-cost-summary',
+    );
+    const $orderProductList = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-product-list',
+    );
+    const $orderConfirmationFooter = orderConfirmationFragment.querySelector(
+      '.order-confirmation__footer',
+    );
+
+    await initializers.mountImmediately(orderApi.initialize, { orderData });
+
+    block.replaceChildren(orderConfirmationFragment);
+
+    const onSignUpClick = async ({ inputsDefaultValueSet, addressesData }) => {
+      const signUpForm = document.createElement('div');
+      AuthProvider.render(SignUp, {
+        routeSignIn: () => '/customer/login',
+        routeRedirectOnEmailConfirmationClose: () => '/customer/account',
+        inputsDefaultValueSet,
+        addressesData,
+      })(signUpForm);
+
+      await showModal(signUpForm);
+    };
+
+    OrderProvider.render(OrderHeader, {
+      orderData,
+      onSignUpClick,
+    })($orderConfirmationHeader);
+
+    OrderProvider.render(OrderStatus, { slots: { OrderActions: () => null } })(
+      $orderStatus,
+    );
+    OrderProvider.render(ShippingStatus)($shippingStatus);
+    OrderProvider.render(CustomerDetails)($customerDetails);
+    OrderProvider.render(OrderCostSummary)($orderCostSummary);
+    OrderProvider.render(OrderProductList)($orderProductList);
+
+    $orderConfirmationFooter.innerHTML = `
+      <div class="order-confirmation-footer__continue-button"></div>
+      <div class="order-confirmation-footer__contact-support">
+        <p>
+          Need help?
+          <a
+            href="/support"
+            rel="noreferrer"
+            class="order-confirmation-footer__contact-support-link"
+            data-testid="order-confirmation-footer__contact-support-link"
+          >
+            Contact us
+          </a>
+        </p>
+      </div>
+    `;
+
+    const $orderConfirmationFooterContinueBtn = $orderConfirmationFooter.querySelector(
+      '.order-confirmation-footer__continue-button',
+    );
+
+    UI.render(Button, {
+      children: 'Continue shopping',
+      'data-testid': 'order-confirmation-footer__continue-button',
+      className: 'order-confirmation-footer__continue-button',
+      size: 'medium',
+      variant: 'primary',
+      type: 'submit',
+      href: '/',
+    })($orderConfirmationFooterContinueBtn);
+  };
+
+  // Event handlers
+  const handleCheckoutInitialized = async (data) => {
+    if (data === null || data.isEmpty) {
+      await displayEmptyCart();
+      return;
+    }
+
+    if (data.isGuest) {
+      await displayGuestAddressForms(data);
+    } else {
+      await displayCustomerAddressForms(data);
+    }
+  };
+
+  const handleCheckoutUpdated = async (data) => {
+    if (data === null || data.isEmpty) {
+      await displayEmptyCart();
+      return;
+    }
+
+    removeEmptyCart();
+
+    if (data.isGuest) {
+      await displayGuestAddressForms(data);
+    } else {
+      removeOverlaySpinner();
+      await displayCustomerAddressForms(data);
+    }
+  };
+
+  const handleAuthenticated = (authenticated) => {
+    if (!authenticated) return;
+    removeModal();
+  };
+
+  const handleCheckoutOrder = async (orderData) => {
+    // Clear address form data
+    sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+    sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+
+    const token = getUserTokenCookie();
+    const orderRef = token ? orderData.number : orderData.token;
+    const orderNumber = orderData.number;
+    const encodedOrderRef = encodeURIComponent(orderRef);
+    const encodedOrderNumber = encodeURIComponent(orderNumber);
+
+    const url = token
+      ? `/order-details?orderRef=${encodedOrderRef}`
+      : `/order-details?orderRef=${encodedOrderRef}&orderNumber=${encodedOrderNumber}`;
+
+    window.history.pushState({}, '', url);
+
+    // TODO cleanup checkout containers
+    await displayOrderConfirmation(orderData);
+  };
+
+  events.on('authenticated', handleAuthenticated);
+  events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
+  events.on('checkout/order', handleCheckoutOrder);
+  events.on('checkout/updated', handleCheckoutUpdated);
+}

--- a/blocks/commerce-checkout-experimentation/README.md
+++ b/blocks/commerce-checkout-experimentation/README.md
@@ -1,0 +1,208 @@
+# Checkout experimentation block
+
+## Introduction
+
+As developers, we've been tasked with extending the checkout to show the delivery options and the estimated shipping cost only after the customer introduces the shipping address.
+
+## Hands on
+
+We'll use the **commerce-checkout** as our starting point and iteratively update it to meet the new product requirements.
+
+### Step 1: ShippingMethods and EstimateShipping rendering
+
+First we need to ensure that the **ShippingMethods** container and the Order's Summary **EstimateShipping** slot are removed from the initial render:
+
+```diff
+const [
+    _mergedCartBanner,
+    _heading,
+    _serverError,
+    _outOfStock,
+    _login,
+    shippingFormSkeleton,
+    _billToShipping,
+    _paymentMethods,
+    billingFormSkeleton,
+    orderSummary,
+    _cartSummary,
+    placeOrder,
+] = await Promise.all([
+  ...
+-  CheckoutProvider.render(ShippingMethods, {
+-    hideOnVirtualCart: true,
+-  })($delivery),
+  ...
+  CartProvider.render(OrderSummary, {
+-    slots: {
+-      EstimateShipping: (esCtx) => {
+-        const estimateShippingForm = document.createElement('div');
+-        CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+-        esCtx.appendChild(estimateShippingForm);
+-      },
+-    },
+  })($orderSummary),
+]);
+```
+
+**Note:** We've renamed the **_orderSummary** variable to **orderSumary** as we are going to use it later on.
+
+### Step 2: Extract the logic
+
+For this second step we are going to create a custom function **displayShippingMethods** that when called, it will render
+the **ShippingMethods** container and update the **OrderSummary** container to pass the **EstimateShipping** slot:
+
+```js
+let shippingMethods;
+const displayShippingMethods = async () => {
+  if (shippingMethods) return;
+
+  $delivery.replaceChildren();
+
+  shippingMethods = await CheckoutProvider.render(ShippingMethods, {
+    hideOnVirtualCart: true,
+  })($delivery);
+
+  orderSummary.setProps((prev) => ({
+    ...prev,
+    slots: {
+      EstimateShipping: (esCtx) => {
+        const estimateShippingForm = document.createElement('div');
+        CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+        esCtx.appendChild(estimateShippingForm);
+      },
+    },
+  }));
+};
+```
+
+**Note:** We've defined a new variable called **shippingMethods** that will eventually hold the reference to the **ShippingMethods** container. We can use it to ensure we do not accidentally render the container twice.
+
+### Step 3: Checkout event handlers
+
+Now that we've written the logic to display the shipping methods, we need to update some of the the checkout event handlers to use it.
+
+We are going to start by updating the handler of the **checkout/initialized** event to call the **displayShippingMethods** after checking the cart's data:
+
+```diff
+const handleCheckoutInitialized = async (data) => {
+  if (data === null || data.isEmpty) {
+    await displayEmptyCart();
+    return;
+  }
+
++  const canDisplayDelivery = !!getCartAddress(data, 'shipping');
+
++  if (canDisplayDelivery) {
++    await displayShippingMethods();
++  }
+
+  if (data.isGuest) {
+    await displayGuestAddressForms(data);
+  } else {
+    await displayCustomerAddressForms(data);
+  }
+};
+```
+
+Now we do the same for the handler of the **checkout/updated** event:
+
+```diff
+const handleCheckoutUpdated = async (data) => {
+  if (data === null || data.isEmpty) {
+    await displayEmptyCart();
+    return;
+  }
+
+  removeEmptyCart();
+
++  const canDisplayDelivery = !!getCartAddress(data, 'shipping');
+
++  if (canDisplayDelivery) {
++    await displayShippingMethods();
++  }
+
+  if (data.isGuest) {
+    await displayGuestAddressForms(data);
+  } else {
+    removeOverlaySpinner();
+    await displayCustomerAddressForms(data);
+  }
+};
+```
+
+### Step 4: Delivery options placeholder
+
+To improve the user experience, we want to display a banner that inform users that the delivery options are only going to be visible after providing the shipping details. To do that, we need to update the definition of the **checkoutFragment**: 
+
+```diff
+ const checkoutFragment = document.createRange().createContextualFragment(`
+  <div class="checkout__wrapper">
+    <div class="checkout__loader"></div>
+    <div class="checkout__banners">
+      <div class="checkout__merged-cart-banner"></div>
+    </div>
+    <div class="checkout__content">
+      <div class="checkout__main">
+        <div class="checkout__block checkout__heading"></div>
+        <div class="checkout__block checkout__empty-cart"></div>
+        <div class="checkout__block checkout__server-error"></div>
+        <div class="checkout__block checkout__out-of-stock"></div>
+        <div class="checkout__block checkout__login"></div>
+        <div class="checkout__block checkout__shipping-form"></div>
+        <div class="checkout__block checkout__bill-to-shipping"></div>
+        <div class="checkout__block checkout__delivery">
++          <h3 class="checkout__delivery-title">Shipping options</h3>
++          <div class="checkout__delivery-banner">Enter your shipping address to view available shipping methods.</div>
+        </div>
+        <div class="checkout__block checkout__payment-methods"></div>
+        <div class="checkout__block checkout__billing-form"></div>
+      </div>
+      <div class="checkout__aside">
+        <div class="checkout__block checkout__block--aside checkout__order-summary"></div>
+        <div class="checkout__block checkout__block--aside checkout__cart-summary"></div>
+      </div>
+      <div class="checkout__place-order"></div>
+    </div>
+  </div>
+`);
+```
+
+Finally, we are going add some styles to the delivery title and banner using some of the available tokens:
+
+```diff
+.checkout__main {
+  display: grid;
+  row-gap: var(--spacing-xbig);
+  margin-top: var(--spacing-medium);
+}
+
+.checkout__aside {
+  display: grid;
+  gap: var(--spacing-xbig);
+}
+
++.checkout__delivery-title {
++  color: var(--color-neutral-800);
++  font: var(--type-body-1-default-font);
++  letter-spacing: var(--type-body-1-default-letter-spacing);
++  margin: 0 0 var(--spacing-medium) 0;
++}
+
++.checkout__delivery-banner {
++  background-color: var(--color-neutral-400);
++  color: var(--color-neutral-700);
++  font: var(--type-body-2-strong-font);
++  letter-spacing: var(--type-body-2-strong-letter-spacing);
++  padding: var(--spacing-small);
++  display: grid;
++  grid-template-columns: 1fr max-content;
++  align-items: center;
++  gap: var(--spacing-small);
++}
+```
+
+## Conclusion
+
+By following these steps, you have successfully updated the base **commerce-checkout** block to only display the delivery options and the estimated shipping cost
+after the customer provides the shipping details.
+

--- a/blocks/commerce-checkout-experimentation/commerce-checkout-experimentation.css
+++ b/blocks/commerce-checkout-experimentation/commerce-checkout-experimentation.css
@@ -1,0 +1,340 @@
+/* stylelint-disable selector-class-pattern */
+.checkout__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-big) 0;
+}
+
+.checkout__main {
+  display: grid;
+  row-gap: var(--spacing-xbig);
+  margin-top: var(--spacing-medium);
+}
+
+.checkout__aside {
+  display: grid;
+  gap: var(--spacing-xbig);
+}
+
+.checkout__delivery-title {
+  color: var(--color-neutral-800);
+  font: var(--type-body-1-default-font);
+  letter-spacing: var(--type-body-1-default-letter-spacing);
+  margin: 0 0 var(--spacing-medium) 0;
+}
+
+.checkout__delivery-banner {
+  background-color: var(--color-neutral-400);
+  color: var(--color-neutral-700);
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+  padding: var(--spacing-small);
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+/* Block dividers */
+.checkout__block.checkout__heading .dropin-header-container {
+  gap: var(--spacing-xsmall);
+}
+
+.checkout__shipping-form {
+  padding-top: var(--spacing-xbig);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+.checkout__payment-methods {
+  padding-top: var(--spacing-xbig);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+/* Hide empty blocks */
+.checkout__block:empty {
+  display: none;
+}
+
+/* Hide blocks with empty divs */
+.checkout__server-error:has(> :empty),
+.checkout__out-of-stock:has(> :empty),
+.checkout__delivery:has(> :empty),
+.checkout__bill-to-shipping:has(> :empty) {
+  display: none;
+}
+
+/* Hide main containers when the cart is empty or there is a server error */
+.checkout__content--error .checkout__out-of-stock,
+.checkout__content--error .checkout__login,
+.checkout__content--error .checkout__shipping-form,
+.checkout__content--error .checkout__bill-to-shipping,
+.checkout__content--error .checkout__delivery,
+.checkout__content--error .checkout__payment-methods,
+.checkout__content--error .checkout__billing-form,
+.checkout__content--empty .checkout__server-error,
+.checkout__content--empty .checkout__out-of-stock,
+.checkout__content--empty .checkout__login,
+.checkout__content--empty .checkout__shipping-form,
+.checkout__content--empty .checkout__bill-to-shipping,
+.checkout__content--empty .checkout__delivery,
+.checkout__content--empty .checkout__payment-methods,
+.checkout__content--empty .checkout__billing-form {
+  display: none !important;
+}
+
+/* Hide aside containers when the cart is empty or there is a server error */
+.checkout__content--error .checkout__aside,
+.checkout__content--empty .checkout__aside {
+  display: none;
+}
+
+/* Integrate place order button into Order Summary - mobile */
+.checkout__place-order {
+  grid-column: unset;
+  justify-items: unset;
+  margin-top: calc(var(--spacing-big) * -1);
+}
+
+/* Hide the place order button when the cart is empty or there is a server error */
+.checkout__content--error .checkout__place-order,
+.checkout__content--empty .checkout__place-order {
+  display: none;
+}
+
+.checkout__loader {
+  align-items: center;
+  background: var(--color-neutral-50);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 9999;
+}
+
+.checkout__loader:empty {
+  display: none;
+}
+
+.checkout__error-banner,
+.checkout__merged-cart-banner {
+  grid-column: 1;
+}
+
+/* remove margin from the heading divider */
+.checkout__heading .dropin-divider {
+  margin: 0;
+}
+
+/* Cart Summary */
+.checkout__block .cart-cart-summary-list {
+  padding: var(--spacing-medium);
+}
+
+/* temporary fix to hide the default cart heading */
+[data-testid='default-cart-heading'] {
+  display: none;
+}
+
+.cart-summary-list__heading {
+  display: flex;
+  justify-content: space-between;
+}
+
+.cart-summary-list__heading-text {
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+.cart-cart-summary-list__heading {
+  row-gap: var(--spacing-small);
+  padding-top: 0;
+}
+
+.cart-cart-summary-list__heading-text {
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+.cart-summary-list__edit {
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+}
+
+.checkout__block
+  .cart-cart-summary-list
+  .cart-cart-summary-list__footer-divider {
+  margin: var(--spacing-small) 0;
+}
+
+/* Sign-in modal */
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2;
+}
+
+#modal-form {
+  width: 800px;
+}
+
+/* Address form */
+.checkout__shipping-form .account-address-form-wrapper__title,
+.checkout__shipping-form .dropin-header-container__title,
+.checkout__billing-form .account-address-form-wrapper__title,
+.checkout__billing-form .dropin-header-container__title {
+  font: var(--type-headline-2-default-font);
+  letter-spacing: var(--type-headline-2-default-letter-spacing);
+  color: var(--color-neutral-800);
+  margin: 0 0 var(--spacing-medium) 0;
+}
+
+.checkout__shipping-form .dropin-header-container .dropin-divider,
+.checkout__billing-form .dropin-header-container .dropin-divider {
+  display: none;
+}
+
+/* Order confirmation */
+.order-confirmation {
+  display: grid;
+  align-items: start;
+  grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+  grid-template-areas: 'main aside';
+  grid-column-gap: var(--grid-4-gutters);
+  margin-bottom: var(--spacing-xbig);
+  padding-top: var(--spacing-xxlarge);
+}
+
+.order-confirmation__main {
+  display: grid;
+  grid-row-gap: var(--spacing-xbig);
+  grid-column: 1 / span 7;
+}
+
+.order-confirmation__aside {
+  display: grid;
+  grid-row-gap: var(--spacing-xbig);
+  grid-column: 9 / span 4;
+}
+
+.order-confirmation__footer {
+  display: grid;
+  gap: var(--spacing-small);
+  text-align: center;
+}
+
+.order-confirmation__footer p {
+  margin: 0;
+}
+
+.order-confirmation__footer .order-confirmation-footer__continue-button {
+  margin: 0 auto;
+  text-align: center;
+  display: inline-block;
+}
+
+.order-confirmation-footer__contact-support {
+  font: var(--type-body-2-default-font);
+  letter-spacing: var(--type-body-2-default-letter-spacing);
+  color: var(--color-neutral-700);
+}
+
+.order-confirmation-footer__contact-support a {
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+  color: var(--color-brand-500);
+  cursor: pointer;
+}
+
+/* Hide empty blocks */
+.order-confirmation__block:empty {
+  display: none;
+}
+
+@media only screen and (width >= 320px) and (width <= 768px) {
+    .checkout__main,
+    .checkout__aside {
+        display: contents;
+    }
+
+    .checkout__block {
+        order: 3;
+    }
+
+    .checkout__heading {
+        order: 1;
+    }
+
+    .checkout__cart-summary {
+        order: 2;
+    }
+
+    .checkout__place-order {
+        order: 4;
+    }
+
+    .order-confirmation {
+        grid-template-columns: repeat(var(--grid-1-columns), 1fr);
+        padding-top: 0;
+    }
+
+    .order-confirmation__main,
+    .order-confirmation__aside {
+        grid-row-gap: var(--spacing-medium);
+    }
+
+    .order-confirmation > div {
+        grid-column: 1 / span 4;
+    }
+
+    .order-confirmation__block .dropin-card {
+        border: 0;
+    }
+}
+
+@media only screen and (width >= 768px) {
+    .checkout__content {
+        display: grid;
+        align-items: start;
+        grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+        gap: var(--spacing-big) var(--grid-4-gutters);
+    }
+
+    .checkout__content--error,
+    .checkout__content--empty {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+
+    .checkout__main {
+        grid-column: 1 / span 7;
+        row-gap: var(--spacing-xbig);
+    }
+
+    .checkout__aside {
+        grid-column: 9 / span 4;
+        gap: var(--spacing-xbig);
+    }
+
+    .checkout__error-banner,
+    .checkout__merged-cart-banner {
+        display: grid;
+        grid-column: 1 / span 12;
+    }
+
+    .checkout__place-order {
+        margin-top: 0;
+    }
+}

--- a/blocks/commerce-checkout-experimentation/commerce-checkout-experimentation.js
+++ b/blocks/commerce-checkout-experimentation/commerce-checkout-experimentation.js
@@ -1,0 +1,812 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-shadow */
+/* eslint-disable no-use-before-define */
+/* eslint-disable prefer-const */
+
+// Dropin Tools
+import { events } from '@dropins/tools/event-bus.js';
+import { initializers } from '@dropins/tools/initializer.js';
+import { debounce } from '@dropins/tools/lib.js';
+
+// Dropin Components
+import {
+  Button,
+  Header,
+  ProgressSpinner,
+  provider as UI,
+} from '@dropins/tools/components.js';
+
+// Auth Dropin
+import * as authApi from '@dropins/storefront-auth/api.js';
+import AuthCombine from '@dropins/storefront-auth/containers/AuthCombine.js';
+import SignUp from '@dropins/storefront-auth/containers/SignUp.js';
+import { render as AuthProvider } from '@dropins/storefront-auth/render.js';
+
+// Account Dropin
+import Addresses from '@dropins/storefront-account/containers/Addresses.js';
+import AddressForm from '@dropins/storefront-account/containers/AddressForm.js';
+import { render as AccountProvider } from '@dropins/storefront-account/render.js';
+
+// Cart Dropin
+import * as cartApi from '@dropins/storefront-cart/api.js';
+import CartSummaryList from '@dropins/storefront-cart/containers/CartSummaryList.js';
+import EmptyCart from '@dropins/storefront-cart/containers/EmptyCart.js';
+import { OrderSummary } from '@dropins/storefront-cart/containers/OrderSummary.js';
+import { render as CartProvider } from '@dropins/storefront-cart/render.js';
+
+// Checkout Dropin
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import BillToShippingAddress from '@dropins/storefront-checkout/containers/BillToShippingAddress.js';
+import EstimateShipping from '@dropins/storefront-checkout/containers/EstimateShipping.js';
+import LoginForm from '@dropins/storefront-checkout/containers/LoginForm.js';
+import MergedCartBanner from '@dropins/storefront-checkout/containers/MergedCartBanner.js';
+import OutOfStock from '@dropins/storefront-checkout/containers/OutOfStock.js';
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import PlaceOrder from '@dropins/storefront-checkout/containers/PlaceOrder.js';
+import ServerError from '@dropins/storefront-checkout/containers/ServerError.js';
+import ShippingMethods from '@dropins/storefront-checkout/containers/ShippingMethods.js';
+
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+// Order Dropin Modules
+import * as orderApi from '@dropins/storefront-order/api.js';
+import CustomerDetails from '@dropins/storefront-order/containers/CustomerDetails.js';
+import OrderCostSummary from '@dropins/storefront-order/containers/OrderCostSummary.js';
+import OrderHeader from '@dropins/storefront-order/containers/OrderHeader.js';
+import OrderProductList from '@dropins/storefront-order/containers/OrderProductList.js';
+import OrderStatus from '@dropins/storefront-order/containers/OrderStatus.js';
+import ShippingStatus from '@dropins/storefront-order/containers/ShippingStatus.js';
+import { render as OrderProvider } from '@dropins/storefront-order/render.js';
+import { getUserTokenCookie } from '../../scripts/initializers/index.js';
+
+// Block-level
+import createModal from '../modal/modal.js';
+
+import {
+  estimateShippingCost,
+  getCartAddress,
+  scrollToElement,
+  setAddressOnCart,
+} from '../../scripts/checkout.js';
+
+export default async function decorate(block) {
+  // Initializers
+  import('../../scripts/initializers/auth.js');
+  import('../../scripts/initializers/account.js');
+  import('../../scripts/initializers/checkout.js');
+
+  const DEBOUNCE_TIME = 1000;
+  const LOGIN_FORM_NAME = 'login-form';
+  const SHIPPING_FORM_NAME = 'selectedShippingAddress';
+  const BILLING_FORM_NAME = 'selectedBillingAddress';
+  const SHIPPING_ADDRESS_DATA_KEY = `${SHIPPING_FORM_NAME}_addressData`;
+  const BILLING_ADDRESS_DATA_KEY = `${BILLING_FORM_NAME}_addressData`;
+
+  // Define the Layout for the Checkout
+  const checkoutFragment = document.createRange().createContextualFragment(`
+    <div class="checkout__wrapper">
+      <div class="checkout__loader"></div>
+      <div class="checkout__merged-cart-banner"></div>
+      <div class="checkout__content">
+        <div class="checkout__main">
+          <div class="checkout__block checkout__heading"></div>
+          <div class="checkout__block checkout__empty-cart"></div>
+          <div class="checkout__block checkout__server-error"></div>
+          <div class="checkout__block checkout__out-of-stock"></div>
+          <div class="checkout__block checkout__login"></div>
+          <div class="checkout__block checkout__shipping-form"></div>
+          <div class="checkout__block checkout__bill-to-shipping"></div>
+          <div class="checkout__block checkout__delivery">
+            <h3 class="checkout__delivery-title">Shipping options</h3>
+            <div class="checkout__delivery-banner">Enter your shipping address to view available shipping methods.</div>
+          </div>
+          <div class="checkout__block checkout__payment-methods"></div>
+          <div class="checkout__block checkout__billing-form"></div>
+          <div class="checkout__block checkout__place-order"></div>
+        </div>
+        <div class="checkout__aside">
+          <div class="checkout__block checkout__block--aside checkout__order-summary"></div>
+          <div class="checkout__block checkout__block--aside checkout__cart-summary"></div>
+        </div>
+      </div>
+    </div>
+  `);
+
+  const $mergedCartBanner = checkoutFragment.querySelector(
+    '.checkout__merged-cart-banner',
+  );
+  const $content = checkoutFragment.querySelector('.checkout__content');
+  const $loader = checkoutFragment.querySelector('.checkout__loader');
+  const $heading = checkoutFragment.querySelector('.checkout__heading');
+  const $emptyCart = checkoutFragment.querySelector('.checkout__empty-cart');
+  const $serverError = checkoutFragment.querySelector(
+    '.checkout__server-error',
+  );
+  const $outOfStock = checkoutFragment.querySelector('.checkout__out-of-stock');
+  const $login = checkoutFragment.querySelector('.checkout__login');
+  const $shippingForm = checkoutFragment.querySelector(
+    '.checkout__shipping-form',
+  );
+  const $billToShipping = checkoutFragment.querySelector(
+    '.checkout__bill-to-shipping',
+  );
+  const $delivery = checkoutFragment.querySelector('.checkout__delivery');
+  const $paymentMethods = checkoutFragment.querySelector(
+    '.checkout__payment-methods',
+  );
+  const $billingForm = checkoutFragment.querySelector(
+    '.checkout__billing-form',
+  );
+  const $orderSummary = checkoutFragment.querySelector(
+    '.checkout__order-summary',
+  );
+  const $cartSummary = checkoutFragment.querySelector(
+    '.checkout__cart-summary',
+  );
+  const $placeOrder = checkoutFragment.querySelector('.checkout__place-order');
+
+  block.appendChild(checkoutFragment);
+
+  // Container and component references
+  let loader;
+  let modal;
+  let shippingFormRef = { current: null };
+  let billingFormRef = { current: null };
+  let shippingForm;
+  let billingForm;
+  let shippingAddresses;
+  let billingAddresses;
+  let emptyCart;
+
+  // Render the initial containers
+  const [
+    _mergedCartBanner,
+    _heading,
+    _serverError,
+    _outOfStock,
+    _login,
+    shippingFormSkeleton,
+    _billToShipping,
+    _paymentMethods,
+    billingFormSkeleton,
+    orderSummary,
+    _cartSummary,
+    placeOrder,
+  ] = await Promise.all([
+    UI.render(Header, {
+      title: 'Experimentation Checkout',
+      size: 'large',
+      divider: true,
+    })($heading),
+
+    CheckoutProvider.render(MergedCartBanner)($mergedCartBanner),
+
+    CheckoutProvider.render(ServerError, {
+      onRetry: () => {
+        $content.classList.remove('checkout__content--error');
+      },
+      onServerError: () => {
+        $content.classList.add('checkout__content--error');
+      },
+    })($serverError),
+
+    CheckoutProvider.render(OutOfStock, {
+      routeCart: () => '/cart',
+      onCartProductsUpdate: (items) => {
+        cartApi.updateProductsFromCart(items).catch(console.error);
+      },
+    })($outOfStock),
+
+    CheckoutProvider.render(LoginForm, {
+      name: LOGIN_FORM_NAME,
+      onSignInClick: async (initialEmailValue) => {
+        const signInForm = document.createElement('div');
+
+        AuthProvider.render(AuthCombine, {
+          signInFormConfig: {
+            renderSignUpLink: true,
+            initialEmailValue,
+            onSuccessCallback: () => {
+              displayOverlaySpinner();
+            },
+          },
+          signUpFormConfig: {},
+          resetPasswordFormConfig: {},
+        })(signInForm);
+
+        await showModal(signInForm);
+      },
+      onSignOutClick: () => {
+        authApi.revokeCustomerToken();
+      },
+    })($login),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($shippingForm),
+
+    CheckoutProvider.render(BillToShippingAddress, {
+      hideOnVirtualCart: true,
+      onChange: (checked) => {
+        $billingForm.style.display = checked ? 'none' : 'block';
+
+        if (!checked && billingFormRef?.current) {
+          const { formData, isDataValid } = billingFormRef.current;
+
+          setAddressOnCart(
+            { data: formData, isDataValid },
+            checkoutApi.setBillingAddress,
+          );
+        }
+      },
+    })($billToShipping),
+
+    CheckoutProvider.render(PaymentMethods)($paymentMethods),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($billingForm),
+
+    CartProvider.render(OrderSummary)($orderSummary),
+
+    CartProvider.render(CartSummaryList, {
+      variant: 'secondary',
+      slots: {
+        Heading: (headingCtx) => {
+          const title = 'Your Cart ({count})';
+
+          const cartSummaryListHeading = document.createElement('div');
+          cartSummaryListHeading.classList.add('cart-summary-list__heading');
+
+          const cartSummaryListHeadingText = document.createElement('div');
+          cartSummaryListHeadingText.classList.add(
+            'cart-summary-list__heading-text',
+          );
+
+          cartSummaryListHeadingText.innerText = title.replace(
+            '({count})',
+            headingCtx.count ? `(${headingCtx.count})` : '',
+          );
+          const editCartLink = document.createElement('a');
+          editCartLink.classList.add('cart-summary-list__edit');
+          editCartLink.href = '/cart';
+          editCartLink.rel = 'noreferrer';
+          editCartLink.innerText = 'Edit';
+
+          cartSummaryListHeading.appendChild(cartSummaryListHeadingText);
+          cartSummaryListHeading.appendChild(editCartLink);
+          headingCtx.appendChild(cartSummaryListHeading);
+
+          headingCtx.onChange((nextHeadingCtx) => {
+            cartSummaryListHeadingText.innerText = title.replace(
+              '({count})',
+              nextHeadingCtx.count ? `(${nextHeadingCtx.count})` : '',
+            );
+          });
+        },
+      },
+    })($cartSummary),
+
+    CheckoutProvider.render(PlaceOrder, {
+      handleValidation: () => {
+        let success = true;
+        const { forms } = document;
+
+        const loginForm = forms[LOGIN_FORM_NAME];
+
+        if (loginForm) {
+          success = loginForm.checkValidity();
+          if (!success) scrollToElement($login);
+        }
+
+        const shippingForm = forms[SHIPPING_FORM_NAME];
+
+        if (
+          success
+          && shippingFormRef.current
+          && shippingForm
+          && shippingForm.checkVisibility()
+        ) {
+          success = shippingFormRef.current.handleValidationSubmit(false);
+        }
+
+        const billingForm = forms[BILLING_FORM_NAME];
+
+        if (
+          success
+          && billingFormRef.current
+          && billingForm
+          && billingForm.checkVisibility()
+        ) {
+          success = billingFormRef.current.handleValidationSubmit(false);
+        }
+
+        return success;
+      },
+      handlePlaceOrder: async ({ cartId }) => {
+        await displayOverlaySpinner();
+
+        orderApi.placeOrder(cartId)
+          .catch(console.error)
+          .finally(() => {
+            removeOverlaySpinner();
+          });
+      },
+    })($placeOrder),
+  ]);
+
+  const showModal = async (content) => {
+    modal = await createModal([content]);
+    modal.showModal();
+  };
+
+  const removeModal = () => {
+    if (!modal) return;
+    modal.removeModal();
+    modal = null;
+  };
+
+  const displayEmptyCart = async () => {
+    if (emptyCart) return;
+
+    emptyCart = await CartProvider.render(EmptyCart, {
+      routeCTA: () => '/',
+    })($emptyCart);
+
+    $content.classList.add('checkout__content--empty');
+  };
+
+  const removeEmptyCart = () => {
+    if (!emptyCart) return;
+
+    emptyCart.remove();
+    emptyCart = null;
+    $emptyCart.innerHTML = '';
+
+    $content.classList.remove('checkout__content--empty');
+  };
+
+  const displayOverlaySpinner = async () => {
+    if (loader) return;
+
+    loader = await UI.render(ProgressSpinner, {
+      className: '.checkout__overlay-spinner',
+    })($loader);
+  };
+
+  const removeOverlaySpinner = () => {
+    if (!loader) return;
+
+    loader.remove();
+    loader = null;
+    $loader.innerHTML = '';
+  };
+
+  let shippingMethods;
+  const displayShippingMethods = async () => {
+    if (shippingMethods) return;
+
+    $delivery.replaceChildren();
+
+    shippingMethods = await CheckoutProvider.render(ShippingMethods, {
+      hideOnVirtualCart: true,
+    })($delivery);
+
+    orderSummary.setProps((prev) => ({
+      ...prev,
+      slots: {
+        EstimateShipping: (esCtx) => {
+          const estimateShippingForm = document.createElement('div');
+          CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+          esCtx.appendChild(estimateShippingForm);
+        },
+      },
+    }));
+  };
+
+  const displayGuestAddressForms = async (data) => {
+    if (data.isVirtual) {
+      shippingForm?.remove();
+      shippingForm = null;
+      $shippingForm.innerHTML = '';
+    } else if (!shippingForm) {
+      const cartShippingAddress = getCartAddress(data, 'shipping');
+
+      const shippingAddressCache = sessionStorage.getItem(
+        SHIPPING_ADDRESS_DATA_KEY,
+      );
+
+      if (cartShippingAddress && shippingAddressCache) {
+        sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+      }
+
+      shippingFormSkeleton.remove();
+
+      let isFirstRenderShipping = true;
+      const hasCartShippingAddress = Boolean(data.shippingAddresses?.[0]);
+
+      const setShippingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setShippingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      const estimateShippingCostOnCart = estimateShippingCost({
+        api: checkoutApi.estimateShippingMethods,
+        debounceMs: DEBOUNCE_TIME,
+      });
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      shippingForm = await AccountProvider.render(AddressForm, {
+        addressesFormTitle: 'Shipping address',
+        className: 'checkout-shipping-form__address-form',
+        formName: SHIPPING_FORM_NAME,
+        forwardFormRef: shippingFormRef,
+        hideActionFormButtons: true,
+        inputsDefaultValueSet: cartShippingAddress ?? {
+          countryCode: storeConfig.defaultCountry,
+        },
+        isOpen: true,
+        onChange: (values) => {
+          const syncAddress = !isFirstRenderShipping || !hasCartShippingAddress;
+          if (syncAddress) setShippingAddressOnCart(values);
+          if (!hasCartShippingAddress) estimateShippingCostOnCart(values);
+          if (isFirstRenderShipping) isFirstRenderShipping = false;
+        },
+        showBillingCheckBox: false,
+        showFormLoader: false,
+        showShippingCheckBox: false,
+      })($shippingForm);
+    }
+
+    if (!billingForm) {
+      const cartBillingAddress = getCartAddress(data, 'billing');
+
+      const billingAddressCache = sessionStorage.getItem(
+        BILLING_ADDRESS_DATA_KEY,
+      );
+
+      if (cartBillingAddress && billingAddressCache) {
+        sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+      }
+
+      billingFormSkeleton.remove();
+
+      let isFirstRenderBilling = true;
+      const hasCartBillingAddress = Boolean(data.billingAddress);
+
+      const setBillingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setBillingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      billingForm = await AccountProvider.render(AddressForm, {
+        addressesFormTitle: 'Billing address',
+        className: 'checkout-billing-form__address-form',
+        formName: BILLING_FORM_NAME,
+        forwardFormRef: billingFormRef,
+        hideActionFormButtons: true,
+        inputsDefaultValueSet: cartBillingAddress ?? {
+          countryCode: storeConfig.defaultCountry,
+        },
+        isOpen: true,
+        onChange: (values) => {
+          const canSetBillingAddressOnCart = !isFirstRenderBilling || !hasCartBillingAddress;
+          if (canSetBillingAddressOnCart) setBillingAddressOnCart(values);
+          if (isFirstRenderBilling) isFirstRenderBilling = false;
+        },
+        showBillingCheckBox: false,
+        showFormLoader: false,
+        showShippingCheckBox: false,
+      })($billingForm);
+    }
+  };
+
+  const displayCustomerAddressForms = async (data) => {
+    if (data.isVirtual) {
+      shippingAddresses?.remove();
+      shippingAddresses = null;
+      $shippingForm.innerHTML = '';
+    } else if (!shippingAddresses) {
+      shippingForm?.remove();
+      shippingForm = null;
+      shippingFormRef = { current: null };
+
+      const cartShippingAddress = getCartAddress(data, 'shipping');
+
+      const shippingAddressId = cartShippingAddress
+        ? (cartShippingAddress?.id ?? 0)
+        : undefined;
+
+      const shippingAddressCache = sessionStorage.getItem(
+        SHIPPING_ADDRESS_DATA_KEY,
+      );
+
+      // clear persisted shipping address if cart has a shipping address
+      if (cartShippingAddress && shippingAddressCache) {
+        sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+      }
+
+      // when shipping address form is empty
+      if (!cartShippingAddress) {
+        checkoutApi.estimateShippingMethods();
+        events.emit('checkout/estimate-shipping-address', {
+          address: {},
+          isValid: false,
+        });
+      }
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      const inputsDefaultValueSet = cartShippingAddress && cartShippingAddress.id === undefined
+        ? cartShippingAddress
+        : { countryCode: storeConfig.defaultCountry };
+
+      const hasCartShippingAddress = Boolean(data.shippingAddresses?.[0]);
+      let isFirstRenderShipping = true;
+
+      const setShippingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setShippingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      shippingAddresses = await AccountProvider.render(Addresses, {
+        addressFormTitle: 'Deliver to new address',
+        defaultSelectAddressId: shippingAddressId,
+        formName: SHIPPING_FORM_NAME,
+        forwardFormRef: shippingFormRef,
+        inputsDefaultValueSet,
+        minifiedView: false,
+        onAddressData: (values) => {
+          const canSetShippingAddressOnCart = !isFirstRenderShipping || !hasCartShippingAddress;
+          if (canSetShippingAddressOnCart) setShippingAddressOnCart(values);
+          if (isFirstRenderShipping) isFirstRenderShipping = false;
+        },
+        selectable: true,
+        selectShipping: true,
+        showBillingCheckBox: false,
+        showSaveCheckBox: true,
+        showShippingCheckBox: false,
+        title: 'Shipping address',
+      })($shippingForm);
+    }
+
+    if (!billingAddresses) {
+      billingForm?.remove();
+      billingForm = null;
+      billingFormRef = { current: null };
+
+      const cartBillingAddress = getCartAddress(data, 'billing');
+
+      const billingAddressId = cartBillingAddress
+        ? (cartBillingAddress?.id ?? 0)
+        : undefined;
+
+      const billingAddressCache = sessionStorage.getItem(
+        BILLING_ADDRESS_DATA_KEY,
+      );
+
+      // clear persisted billing address if cart has a billing address
+      if (cartBillingAddress && billingAddressCache) {
+        sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+      }
+
+      const storeConfig = checkoutApi.getStoreConfigCache();
+
+      const inputsDefaultValueSet = cartBillingAddress && cartBillingAddress.id === undefined
+        ? cartBillingAddress
+        : { countryCode: storeConfig.defaultCountry };
+
+      const hasCartBillingAddress = Boolean(data.billingAddress);
+      let isFirstRenderBilling = true;
+
+      const setBillingAddressOnCart = setAddressOnCart({
+        api: checkoutApi.setBillingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      });
+
+      billingAddresses = await AccountProvider.render(Addresses, {
+        addressFormTitle: 'Bill to new address',
+        defaultSelectAddressId: billingAddressId,
+        formName: BILLING_FORM_NAME,
+        forwardFormRef: billingFormRef,
+        inputsDefaultValueSet,
+        minifiedView: false,
+        onAddressData: (values) => {
+          const canSetBillingAddressOnCart = !isFirstRenderBilling || !hasCartBillingAddress;
+          if (canSetBillingAddressOnCart) setBillingAddressOnCart(values);
+          if (isFirstRenderBilling) isFirstRenderBilling = false;
+        },
+        selectable: true,
+        selectBilling: true,
+        showBillingCheckBox: false,
+        showSaveCheckBox: true,
+        showShippingCheckBox: false,
+        title: 'Billing address',
+      })($billingForm);
+    }
+  };
+
+  const displayOrderConfirmation = async (orderData) => {
+    // Define the Layout for the Order Confirmation
+    const orderConfirmationFragment = document.createRange()
+      .createContextualFragment(`
+      <div class="order-confirmation">
+        <div class="order-confirmation__main">
+          <div class="order-confirmation__block order-confirmation__header"></div>
+          <div class="order-confirmation__block order-confirmation__order-status"></div>
+          <div class="order-confirmation__block order-confirmation__shipping-status"></div>
+          <div class="order-confirmation__block order-confirmation__customer-details"></div>
+        </div>
+        <div class="order-confirmation__aside">
+          <div class="order-confirmation__block order-confirmation__order-cost-summary"></div>
+          <div class="order-confirmation__block order-confirmation__order-product-list"></div>
+          <div class="order-confirmation__block order-confirmation__footer"></div>
+        </div>
+      </div>
+  `);
+
+    // Order confirmation elements
+    const $orderConfirmationHeader = orderConfirmationFragment.querySelector(
+      '.order-confirmation__header',
+    );
+    const $orderStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-status',
+    );
+    const $shippingStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__shipping-status',
+    );
+    const $customerDetails = orderConfirmationFragment.querySelector(
+      '.order-confirmation__customer-details',
+    );
+    const $orderCostSummary = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-cost-summary',
+    );
+    const $orderProductList = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-product-list',
+    );
+    const $orderConfirmationFooter = orderConfirmationFragment.querySelector(
+      '.order-confirmation__footer',
+    );
+
+    await initializers.mountImmediately(orderApi.initialize, { orderData });
+
+    block.replaceChildren(orderConfirmationFragment);
+
+    const onSignUpClick = async ({ inputsDefaultValueSet, addressesData }) => {
+      const signUpForm = document.createElement('div');
+      AuthProvider.render(SignUp, {
+        routeSignIn: () => '/customer/login',
+        routeRedirectOnEmailConfirmationClose: () => '/customer/account',
+        inputsDefaultValueSet,
+        addressesData,
+      })(signUpForm);
+
+      showModal(signUpForm);
+    };
+
+    OrderProvider.render(OrderHeader, {
+      orderData,
+      onSignUpClick,
+    })($orderConfirmationHeader);
+
+    OrderProvider.render(OrderStatus, { slots: { OrderActions: () => null } })(
+      $orderStatus,
+    );
+    OrderProvider.render(ShippingStatus)($shippingStatus);
+    OrderProvider.render(CustomerDetails)($customerDetails);
+    OrderProvider.render(OrderCostSummary)($orderCostSummary);
+    OrderProvider.render(OrderProductList)($orderProductList);
+
+    $orderConfirmationFooter.innerHTML = `
+      <div class="order-confirmation-footer__continue-button"></div>
+      <div class="order-confirmation-footer__contact-support">
+        <p>
+          Need help?
+          <a
+            href="/support"
+            rel="noreferrer"
+            class="order-confirmation-footer__contact-support-link"
+            data-testid="order-confirmation-footer__contact-support-link"
+          >
+            Contact us
+          </a>
+        </p>
+      </div>
+    `;
+
+    const $orderConfirmationFooterContinueBtn = $orderConfirmationFooter.querySelector(
+      '.order-confirmation-footer__continue-button',
+    );
+
+    UI.render(Button, {
+      children: 'Continue shopping',
+      'data-testid': 'order-confirmation-footer__continue-button',
+      className: 'order-confirmation-footer__continue-button',
+      size: 'medium',
+      variant: 'primary',
+      type: 'submit',
+      href: '/',
+    })($orderConfirmationFooterContinueBtn);
+  };
+
+  // Event handlers
+  const handleCheckoutInitialized = async (data) => {
+    if (data === null || data.isEmpty) {
+      await displayEmptyCart();
+      return;
+    }
+
+    const canDisplayDelivery = !!getCartAddress(data, 'shipping');
+
+    if (canDisplayDelivery) {
+      await displayShippingMethods();
+    }
+
+    if (data.isGuest) {
+      await displayGuestAddressForms(data);
+    } else {
+      await displayCustomerAddressForms(data);
+    }
+  };
+
+  const handleCheckoutUpdated = async (data) => {
+    if (data === null || data.isEmpty) {
+      await displayEmptyCart();
+      return;
+    }
+
+    removeEmptyCart();
+
+    const canDisplayDelivery = !!getCartAddress(data, 'shipping');
+
+    if (canDisplayDelivery) {
+      await displayShippingMethods();
+    }
+
+    if (data.isGuest) {
+      await displayGuestAddressForms(data);
+    } else {
+      removeOverlaySpinner();
+      await displayCustomerAddressForms(data);
+    }
+  };
+
+  const handleAuthenticated = (authenticated) => {
+    if (!authenticated) return;
+    removeModal();
+  };
+
+  const handleCheckoutOrder = async (orderData) => {
+    // clear address form data
+    sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+    sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+
+    const token = getUserTokenCookie();
+    const orderRef = token ? orderData.number : orderData.token;
+    const encodedOrderRef = encodeURIComponent(orderRef);
+
+    window.history.pushState(
+      {},
+      '',
+      `/order-details?orderRef=${encodedOrderRef}`,
+    );
+
+    // TODO cleanup checkout containers
+    await displayOrderConfirmation(orderData);
+  };
+
+  events.on('authenticated', handleAuthenticated);
+  events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
+  events.on('checkout/order', handleCheckoutOrder);
+  events.on('checkout/updated', handleCheckoutUpdated);
+}

--- a/blocks/commerce-checkout-luma/README.md
+++ b/blocks/commerce-checkout-luma/README.md
@@ -1,0 +1,13 @@
+# Commerce Checkout Luma
+
+This commerce block attempts to replicate Luma's checkout experience using Dropin containers.
+
+## What does it cover
+
+| Feature               | Covered |
+| --------------------- | ------- |
+| Custom Payment Method | ❌      |
+| Customer Checkout     | ❌      |
+| Empty Cart            | ✅      |
+| Guest Checkout        | ✅      |
+| Virtual Cart          | ❌      |

--- a/blocks/commerce-checkout-luma/commerce-checkout-luma.css
+++ b/blocks/commerce-checkout-luma/commerce-checkout-luma.css
@@ -1,0 +1,95 @@
+/* stylelint-disable selector-class-pattern */
+
+.checkout__progress {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-big);
+  margin-bottom: var(--spacing-big);
+}
+
+.checkout__progress--empty {
+  display: none;
+}
+
+.checkout__progress__step {
+  flex: 1;
+}
+
+.checkout__progress__step .dropin-button {
+  width: 100%;
+}
+
+/* select active dropin-button using active attribute */
+.checkout__progress__step .dropin-button[active] {
+  background: var(--color-button-active);
+}
+
+.checkout_login {
+  order: 1;
+}
+
+.checkout__steps {
+  display: grid;
+  align-items: start;
+  grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+  gap: var(--spacing-big);
+  padding-top: 1.5rem;
+}
+
+.checkout__steps--empty {
+  display: none;
+}
+
+.checkout__steps__main {
+  grid-column: 1 / span 7;
+}
+
+.checkout__steps__aside {
+  grid-column: 9 / span 4;
+}
+
+.checkout__shipping,
+.checkout__payment {
+  display: grid;
+  gap: var(--spacing-big);
+}
+
+.checkout__continue-to-payment {
+  display: flex;
+  justify-content: end;
+}
+
+.checkout__loader {
+  align-items: center;
+  background: var(--color-neutral-50);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 9999;
+}
+
+/* temporary fix to hide the default cart heading */
+[data-testid='default-cart-heading'] {
+  display: none;
+}
+
+@media only screen and (width >= 320px) and (width <= 768px) {
+  .checkout__steps {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-big) 0;
+  }
+
+  .checkout__steps__main,
+  .checkout__steps__aside {
+    grid-column: auto;
+  }
+
+  .checkout__steps__aside {
+    order: -1;
+  }
+}

--- a/blocks/commerce-checkout-luma/commerce-checkout-luma.js
+++ b/blocks/commerce-checkout-luma/commerce-checkout-luma.js
@@ -1,0 +1,536 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-shadow */
+/* eslint-disable no-use-before-define */
+/* eslint-disable prefer-const */
+
+// Dropin Tools
+import { events } from '@dropins/tools/event-bus.js';
+import { initializers } from '@dropins/tools/initializer.js';
+
+// Dropin Components
+import { Button, Header, provider as UI } from '@dropins/tools/components.js';
+
+// Auth Dropin
+import SignUp from '@dropins/storefront-auth/containers/SignUp.js';
+import { render as AuthProvider } from '@dropins/storefront-auth/render.js';
+
+// Account Dropin
+import AddressForm from '@dropins/storefront-account/containers/AddressForm.js';
+import { render as AccountProvider } from '@dropins/storefront-account/render.js';
+
+// Cart Dropin
+import EmptyCart from '@dropins/storefront-cart/containers/EmptyCart.js';
+import { OrderSummary } from '@dropins/storefront-cart/containers/OrderSummary.js';
+import { render as CartProvider } from '@dropins/storefront-cart/render.js';
+
+// Checkout Dropin
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import BillToShippingAddress from '@dropins/storefront-checkout/containers/BillToShippingAddress.js';
+import EstimateShipping from '@dropins/storefront-checkout/containers/EstimateShipping.js';
+import LoginForm from '@dropins/storefront-checkout/containers/LoginForm.js';
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import PlaceOrder from '@dropins/storefront-checkout/containers/PlaceOrder.js';
+import ShippingMethods from '@dropins/storefront-checkout/containers/ShippingMethods.js';
+
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+// Order Dropin Modules
+import * as orderApi from '@dropins/storefront-order/api.js';
+import CustomerDetails from '@dropins/storefront-order/containers/CustomerDetails.js';
+import OrderCostSummary from '@dropins/storefront-order/containers/OrderCostSummary.js';
+import OrderHeader from '@dropins/storefront-order/containers/OrderHeader.js';
+import OrderProductList from '@dropins/storefront-order/containers/OrderProductList.js';
+import OrderStatus from '@dropins/storefront-order/containers/OrderStatus.js';
+import ShippingStatus from '@dropins/storefront-order/containers/ShippingStatus.js';
+import { render as OrderProvider } from '@dropins/storefront-order/render.js';
+import { getUserTokenCookie } from '../../scripts/initializers/index.js';
+
+// Block-level
+import { getCartAddress, setAddressOnCart } from '../../scripts/checkout.js';
+import createModal from '../modal/modal.js';
+
+export default async function decorate(block) {
+  // Initializers
+  import('../../scripts/initializers/auth.js');
+  import('../../scripts/initializers/checkout.js');
+
+  const DEBOUNCE_TIME = 1000;
+  const LOGIN_FORM_NAME = 'login-form';
+  const SHIPPING_FORM_NAME = 'selectedShippingAddress';
+  const BILLING_FORM_NAME = 'selectedBillingAddress';
+  const SHIPPING_ADDRESS_DATA_KEY = `${SHIPPING_FORM_NAME}_addressData`;
+  const BILLING_ADDRESS_DATA_KEY = `${BILLING_FORM_NAME}_addressData`;
+
+  // Define the Layout for the Checkout
+  const fragment = document.createRange().createContextualFragment(`
+    <div class="checkout__wrapper">
+      <div class="checkout__progress">
+        <div class="checkout__progress__step checkout__progress__shipping"></div>
+        <div class="checkout__progress__step checkout__progress__payment"></div>
+      </div>
+      <div class="checkout__heading"></div>
+      <div class="checkout__empty-cart"></div>
+      <div class="checkout__steps">
+        <div class="checkout__steps__main"/>
+          <div class="checkout__shipping">
+            <div class="checkout__login"></div>
+            <div class="checkout__shipping-form"></div>
+            <div class="checkout__shipping-methods"></div>
+            <div class="checkout__continue-to-payment"></div>
+          </div>
+          <div class="checkout__payment">
+            <div class="checkout__payment-methods"></div>
+            <div class="checkout__bill-to-shipping"></div>
+            <div class="checkout__billing-form"></div>
+            <div class="checkout__place-order"></div>
+          </div>
+        </div>
+        <div class="checkout__steps__aside"/>
+          <div class="checkout__order-summary"/>
+        </div>
+      </div>
+    </div>
+  `);
+
+  const $progress = fragment.querySelector('.checkout__progress');
+  const $shippingProgress = fragment.querySelector(
+    '.checkout__progress__shipping',
+  );
+  const $paymentProgress = fragment.querySelector(
+    '.checkout__progress__payment',
+  );
+
+  const $heading = fragment.querySelector('.checkout__heading');
+  const $emptyCart = fragment.querySelector('.checkout__empty-cart');
+
+  const $steps = fragment.querySelector('.checkout__steps');
+
+  const $shippingStep = fragment.querySelector('.checkout__shipping');
+  const $login = fragment.querySelector('.checkout__login');
+  const $shippingForm = fragment.querySelector('.checkout__shipping-form');
+  const $shippingMethods = fragment.querySelector(
+    '.checkout__shipping-methods',
+  );
+  const $continueToPaymentBtn = fragment.querySelector(
+    '.checkout__continue-to-payment',
+  );
+
+  const $paymentStep = fragment.querySelector('.checkout__payment');
+  const $paymentMethods = fragment.querySelector('.checkout__payment-methods');
+  const $billToShipping = fragment.querySelector('.checkout__bill-to-shipping');
+  const $billingForm = fragment.querySelector('.checkout__billing-form');
+  const $placeOrder = fragment.querySelector('.checkout__place-order');
+
+  const $orderSummary = fragment.querySelector('.checkout__order-summary');
+
+  block.replaceChildren(fragment);
+
+  // Render initial containers and components
+  let [
+    shippingProgress,
+    paymentProgress,
+    heading,
+    _loginForm,
+    shippingFormSkeleton,
+    _shippingMethods,
+    continuePaymentBtn,
+    _orderSummary,
+  ] = await Promise.all([
+    UI.render(Button, {
+      active: false,
+      activeChildren: 'SHIPPING',
+      children: 'SHIPPING',
+      disabled: true,
+      variant: 'primary',
+      onClick: () => {
+        $shippingStep.style.display = 'grid';
+        shippingProgress.setProps((prev) => ({
+          ...prev,
+          active: true,
+        }));
+
+        $paymentStep.style.display = 'none';
+        paymentProgress.setProps((prev) => ({
+          ...prev,
+          active: false,
+        }));
+      },
+    })($shippingProgress),
+
+    UI.render(Button, {
+      active: false,
+      activeChildren: 'PAYMENT',
+      children: 'PAYMENT',
+      disabled: true,
+      variant: 'primary',
+      onClick: () => {
+        $shippingStep.style.display = 'none';
+        shippingProgress.setProps((prev) => ({
+          ...prev,
+          active: false,
+        }));
+
+        $paymentStep.style.display = 'grid';
+        paymentProgress.setProps((prev) => ({
+          ...prev,
+          active: true,
+        }));
+      },
+    })($paymentProgress),
+
+    UI.render(Header, {
+      title: 'Luma Checkout',
+      size: 'large',
+      divider: true,
+    })($heading),
+
+    CheckoutProvider.render(LoginForm, {
+      name: LOGIN_FORM_NAME,
+    })($login),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($shippingForm),
+
+    CheckoutProvider.render(ShippingMethods, {
+      hideOnVirtualCart: true,
+    })($shippingMethods),
+
+    await UI.render(Button, {
+      children: 'Next',
+      disabled: true,
+      onClick: async () => {
+        await continueToPayment();
+      },
+    })($continueToPaymentBtn),
+
+    CartProvider.render(OrderSummary, {
+      slots: {
+        EstimateShipping: (esCtx) => {
+          const estimateShippingForm = document.createElement('div');
+          CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+          esCtx.appendChild(estimateShippingForm);
+        },
+      },
+    })($orderSummary),
+  ]);
+
+  // Dynamic containers and components
+
+  let modal;
+
+  const showModal = async (content) => {
+    modal = await createModal([content]);
+    modal.showModal();
+  };
+
+  let emptyCart;
+
+  const displayEmptyCart = async () => {
+    if (emptyCart) return;
+
+    emptyCart = await CartProvider.render(EmptyCart, {
+      routeCTA: () => '/',
+    })($emptyCart);
+
+    heading.setProps((prev) => ({
+      ...prev,
+      title: 'Checkout',
+    }));
+
+    $progress.classList.add('checkout__progress--empty');
+    $steps.classList.add('checkout__steps--empty');
+  };
+
+  const removeEmptyCart = () => {
+    if (!emptyCart) return;
+
+    emptyCart.remove();
+    emptyCart = null;
+    $emptyCart.innerHTML = '';
+
+    $progress.classList.remove('checkout__progress--empty');
+    $steps.classList.remove('checkout__steps--empty');
+  };
+
+  const continueToShipping = async (data) => {
+    if (!shippingFormSkeleton) return;
+
+    heading.setProps((prev) => ({
+      ...prev,
+      title: 'Shipping Method',
+    }));
+
+    shippingProgress.setProps((prev) => ({
+      ...prev,
+      active: true,
+      disabled: false,
+    }));
+
+    const cartShippingAddress = getCartAddress(data, 'shipping');
+
+    if (!cartShippingAddress) {
+      await checkoutApi.estimateShippingMethods();
+
+      events.emit('checkout/estimate-shipping-address', {
+        address: {},
+        isValid: false,
+      });
+    }
+
+    // remove the shipping form sekeleton
+    shippingFormSkeleton.remove();
+    shippingFormSkeleton = null;
+    $shippingForm.innerHTML = '';
+
+    const storeConfig = checkoutApi.getStoreConfigCache();
+
+    await AccountProvider.render(AddressForm, {
+      addressesFormTitle: 'Shipping address',
+      className: 'checkout-shipping-form__address-form',
+      formName: SHIPPING_FORM_NAME,
+      hideActionFormButtons: true,
+      inputsDefaultValueSet: cartShippingAddress ?? {
+        countryCode: storeConfig.defaultCountry,
+      },
+      isOpen: true,
+      onChange: setAddressOnCart({
+        api: checkoutApi.setShippingAddress,
+        debounceMs: DEBOUNCE_TIME,
+      }),
+      showBillingCheckBox: false,
+      showShippingCheckBox: false,
+    })($shippingForm);
+  };
+
+  let paymentContainers;
+
+  const continueToPayment = async (data) => {
+    if (paymentContainers) return;
+
+    heading.setProps((prev) => ({
+      ...prev,
+      title: 'Payment Method',
+    }));
+
+    paymentProgress.setProps((prev) => ({
+      ...prev,
+      active: true,
+      disabled: false,
+    }));
+
+    shippingProgress.setProps((prev) => ({
+      ...prev,
+      active: false,
+      disabled: false,
+    }));
+
+    $shippingStep.style.display = 'none';
+
+    const cartBillingAddress = getCartAddress(data, 'billing');
+
+    const storeConfig = checkoutApi.getStoreConfigCache();
+
+    paymentContainers = await Promise.all([
+      CheckoutProvider.render(PaymentMethods)($paymentMethods),
+
+      CheckoutProvider.render(BillToShippingAddress, {
+        hideOnVirtualCart: true,
+        onChange: (checked) => {
+          $billingForm.style.display = checked ? 'none' : 'block';
+        },
+      })($billToShipping),
+
+      AccountProvider.render(AddressForm, {
+        addressesFormTitle: 'Billing address',
+        className: 'checkout-billing-form__address-form',
+        formName: BILLING_FORM_NAME,
+        hideActionFormButtons: true,
+        inputsDefaultValueSet: cartBillingAddress ?? {
+          countryCode: storeConfig.defaultCountry,
+        },
+        isOpen: true,
+        onChange: setAddressOnCart({
+          api: checkoutApi.setBillingAddress,
+          debounceMs: DEBOUNCE_TIME,
+        }),
+        showBillingCheckBox: false,
+        showShippingCheckBox: false,
+      })($billingForm),
+
+      CheckoutProvider.render(PlaceOrder, {
+        disabled: true,
+        handlePlaceOrder: async ({ cartId }) => {
+          orderApi.placeOrder(cartId).catch(console.error);
+        },
+      })($placeOrder),
+    ]);
+
+    continuePaymentBtn.remove();
+    $continueToPaymentBtn.innerHTML = '';
+  };
+
+  const displayOrderConfirmation = async (orderData) => {
+    // Define the Layout for the Order Confirmation
+    const orderConfirmationFragment = document.createRange()
+      .createContextualFragment(`
+      <div class="order-confirmation">
+        <div class="order-confirmation__main">
+          <div class="order-confirmation__block order-confirmation__header"></div>
+          <div class="order-confirmation__block order-confirmation__order-status"></div>
+          <div class="order-confirmation__block order-confirmation__shipping-status"></div>
+          <div class="order-confirmation__block order-confirmation__customer-details"></div>
+        </div>
+        <div class="order-confirmation__aside">
+          <div class="order-confirmation__block order-confirmation__order-cost-summary"></div>
+          <div class="order-confirmation__block order-confirmation__order-product-list"></div>
+          <div class="order-confirmation__block order-confirmation__footer"></div>
+        </div>
+      </div>
+  `);
+
+    // Order confirmation elements
+    const $orderConfirmationHeader = orderConfirmationFragment.querySelector(
+      '.order-confirmation__header',
+    );
+    const $orderStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-status',
+    );
+    const $shippingStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__shipping-status',
+    );
+    const $customerDetails = orderConfirmationFragment.querySelector(
+      '.order-confirmation__customer-details',
+    );
+    const $orderCostSummary = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-cost-summary',
+    );
+    const $orderProductList = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-product-list',
+    );
+    const $orderConfirmationFooter = orderConfirmationFragment.querySelector(
+      '.order-confirmation__footer',
+    );
+
+    await initializers.mountImmediately(orderApi.initialize, { orderData });
+
+    block.replaceChildren(orderConfirmationFragment);
+
+    const onSignUpClick = async ({ inputsDefaultValueSet, addressesData }) => {
+      const signUpForm = document.createElement('div');
+      AuthProvider.render(SignUp, {
+        routeSignIn: () => '/customer/login',
+        routeRedirectOnEmailConfirmationClose: () => '/customer/account',
+        inputsDefaultValueSet,
+        addressesData,
+      })(signUpForm);
+
+      showModal(signUpForm);
+    };
+
+    OrderProvider.render(OrderHeader, {
+      orderData,
+      onSignUpClick,
+    })($orderConfirmationHeader);
+
+    OrderProvider.render(OrderStatus, { slots: { OrderActions: () => null } })(
+      $orderStatus,
+    );
+    OrderProvider.render(ShippingStatus)($shippingStatus);
+    OrderProvider.render(CustomerDetails)($customerDetails);
+    OrderProvider.render(OrderCostSummary)($orderCostSummary);
+    OrderProvider.render(OrderProductList)($orderProductList);
+
+    $orderConfirmationFooter.innerHTML = `
+      <div class="order-confirmation-footer__continue-button"></div>
+      <div class="order-confirmation-footer__contact-support">
+        <p>
+          Need help?
+          <a
+            href="/support"
+            rel="noreferrer"
+            class="order-confirmation-footer__contact-support-link"
+            data-testid="order-confirmation-footer__contact-support-link"
+          >
+            Contact us
+          </a>
+        </p>
+      </div>
+    `;
+
+    const $orderConfirmationFooterContinueBtn = $orderConfirmationFooter.querySelector(
+      '.order-confirmation-footer__continue-button',
+    );
+
+    UI.render(Button, {
+      children: 'Continue shopping',
+      'data-testid': 'order-confirmation-footer__continue-button',
+      className: 'order-confirmation-footer__continue-button',
+      size: 'medium',
+      variant: 'primary',
+      type: 'submit',
+      href: '/',
+    })($orderConfirmationFooterContinueBtn);
+  };
+
+  // Define checkout event handlers and shared utilities
+  const isEmptyCart = (data) => data === null || data.isEmpty;
+
+  const canProceedToPayment = (data) => {
+    const { email } = data;
+    const shippingAddresses = data.shippingAddresses || [];
+
+    if (!email || shippingAddresses.length === 0) return false;
+
+    const selectedAddress = shippingAddresses[0];
+    const selectedDelivery = selectedAddress.selectedShippingMethod;
+
+    return !!selectedDelivery;
+  };
+
+  async function handleCheckoutInitialized(data) {
+    if (isEmptyCart(data)) {
+      await displayEmptyCart();
+    } else {
+      removeEmptyCart();
+      await continueToShipping(data);
+      if (canProceedToPayment(data)) await continueToPayment();
+    }
+  }
+
+  async function handleCheckoutUpdated(data) {
+    if (isEmptyCart(data)) {
+      await displayEmptyCart();
+    } else {
+      removeEmptyCart();
+      await continueToShipping(data);
+      if (!canProceedToPayment(data)) return;
+      continuePaymentBtn.setProps((prev) => ({ ...prev, disabled: false }));
+    }
+  }
+
+  async function handleCheckoutOrder(orderData) {
+    // clear address form data
+    sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+    sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+
+    const token = getUserTokenCookie();
+    const orderRef = token ? orderData.number : orderData.token;
+    const encodedOrderRef = encodeURIComponent(orderRef);
+
+    window.history.pushState(
+      {},
+      '',
+      `/order-details?orderRef=${encodedOrderRef}`,
+    );
+
+    // TODO cleanup checkout containers
+    await displayOrderConfirmation(orderData);
+  }
+
+  events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
+  events.on('checkout/updated', handleCheckoutUpdated);
+  events.on('checkout/order', handleCheckoutOrder);
+}

--- a/blocks/commerce-checkout-multi-step/README.md
+++ b/blocks/commerce-checkout-multi-step/README.md
@@ -1,0 +1,684 @@
+# Commerce Checkout Multi-step
+
+As developers, we've been tasked with implementing a multi-step checkout using the available Storefront Dropin containers.
+
+## Hands on
+
+We'll use the **commerce-checkout** block as our starting point and iteratively update it to meet the new product requirements.
+
+For simplicity, we are only going to cover the guest checkout experience. Check the table below for more details:
+
+| Feature               | Covered |
+| --------------------- | ------- |
+| Custom Payment Method | ❌      |
+| Customer Checkout     | ❌      |
+| Empty Cart            | ✅      |
+| Guest Checkout        | ✅      |
+| Virtual Cart          | ❌      |
+| Order Confirmation    | ✅      |
+
+### Step 1: Duplicate the commerce-checkout block
+
+First, we'll duplicate the **commerce-checkout** block. Next, make sure to remove all the content from the CSS file. Finally, open the JS file and remove everything from inside the **decorate** function so that it looks like this:
+
+```js
+export default async function decorate(block) {};
+```
+
+### Step 2: Initialization
+
+We need to ensure we import the initializers of the all dropins that we are going to use. For this example, we'll use the auth and the checkout:
+
+```diff
+export default async function decorate(block) {
++  // Initializers
++  import('../../scripts/initializers/auth.js');
++  import('../../scripts/initializers/checkout.js');
+
++  const DEBOUNCE_TIME = 1000;
++  const LOGIN_FORM_NAME = 'login-form';
++  const SHIPPING_FORM_NAME = 'selectedShippingAddress';
++  const BILLING_FORM_NAME = 'selectedBillingAddress';
++  const SHIPPING_ADDRESS_DATA_KEY = `${SHIPPING_FORM_NAME}_addressData`;
++  const BILLING_ADDRESS_DATA_KEY = `${BILLING_FORM_NAME}_addressData`;
+
++  // Pre-fetch checkout store configuration
++  const storeConfig = await checkoutApi.getStoreConfig();
+};
+```
+
+**Note:** We've also defined some constants that we are going to use later on to render the containers and we've also pre-fetched the store configuration that the checkout dropin is going to use.
+
+### Step 3: Layout
+
+We'll define the layout for or checkout with a contextual fragment and we'll also reference the DOM elements were we are going to render our containers. Finally, we replace the block content with the fragment we've just created.
+
+```diff
+export default async function decorate(block) {
+  ...
++  // Define the Layout for the Checkout
++  const fragment = document.createRange().createContextualFragment(`
++    <div class="checkout__wrapper">
++      <div class="checkout__heading"></div>
++      <div class="checkout__empty-cart"></div>
++      <div class="checkout__content">
++        <div class="checkout__main">
++          <div class="checkout__shipping">
++            <div class="checkout__shipping-title"></div>
++            <div class="checkout__login"></div>
++            <div class="checkout__shipping-form"></div>
++            <div class="checkout__continue-to-delivery"></div>
++          </div>
++          <div class="checkout__delivery">
++            <div class="checkout__delivery-title"></div>
++            <div class="checkout__delivery-methods"></div>
++            <div class="checkout__continue-to-payment"></div>
++          </div>
++          <div class="checkout__payment">
++            <div class="checkout__payment-title"></div>
++            <div class="checkout__bill-to-shipping"></div>
++            <div class="checkout__billing-form"></div>
++            <div class="checkout__payment-methods"></div>
++            <div class="checkout__place-order"></div>
++          </div>
++        </div>
++        <div class="checkout__aside">
++          <div class="checkout__order-summary"></div>
++          <div class="checkout__cart-summary"></div>
++        </div>
++      </div>
++    </div>
++  `);
++
++  const $heading = fragment.querySelector('.checkout__heading');
++  const $emptyCart = fragment.querySelector('.checkout__empty-cart');
++  const $content = fragment.querySelector('.checkout__content');
++
++  const $orderSummary = fragment.querySelector('.checkout__order-summary');
++  const $cartSummary = fragment.querySelector('.checkout__cart-summary');
++
++  const $shippingTitle = fragment.querySelector('.checkout__shipping-title');
++  const $login = fragment.querySelector('.checkout__login');
++  const $shippingForm = fragment.querySelector('.checkout__shipping-form');
++  const $continueToDeliveryBtn = fragment.querySelector(
++    '.checkout__continue-to-delivery',
++  );
++
++  const $deliveryTitle = fragment.querySelector('.checkout__delivery-title');
++  const $deliveryMethods = fragment.querySelector(
++    '.checkout__delivery-methods',
++  );
++  const $continueToPaymentBtn = fragment.querySelector(
++    '.checkout__continue-to-payment',
++  );
++
++  const $paymentTitle = fragment.querySelector('.checkout__payment-title');
++  const $billToShipping = fragment.querySelector('.checkout__bill-to-shipping');
++  const $billingForm = fragment.querySelector('.checkout__billing-form');
++  const $paymentMethods = fragment.querySelector('.checkout__payment-methods');
++  const $placeOrder = fragment.querySelector('.checkout__place-order');
++
++  block.replaceChildren(fragment);
+};
+```
+
+### Step 4: Render the initial containers
+
+We'll render the initial containers to the corresponding DOM elements that we've created in the previous step:
+
+```js
+export default async function decorate(block) {
+  ...
+  const [
+    heading,
+    _shippingInfoHeading,
+    __shippingMethodHeading,
+    _paymentHeading,
+    _loginForm,
+    shippingFormSkeleton,
+    continueToDeliveryBtn,
+    orderSummary,
+    _cartSummary,
+  ] = await Promise.all([
+    UI.render(Header, {
+      title: 'Guest Checkout',
+      size: 'large',
+      divider: false,
+    })($heading),
+
+    UI.render(Header, {
+      title: '1. SHIPPING INFORMATION',
+      size: 'medium',
+      divider: false,
+    })($shippingTitle),
+
+    UI.render(Header, {
+      title: '2. SHIPPING METHOD',
+      size: 'medium',
+      divider: false,
+    })($deliveryTitle),
+
+    UI.render(Header, {
+      title: '3. PAYMENT INFORMATION',
+      size: 'medium',
+      divider: false,
+    })($paymentTitle),
+
+    // render the initial containers
+    CheckoutProvider.render(LoginForm, {
+      name: LOGIN_FORM_NAME,
+    })($login),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($shippingForm),
+
+    UI.render(Button, {
+      children: 'CONTINUE TO SHIPPING METHOD',
+      disabled: true,
+      onClick: async () => {
+        await continueToDelivery();
+      },
+    })($continueToDeliveryBtn),
+
+    CartProvider.render(OrderSummary)($orderSummary),
+
+    CartProvider.render(CartSummaryList, {
+      variant: 'secondary',
+      slots: {
+        Heading: (headingCtx) => {
+          const title = 'Your Cart ({count})';
+
+          const cartSummaryListHeading = document.createElement('div');
+          cartSummaryListHeading.classList.add('cart-summary-list__heading');
+
+          const cartSummaryListHeadingText = document.createElement('div');
+          cartSummaryListHeadingText.classList.add(
+            'cart-summary-list__heading-text',
+          );
+
+          cartSummaryListHeadingText.innerText = title.replace(
+            '({count})',
+            headingCtx.count ? `(${headingCtx.count})` : '',
+          );
+          const editCartLink = document.createElement('a');
+          editCartLink.classList.add('cart-summary-list__edit');
+          editCartLink.href = '/cart';
+          editCartLink.rel = 'noreferrer';
+          editCartLink.innerText = 'Edit';
+
+          cartSummaryListHeading.appendChild(cartSummaryListHeadingText);
+          cartSummaryListHeading.appendChild(editCartLink);
+          headingCtx.appendChild(cartSummaryListHeading);
+
+          headingCtx.onChange((nextHeadingCtx) => {
+            cartSummaryListHeadingText.innerText = title.replace(
+              '({count})',
+              nextHeadingCtx.count ? `(${nextHeadingCtx.count})` : '',
+            );
+          });
+        },
+      },
+    })($cartSummary),
+  ]);
+};
+```
+
+At this point, if you access the page were you are using the block, you should see that all the containers are being rendered. The layout is probably not looking good, but don't worry, we are going to fix this in the next step. 
+
+### Step 5: Styles
+
+As promised, we'll now add some styles to our layout and containers to make them look good. Just open the **commerce-checkout-multi-step.css** file and add the following styles:
+
+```css
+/* stylelint-disable selector-class-pattern */
+
+.checkout__wrapper {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.checkout__banners {
+  padding-top: 1.5rem;
+}
+
+.checkout__content {
+  display: grid;
+  align-items: start;
+  grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+  gap: var(--spacing-big);
+  padding-top: 1.5rem;
+}
+
+.checkout__content--empty {
+  display: none;
+}
+
+.checkout__empty-cart {
+  padding-top: 1.5rem;
+}
+
+.checkout__main {
+  display: grid;
+  grid-column: 1 / span 7;
+  row-gap: var(--spacing-xbig);
+}
+
+.checkout__aside {
+  display: grid;
+  grid-column: 9 / span 4;
+  row-gap: var(--spacing-xbig);
+}
+
+.checkout__shipping {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-big);
+  padding: 0;
+}
+
+.checkout__shipping:has(> div:empty:not(.checkout__continue-to-delivery)) {
+  gap: 0;
+  padding-top: var(--spacing-small);
+  padding-bottom: var(--spacing-small);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+  border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+.checkout__delivery {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-big);
+  padding: 0;
+}
+
+.checkout__delivery:has(> div:empty:not(.checkout__continue-to-payment)) {
+  gap: 0;
+  padding-top: var(--spacing-small);
+  padding-bottom: var(--spacing-small);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+  border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+.checkout__payment {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-big);
+  padding: 0;
+}
+
+.checkout__payment:has(> div:empty) {
+  gap: 0;
+  padding-top: var(--spacing-small);
+  padding-bottom: var(--spacing-small);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+  border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+/* temporary fix to hide the default cart heading */
+[data-testid='default-cart-heading'] {
+  display: none;
+}
+
+/* Responsive adjustments */
+@media only screen and (width <= 768px) {
+  .checkout__wrapper {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .checkout__content {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-big) 0;
+  }
+
+  .checkout__main,
+  .checkout__aside {
+    grid-column: auto;
+  }
+
+  .checkout__aside {
+    order: -1;
+  }
+}
+```
+
+### Step 6: Empty cart
+
+First we'll create two utility functions that will allow us to display or remove the **EmptyCart** container when needed:
+
+```js
+let emptyCart;
+const displayEmptyCart = async () => {
+  if (emptyCart) return;
+
+  heading.setProps((prev) => ({
+    ...prev,
+    title: 'Empty Cart',
+  }));
+
+  emptyCart = await CartProvider.render(EmptyCart, {
+    routeCTA: () => '/',
+  })($emptyCart);
+
+  $content.classList.add('checkout__content--empty');
+};
+
+const removeEmptyCart = () => {
+  if (!emptyCart) return;
+
+  emptyCart.remove();
+  emptyCart = null;
+  $emptyCart.innerHTML = '';
+
+  heading.setProps((prev) => ({
+    ...prev,
+    title: 'Guest Checkout',
+  }));
+
+  $content.classList.remove('checkout__content--empty');
+};
+```
+
+**Note:** See how we are also changing the heading title and adding a new class to the content wrapper so that we are able to hide it.
+
+Next, we have to start listening for the **checkout/initialized** and **checkout/updated** events so that we are able to identify when to display the empty cart. Add the following declarations at the end of the **decorate** function.
+
+```js
+events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
+events.on('checkout/updated', handleCheckoutUpdated);
+```
+
+Finally, we'll add the missing handlers for the previous events:
+
+```js
+async function handleCheckoutInitialized(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+}
+
+async function handleCheckoutUpdated(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+  removeEmptyCart();
+}
+```
+
+At this point, if you access the checkout page without a cart, you should see the **EmptyCart** container displayed.
+
+### Step 7: Shipping Address
+
+You've probably noticed that even after initializing the checkout the shipping form is still loading. To solve this issue, we are going to create a new utility method that we are going to call **continueToShipping**, that is going to remove the skeleton and render the shipping form when the checkout is initialized:
+
+```js
+let shippingForm;
+
+const continueToShipping = async (initialData = null) => {
+  if (shippingForm) return;
+
+  // cleanup
+  shippingFormSkeleton.remove();
+  $shippingForm.innerHTML = '';
+
+  shippingForm = await AccountProvider.render(AddressForm, {
+    addressesFormTitle: 'Shipping address',
+    className: 'checkout-shipping-form__address-form',
+    formName: SHIPPING_FORM_NAME,
+    hideActionFormButtons: true,
+    inputsDefaultValueSet: initialData ?? {
+      countryCode: storeConfig.defaultCountry,
+    },
+    isOpen: true,
+    onChange: debounce((values) => {
+      setAddressOnCart(values, checkoutApi.setShippingAddress);
+    }, DEBOUNCE_TIME),
+    showBillingCheckBox: false,
+    showShippingCheckBox: false,
+  })($shippingForm);
+};
+```
+
+Next, we need to update the handlers to use it:
+
+```diff
+async function handleCheckoutInitialized(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+
++  // continue to shipping
++  const cartShippingAddress = getCartAddress(data, 'shipping');
++  await continueToShipping(cartShippingAddress);
+}
+
+async function handleCheckoutUpdated(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+
+  removeEmptyCart();
+
++  // continue to shipping
++  const cartShippingAddress = getCartAddress(data, 'shipping');
++  await continueToShipping(cartShippingAddress);
+}
+```
+
+**Note:** We pass the data received in the event to ensure the form is properly initialized with the selected shipping address from the cart if necessary.
+
+### Step 8: Delivery
+
+If we go back to [step 4](#step-4-render-the-initial-containers), more precisely to the part where we rendered the **CONTINUE TO SHIPPING METHOD** button, we should see that we added a call to a non existing **continueToDelivery** method and that the button is disabled by default.
+
+First we are going to update the **handleCheckoutUpdated** handler to enable the button when the received data contains a selected shipping address:
+
+```diff
+async function handleCheckoutUpdated(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+
+  removeEmptyCart();
+
+  // continue to shipping
+  const cartShippingAddress = getCartAddress(data, 'shipping');
+  await continueToShipping(cartShippingAddress);
+
++  if (!cartShippingAddress) return;
++
++  continueToDeliveryBtn.setProps((prev) => ({
++    ...prev,
++    disabled: false,
++  }));
+}
+```
+
+Next, we are going to update the logic inside **handleCheckoutInitialized** handler to automatically call the **continueToDelivery** method if the cart already contains the necessary data:
+
+```diff
+async function handleCheckoutInitialized(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+
+  // continue to shipping
+  const cartShippingAddress = getCartAddress(data, 'shipping');
+  await continueToShipping(cartShippingAddress);
+
++  // continue to delivery
++  if (!cartShippingAddress) return;
++  await continueToDelivery();
+}
+```
+
+Finally, we are going create the **continueToDelivery** function that renders all the containers that are relevant to the delivery step:
+
+```js
+let deliveryMethods;
+let continueToPaymentBtn;
+
+const continueToDelivery = async () => {
+  if (deliveryMethods) return;
+
+  deliveryMethods = await CheckoutProvider.render(ShippingMethods, {
+    hideOnVirtualCart: true,
+  })($deliveryMethods);
+
+  orderSummary.setProps((prev) => ({
+    ...prev,
+    slots: {
+      EstimateShipping: (esCtx) => {
+        const estimateShippingForm = document.createElement('div');
+        CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+        esCtx.appendChild(estimateShippingForm);
+      },
+    },
+  }));
+
+  continueToDeliveryBtn.remove();
+  $continueToDeliveryBtn.remove();
+
+  continueToPaymentBtn = await UI.render(Button, {
+    children: 'CONTINUE TO PAYMENT INFORMATION',
+    disabled: true,
+    onClick: async () => {
+      await continueToPayment();
+    },
+  })($continueToPaymentBtn);
+};
+```
+
+### Step 9: Payment
+
+Similarly to what we did in the [step 8](#step-8-delivery), we now need to add the logic to enable the **CONTINUE TO PAYMENT INFORMATION** button and to implement the missing method **continueToPayment**.
+
+Same as we did before, we are going to start by updating the handlers:
+
+```diff
+async function handleCheckoutInitialized(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+
+  // continue to shipping
+  const cartShippingAddress = getCartAddress(data, 'shipping');
+  await continueToShipping(cartShippingAddress);
+
+  // continue to delivery
+  if (!cartShippingAddress) return;
+  await continueToDelivery();
+
++  // continue to payment
++  const deliveryMethod = getCartDeliveryMethod(data);
++  if (!deliveryMethod) return;
++  await continueToPayment();
+}
+```
+
+```diff
+async function handleCheckoutUpdated(data) {
+  if (isEmptyCart(data)) {
+    await displayEmptyCart();
+    return;
+  }
+
+  removeEmptyCart();
+
+  // continue to shipping
+  const cartShippingAddress = getCartAddress(data, 'shipping');
+  await continueToShipping(cartShippingAddress);
+
+  if (!cartShippingAddress) return;
+
+  continueToDeliveryBtn.setProps((prev) => ({
+    ...prev,
+    disabled: false,
+  }));
+
++  const deliveryMethod = getCartDeliveryMethod(data);
++  if (!deliveryMethod) return;
++
++  continueToPaymentBtn.setProps((prev) => ({
++    ...prev,
++    disabled: false,
++  }));
+}
+```
+
+Next, we are going create the **continueToPayment** function that renders all the containers that are relevant to the payment step:
+
+```js
+let billToShipping;
+let billingForm;
+let paymentMethods;
+let placeOrder;
+
+const continueToPayment = async () => {
+  if (!billToShipping) {
+    billToShipping = await CheckoutProvider.render(BillToShippingAddress, {
+      hideOnVirtualCart: true,
+      onChange: (checked) => {
+        $billingForm.style.display = checked ? 'none' : 'block';
+      },
+    })($billToShipping);
+  }
+
+  if (!billingForm) {
+    billingForm = await AccountProvider.render(AddressForm, {
+      addressesFormTitle: 'Billing address',
+      className: 'checkout-billing-form__address-form',
+      formName: BILLING_FORM_NAME,
+      hideActionFormButtons: true,
+      isOpen: true,
+      onChange: debounce((values) => {
+        setAddressOnCart(values, checkoutApi.setBillingAddress);
+      }, DEBOUNCE_TIME),
+      showBillingCheckBox: false,
+      showShippingCheckBox: false,
+    })($billingForm);
+  }
+
+  if (!paymentMethods) {
+    paymentMethods = await CheckoutProvider.render(PaymentMethods)($paymentMethods);
+  }
+
+  if (!placeOrder) {
+    placeOrder = await CheckoutProvider.render(PlaceOrder)($placeOrder);
+  }
+
+  continueToPaymentBtn.remove();
+  $continueToPaymentBtn.remove();
+};
+```
+
+At this point, we should have a fully functional multi-step checkout, but we still have some work to do...
+
+### Step 10: Order confirmation
+
+The last step to complete our checkout is to create our order confirmation page. To make things easy, we are going to reuse the code from the **commerce-checkout** block.
+
+First we are going to copy the **displayOrderConfirmation** function.
+
+Then, we are going to copy the **handleCheckoutOrder** handler.
+
+And finally, we are going to register the **checkout/order** event listener:
+
+```diff
+  events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
++ events.on('checkout/order', handleCheckoutOrder);
+  events.on('checkout/updated', handleCheckoutUpdated);
+```
+
+## Conclusion
+
+By following these steps, you have successfully implemented a multi-step checkout block using some of the available Storefront Dropin containers.

--- a/blocks/commerce-checkout-multi-step/commerce-checkout-multi-step.css
+++ b/blocks/commerce-checkout-multi-step/commerce-checkout-multi-step.css
@@ -1,0 +1,110 @@
+/* stylelint-disable selector-class-pattern */
+
+.checkout__wrapper {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.checkout__banners {
+  padding-top: 1.5rem;
+}
+
+.checkout__content {
+  display: grid;
+  align-items: start;
+  grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+  gap: var(--spacing-big);
+  padding-top: 1.5rem;
+}
+
+.checkout__content--empty {
+  display: none;
+}
+
+.checkout__empty-cart {
+  padding-top: 1.5rem;
+}
+
+.checkout__main {
+  display: grid;
+  grid-column: 1 / span 7;
+  row-gap: var(--spacing-xbig);
+}
+
+.checkout__aside {
+  display: grid;
+  grid-column: 9 / span 4;
+  row-gap: var(--spacing-xbig);
+}
+
+.checkout__shipping {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-big);
+  padding: 0;
+}
+
+.checkout__shipping:has(> div:empty:not(.checkout__continue-to-delivery)) {
+  gap: 0;
+  padding-top: var(--spacing-small);
+  padding-bottom: var(--spacing-small);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+  border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+.checkout__delivery {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-big);
+  padding: 0;
+}
+
+.checkout__delivery:has(> div:empty:not(.checkout__continue-to-payment)) {
+  gap: 0;
+  padding-top: var(--spacing-small);
+  padding-bottom: var(--spacing-small);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+  border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+.checkout__payment {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-big);
+  padding: 0;
+}
+
+.checkout__payment:has(> div:empty) {
+  gap: 0;
+  padding-top: var(--spacing-small);
+  padding-bottom: var(--spacing-small);
+  border-top: var(--shape-border-width-3) solid var(--color-neutral-400);
+  border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
+}
+
+/* temporary fix to hide the default cart heading */
+[data-testid='default-cart-heading'] {
+  display: none;
+}
+
+/* Responsive adjustments */
+@media only screen and (width <= 768px) {
+  .checkout__wrapper {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .checkout__content {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-big) 0;
+  }
+
+  .checkout__main,
+  .checkout__aside {
+    grid-column: auto;
+  }
+
+  .checkout__aside {
+    order: -1;
+  }
+}

--- a/blocks/commerce-checkout-multi-step/commerce-checkout-multi-step.js
+++ b/blocks/commerce-checkout-multi-step/commerce-checkout-multi-step.js
@@ -1,0 +1,557 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-shadow */
+/* eslint-disable no-use-before-define */
+/* eslint-disable prefer-const */
+
+// Dropin Tools
+import { events } from '@dropins/tools/event-bus.js';
+import { initializers } from '@dropins/tools/initializer.js';
+
+// Dropin Components
+import { Button, Header, provider as UI } from '@dropins/tools/components.js';
+
+// Auth Dropin
+import SignUp from '@dropins/storefront-auth/containers/SignUp.js';
+import { render as AuthProvider } from '@dropins/storefront-auth/render.js';
+
+// Account Dropin
+import AddressForm from '@dropins/storefront-account/containers/AddressForm.js';
+import { render as AccountProvider } from '@dropins/storefront-account/render.js';
+
+// Cart Dropin
+import { CartSummaryList } from '@dropins/storefront-cart/containers/CartSummaryList.js';
+import EmptyCart from '@dropins/storefront-cart/containers/EmptyCart.js';
+import { OrderSummary } from '@dropins/storefront-cart/containers/OrderSummary.js';
+import { render as CartProvider } from '@dropins/storefront-cart/render.js';
+
+// Checkout Dropin
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import BillToShippingAddress from '@dropins/storefront-checkout/containers/BillToShippingAddress.js';
+import EstimateShipping from '@dropins/storefront-checkout/containers/EstimateShipping.js';
+import LoginForm from '@dropins/storefront-checkout/containers/LoginForm.js';
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import PlaceOrder from '@dropins/storefront-checkout/containers/PlaceOrder.js';
+import ShippingMethods from '@dropins/storefront-checkout/containers/ShippingMethods.js';
+
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+// Order Dropin Modules
+import * as orderApi from '@dropins/storefront-order/api.js';
+import CustomerDetails from '@dropins/storefront-order/containers/CustomerDetails.js';
+import OrderCostSummary from '@dropins/storefront-order/containers/OrderCostSummary.js';
+import OrderHeader from '@dropins/storefront-order/containers/OrderHeader.js';
+import OrderProductList from '@dropins/storefront-order/containers/OrderProductList.js';
+import OrderStatus from '@dropins/storefront-order/containers/OrderStatus.js';
+import ShippingStatus from '@dropins/storefront-order/containers/ShippingStatus.js';
+import { render as OrderProvider } from '@dropins/storefront-order/render.js';
+import { getUserTokenCookie } from '../../scripts/initializers/index.js';
+
+// Block-level
+import {
+  getCartAddress,
+  getCartDeliveryMethod,
+  setAddressOnCart,
+} from '../../scripts/checkout.js';
+import createModal from '../modal/modal.js';
+
+export default async function decorate(block) {
+  // Initializers
+  import('../../scripts/initializers/auth.js');
+  import('../../scripts/initializers/checkout.js');
+
+  const DEBOUNCE_TIME = 1000;
+  const LOGIN_FORM_NAME = 'login-form';
+  const SHIPPING_FORM_NAME = 'selectedShippingAddress';
+  const BILLING_FORM_NAME = 'selectedBillingAddress';
+  const SHIPPING_ADDRESS_DATA_KEY = `${SHIPPING_FORM_NAME}_addressData`;
+  const BILLING_ADDRESS_DATA_KEY = `${BILLING_FORM_NAME}_addressData`;
+
+  // Define the Layout for the Checkout
+  const fragment = document.createRange().createContextualFragment(`
+    <div class="checkout__wrapper">
+      <div class="checkout__heading"></div>
+      <div class="checkout__empty-cart"></div>
+      <div class="checkout__content">
+        <div class="checkout__main">
+          <div class="checkout__shipping">
+            <div class="checkout__shipping-title"></div>
+            <div class="checkout__login"></div>
+            <div class="checkout__shipping-form"></div>
+            <div class="checkout__continue-to-delivery"></div>
+          </div>
+          <div class="checkout__delivery">
+            <div class="checkout__delivery-title"></div>
+            <div class="checkout__delivery-methods"></div>
+            <div class="checkout__continue-to-payment"></div>
+          </div>
+          <div class="checkout__payment">
+            <div class="checkout__payment-title"></div>
+            <div class="checkout__bill-to-shipping"></div>
+            <div class="checkout__billing-form"></div>
+            <div class="checkout__payment-methods"></div>
+            <div class="checkout__place-order"></div>
+          </div>
+        </div>
+        <div class="checkout__aside">
+          <div class="checkout__order-summary"></div>
+          <div class="checkout__cart-summary"></div>
+        </div>
+      </div>
+    </div>
+  `);
+
+  const $heading = fragment.querySelector('.checkout__heading');
+  const $emptyCart = fragment.querySelector('.checkout__empty-cart');
+  const $content = fragment.querySelector('.checkout__content');
+
+  const $orderSummary = fragment.querySelector('.checkout__order-summary');
+  const $cartSummary = fragment.querySelector('.checkout__cart-summary');
+
+  const $shippingTitle = fragment.querySelector('.checkout__shipping-title');
+  const $login = fragment.querySelector('.checkout__login');
+  const $shippingForm = fragment.querySelector('.checkout__shipping-form');
+  const $continueToDeliveryBtn = fragment.querySelector(
+    '.checkout__continue-to-delivery',
+  );
+
+  const $deliveryTitle = fragment.querySelector('.checkout__delivery-title');
+  const $deliveryMethods = fragment.querySelector(
+    '.checkout__delivery-methods',
+  );
+  const $continueToPaymentBtn = fragment.querySelector(
+    '.checkout__continue-to-payment',
+  );
+
+  const $paymentTitle = fragment.querySelector('.checkout__payment-title');
+  const $billToShipping = fragment.querySelector('.checkout__bill-to-shipping');
+  const $billingForm = fragment.querySelector('.checkout__billing-form');
+  const $paymentMethods = fragment.querySelector('.checkout__payment-methods');
+  const $placeOrder = fragment.querySelector('.checkout__place-order');
+
+  block.replaceChildren(fragment);
+
+  // Render the initial containers
+  const [
+    heading,
+    _shippingInfoHeading,
+    __shippingMethodHeading,
+    _paymentHeading,
+    _loginForm,
+    shippingFormSkeleton,
+    continueToDeliveryBtn,
+    orderSummary,
+    _cartSummary,
+  ] = await Promise.all([
+    UI.render(Header, {
+      title: 'Guest Checkout',
+      size: 'large',
+      divider: false,
+    })($heading),
+
+    UI.render(Header, {
+      title: '1. SHIPPING INFORMATION',
+      size: 'medium',
+      divider: false,
+    })($shippingTitle),
+
+    UI.render(Header, {
+      title: '2. SHIPPING METHOD',
+      size: 'medium',
+      divider: false,
+    })($deliveryTitle),
+
+    UI.render(Header, {
+      title: '3. PAYMENT INFORMATION',
+      size: 'medium',
+      divider: false,
+    })($paymentTitle),
+
+    // render the initial containers
+    CheckoutProvider.render(LoginForm, {
+      name: LOGIN_FORM_NAME,
+    })($login),
+
+    AccountProvider.render(AddressForm, {
+      isOpen: true,
+      showFormLoader: true,
+    })($shippingForm),
+
+    UI.render(Button, {
+      children: 'CONTINUE TO SHIPPING METHOD',
+      disabled: true,
+      onClick: async () => {
+        await continueToDelivery();
+      },
+    })($continueToDeliveryBtn),
+
+    CartProvider.render(OrderSummary)($orderSummary),
+
+    CartProvider.render(CartSummaryList, {
+      variant: 'secondary',
+      slots: {
+        Heading: (headingCtx) => {
+          const title = 'Your Cart ({count})';
+
+          const cartSummaryListHeading = document.createElement('div');
+          cartSummaryListHeading.classList.add('cart-summary-list__heading');
+
+          const cartSummaryListHeadingText = document.createElement('div');
+          cartSummaryListHeadingText.classList.add(
+            'cart-summary-list__heading-text',
+          );
+
+          cartSummaryListHeadingText.innerText = title.replace(
+            '({count})',
+            headingCtx.count ? `(${headingCtx.count})` : '',
+          );
+          const editCartLink = document.createElement('a');
+          editCartLink.classList.add('cart-summary-list__edit');
+          editCartLink.href = '/cart';
+          editCartLink.rel = 'noreferrer';
+          editCartLink.innerText = 'Edit';
+
+          cartSummaryListHeading.appendChild(cartSummaryListHeadingText);
+          cartSummaryListHeading.appendChild(editCartLink);
+          headingCtx.appendChild(cartSummaryListHeading);
+
+          headingCtx.onChange((nextHeadingCtx) => {
+            cartSummaryListHeadingText.innerText = title.replace(
+              '({count})',
+              nextHeadingCtx.count ? `(${nextHeadingCtx.count})` : '',
+            );
+          });
+        },
+      },
+    })($cartSummary),
+  ]);
+
+  // Dynamic containers and components
+
+  let modal;
+
+  const showModal = async (content) => {
+    modal = await createModal([content]);
+    modal.showModal();
+  };
+
+  let emptyCart;
+
+  const displayEmptyCart = async () => {
+    if (emptyCart) return;
+
+    heading.setProps((prev) => ({
+      ...prev,
+      title: 'Empty Cart',
+    }));
+
+    emptyCart = await CartProvider.render(EmptyCart, {
+      routeCTA: () => '/',
+    })($emptyCart);
+
+    $content.classList.add('checkout__content--empty');
+  };
+
+  const removeEmptyCart = () => {
+    if (!emptyCart) return;
+
+    emptyCart.remove();
+    emptyCart = null;
+    $emptyCart.innerHTML = '';
+
+    heading.setProps((prev) => ({
+      ...prev,
+      title: 'Guest Checkout',
+    }));
+
+    $content.classList.remove('checkout__content--empty');
+  };
+
+  let shippingForm;
+
+  const continueToShipping = async (initialData = null) => {
+    if (shippingForm) return;
+
+    // cleanup
+    shippingFormSkeleton.remove();
+    $shippingForm.innerHTML = '';
+
+    const storeConfig = checkoutApi.getStoreConfigCache();
+
+    shippingForm = await AccountProvider.render(AddressForm, {
+      addressesFormTitle: 'Shipping address',
+      className: 'checkout-shipping-form__address-form',
+      formName: SHIPPING_FORM_NAME,
+      hideActionFormButtons: true,
+      inputsDefaultValueSet: initialData ?? {
+        countryCode: storeConfig.defaultCountry,
+      },
+      isOpen: true,
+      onChange: setAddressOnCart({
+        api: checkoutApi.setShippingAddress,
+        debounceMs: DEBOUNCE_TIME,
+        placeOrderBtn: placeOrder,
+      }),
+      showBillingCheckBox: false,
+      showShippingCheckBox: false,
+    })($shippingForm);
+  };
+
+  let deliveryMethods;
+  let continueToPaymentBtn;
+
+  const continueToDelivery = async () => {
+    if (deliveryMethods) return;
+
+    deliveryMethods = await CheckoutProvider.render(ShippingMethods, {
+      hideOnVirtualCart: true,
+    })($deliveryMethods);
+
+    orderSummary.setProps((prev) => ({
+      ...prev,
+      slots: {
+        EstimateShipping: (esCtx) => {
+          const estimateShippingForm = document.createElement('div');
+          CheckoutProvider.render(EstimateShipping)(estimateShippingForm);
+          esCtx.appendChild(estimateShippingForm);
+        },
+      },
+    }));
+
+    continueToDeliveryBtn.remove();
+    $continueToDeliveryBtn.remove();
+
+    continueToPaymentBtn = await UI.render(Button, {
+      children: 'CONTINUE TO PAYMENT INFORMATION',
+      disabled: true,
+      onClick: async () => {
+        await continueToPayment();
+      },
+    })($continueToPaymentBtn);
+  };
+
+  let billToShipping;
+  let billingForm;
+  let paymentMethods;
+  let placeOrder;
+
+  const continueToPayment = async () => {
+    if (!billToShipping) {
+      billToShipping = await CheckoutProvider.render(BillToShippingAddress, {
+        hideOnVirtualCart: true,
+        onChange: (checked) => {
+          $billingForm.style.display = checked ? 'none' : 'block';
+        },
+      })($billToShipping);
+    }
+
+    if (!billingForm) {
+      billingForm = await AccountProvider.render(AddressForm, {
+        addressesFormTitle: 'Billing address',
+        className: 'checkout-billing-form__address-form',
+        formName: BILLING_FORM_NAME,
+        hideActionFormButtons: true,
+        isOpen: true,
+        onChange: setAddressOnCart({
+          api: checkoutApi.setBillingAddress,
+          debounceMs: DEBOUNCE_TIME,
+          placeOrderBtn: placeOrder,
+        }),
+        showBillingCheckBox: false,
+        showShippingCheckBox: false,
+      })($billingForm);
+    }
+
+    if (!paymentMethods) {
+      paymentMethods = await CheckoutProvider.render(PaymentMethods)($paymentMethods);
+    }
+
+    if (!placeOrder) {
+      placeOrder = await CheckoutProvider.render(PlaceOrder, {
+        handlePlaceOrder: async ({ cartId }) => {
+          orderApi.placeOrder(cartId).catch(console.error);
+        },
+      })($placeOrder);
+    }
+
+    continueToPaymentBtn.remove();
+    $continueToPaymentBtn.remove();
+  };
+
+  const displayOrderConfirmation = async (orderData) => {
+    // Define the Layout for the Order Confirmation
+    const orderConfirmationFragment = document.createRange()
+      .createContextualFragment(`
+      <div class="order-confirmation">
+        <div class="order-confirmation__main">
+          <div class="order-confirmation__block order-confirmation__header"></div>
+          <div class="order-confirmation__block order-confirmation__order-status"></div>
+          <div class="order-confirmation__block order-confirmation__shipping-status"></div>
+          <div class="order-confirmation__block order-confirmation__customer-details"></div>
+        </div>
+        <div class="order-confirmation__aside">
+          <div class="order-confirmation__block order-confirmation__order-cost-summary"></div>
+          <div class="order-confirmation__block order-confirmation__order-product-list"></div>
+          <div class="order-confirmation__block order-confirmation__footer"></div>
+        </div>
+      </div>
+  `);
+
+    // Order confirmation elements
+    const $orderConfirmationHeader = orderConfirmationFragment.querySelector(
+      '.order-confirmation__header',
+    );
+    const $orderStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-status',
+    );
+    const $shippingStatus = orderConfirmationFragment.querySelector(
+      '.order-confirmation__shipping-status',
+    );
+    const $customerDetails = orderConfirmationFragment.querySelector(
+      '.order-confirmation__customer-details',
+    );
+    const $orderCostSummary = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-cost-summary',
+    );
+    const $orderProductList = orderConfirmationFragment.querySelector(
+      '.order-confirmation__order-product-list',
+    );
+    const $orderConfirmationFooter = orderConfirmationFragment.querySelector(
+      '.order-confirmation__footer',
+    );
+
+    await initializers.mountImmediately(orderApi.initialize, { orderData });
+
+    block.replaceChildren(orderConfirmationFragment);
+
+    const onSignUpClick = async ({ inputsDefaultValueSet, addressesData }) => {
+      const signUpForm = document.createElement('div');
+      AuthProvider.render(SignUp, {
+        routeSignIn: () => '/customer/login',
+        routeRedirectOnEmailConfirmationClose: () => '/customer/account',
+        inputsDefaultValueSet,
+        addressesData,
+      })(signUpForm);
+
+      showModal(signUpForm);
+    };
+
+    OrderProvider.render(OrderHeader, {
+      orderData,
+      onSignUpClick,
+    })($orderConfirmationHeader);
+
+    OrderProvider.render(OrderStatus, { slots: { OrderActions: () => null } })(
+      $orderStatus,
+    );
+    OrderProvider.render(ShippingStatus)($shippingStatus);
+    OrderProvider.render(CustomerDetails)($customerDetails);
+    OrderProvider.render(OrderCostSummary)($orderCostSummary);
+    OrderProvider.render(OrderProductList)($orderProductList);
+
+    $orderConfirmationFooter.innerHTML = `
+      <div class="order-confirmation-footer__continue-button"></div>
+      <div class="order-confirmation-footer__contact-support">
+        <p>
+          Need help?
+          <a
+            href="/support"
+            rel="noreferrer"
+            class="order-confirmation-footer__contact-support-link"
+            data-testid="order-confirmation-footer__contact-support-link"
+          >
+            Contact us
+          </a>
+        </p>
+      </div>
+    `;
+
+    const $orderConfirmationFooterContinueBtn = $orderConfirmationFooter.querySelector(
+      '.order-confirmation-footer__continue-button',
+    );
+
+    UI.render(Button, {
+      children: 'Continue shopping',
+      'data-testid': 'order-confirmation-footer__continue-button',
+      className: 'order-confirmation-footer__continue-button',
+      size: 'medium',
+      variant: 'primary',
+      type: 'submit',
+      href: '/',
+    })($orderConfirmationFooterContinueBtn);
+  };
+
+  // Define checkout event handlers and shared utilities
+  const isEmptyCart = (data) => data === null || data.isEmpty;
+
+  async function handleCheckoutInitialized(data) {
+    if (isEmptyCart(data)) {
+      await displayEmptyCart();
+      return;
+    }
+
+    // continue to shipping
+    const cartShippingAddress = getCartAddress(data, 'shipping');
+    await continueToShipping(cartShippingAddress);
+
+    // continue to delivery
+    if (!cartShippingAddress) return;
+    await continueToDelivery();
+
+    // continue to payment
+    const deliveryMethod = getCartDeliveryMethod(data);
+    if (!deliveryMethod) return;
+    await continueToPayment();
+  }
+
+  async function handleCheckoutUpdated(data) {
+    if (isEmptyCart(data)) {
+      await displayEmptyCart();
+      return;
+    }
+
+    removeEmptyCart();
+
+    // continue to shipping
+    const cartShippingAddress = getCartAddress(data, 'shipping');
+    await continueToShipping(cartShippingAddress);
+
+    if (!cartShippingAddress) return;
+
+    continueToDeliveryBtn.setProps((prev) => ({
+      ...prev,
+      disabled: false,
+    }));
+
+    const deliveryMethod = getCartDeliveryMethod(data);
+    if (!deliveryMethod) return;
+
+    continueToPaymentBtn.setProps((prev) => ({
+      ...prev,
+      disabled: false,
+    }));
+  }
+
+  async function handleCheckoutOrder(orderData) {
+    // clear address form data
+    sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
+    sessionStorage.removeItem(BILLING_ADDRESS_DATA_KEY);
+
+    const token = getUserTokenCookie();
+    const orderRef = token ? orderData.number : orderData.token;
+    const encodedOrderRef = encodeURIComponent(orderRef);
+
+    window.history.pushState(
+      {},
+      '',
+      `/order-details?orderRef=${encodedOrderRef}`,
+    );
+
+    // TODO cleanup checkout containers
+    await displayOrderConfirmation(orderData);
+  }
+
+  events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
+  events.on('checkout/order', handleCheckoutOrder);
+  events.on('checkout/updated', handleCheckoutUpdated);
+}


### PR DESCRIPTION
Move the existing checkout demo blocks from the Checkout dropin to the Boilerplate within the demos branch. This migration will maintain their functionality and ensure reliability, keeping the blocks up-to-date and readily available for further development and testing in the demos branch.

Test URLs:
- Before: https://demos--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://USF-1871--aem-boilerplate-commerce--hlxsites.aem.live/
