### PR TITLE
dedupe performCatalogServiceQuery

### DIFF
--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -32,21 +32,35 @@ export async function commerceEndpointWithQueryParams() {
 
 /* Common functionality */
 
-export async function performCatalogServiceQuery(query, variables) {
+export async function performCatalogServiceQuery(query, variables, method = 'GET') {
   const headers = {
     'Content-Type': 'application/json',
     'x-api-key': await getConfigValue('commerce-x-api-key'),
   };
 
   const apiCall = await commerceEndpointWithQueryParams();
-  apiCall.searchParams.append('query', query.replace(/(?:\r\n|\r|\n|\t|[\s]{4})/g, ' ')
-    .replace(/\s\s+/g, ' '));
-  apiCall.searchParams.append('variables', variables ? JSON.stringify(variables) : null);
+  let response;
+  if (method === 'GET') {
+    apiCall.searchParams.append('query', query.replace(/(?:\r\n|\r|\n|\t|[\s]{4})/g, ' ')
+      .replace(/\s\s+/g, ' '));
+    apiCall.searchParams.append('variables', variables ? JSON.stringify(variables) : null);
 
-  const response = await fetch(apiCall, {
-    method: 'GET',
-    headers,
-  });
+    response = await fetch(apiCall, {
+      method: 'GET',
+      headers,
+    });
+  } else if (method === 'POST') {
+    response = await fetch(apiCall, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: query.replace(/(?:\r\n|\r|\n|\t|[\s]{4})/g, ' ').replace(/\s\s+/g, ' '),
+        variables,
+      }),
+    });
+  } else {
+    throw new Error(`Unsupported method: ${method}`);
+  }
 
   if (!response.ok) {
     return null;

--- a/tools/picker/src/index.js
+++ b/tools/picker/src/index.js
@@ -4,6 +4,7 @@ import * as ReactDOM from 'react-dom';
 import Picker from './picker.js';
 import getCategoriesInCategory from './queries/categories.graphql.js';
 import getProductsInCategory from './queries/products.graphql.js';
+import { performCatalogServiceQuery } from '../../../scripts/commerce.js';
 
 import './styles.css';
 
@@ -11,7 +12,7 @@ import './styles.css';
  * Object containing all configuration files that should be exposed in the picker.
  */
 const configFiles = {
-    'prod': 'https://main--aem-boilerplate-commerce--hlxsites.hlx.live/configs.json?sheet=prod',
+    'prod': 'https://main--aem-boilerplate-commerce--hlxsites.hlx.live/configs.json',
     'stage': 'https://main--aem-boilerplate-commerce--hlxsites.hlx.live/configs-stage.json',
     'dev': 'https://main--aem-boilerplate-commerce--hlxsites.hlx.live/configs-dev.json',
 }
@@ -22,7 +23,7 @@ const defaultConfig = 'prod';
 
 /**
  * List of blocks to be available in the picker.
- * 
+ *
  * Format: Object with key -> block mapping. Each block is defined by the following properties:
  *   key: Unique key, must be same as the key in the object
  *   name: Displayed name of the block
@@ -113,37 +114,6 @@ const blocks = {
         'type': 'folder',
     },
 };
-
-async function performCatalogServiceQuery(query, config, variables) {
-    const headers = {
-        'x-api-key': config['commerce-x-api-key'],
-        'Content-Type': 'application/json',
-    };
-
-    // Set Query Parameters so they can be appended to the endpoint
-    const apiCall = new URL(config['commerce-endpoint']);
-    apiCall.searchParams.append("Magento-Environment-Id", config['commerce-environment-id']);
-    apiCall.searchParams.append("Magento-Website-Code", config['commerce-website-code']);
-    apiCall.searchParams.append("Magento-Store-View-Code", config['commerce-store-view-code']);
-    apiCall.searchParams.append("Magento-Store-Code", config['commerce-store-code']);
-    apiCall.searchParams.append("Magento-Customer-Group", config['commerce-customer-group']);
-    apiCall.searchParams.append('query', query.replace(/(?:\r\n|\r|\n|\t|[\s]{4})/g, ' ')
-        .replace(/\s\s+/g, ' '));
-    apiCall.searchParams.append('variables', variables ? JSON.stringify(variables) : null);
-
-    const response = await fetch(apiCall, {
-        method: 'GET',
-        headers,
-    });
-
-    if (!response.ok) {
-        return null;
-    }
-
-    const queryResponse = await response.json();
-
-    return queryResponse.data;
-}
 
 const getItems = async (folderKey, page = 1, config) => {
     let newItems = {};


### PR DESCRIPTION
The `performCatalogServiceQuery` was implemented 3 times. We only need one.
The main difference is that in the `picker` tool, `GET` is used, and in the `pdp-metadata` tool, `POST` is used.

# Validation

The Picker and PDP Metadata tool should function as expected. Notably a "big" change is that now the config for the metadata tool is now fetched using `getConfigValue` calls rather than the [logic in pdp-metadata.js](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/tools/pdp-metadata/pdp-metadata.js#L187-L190)

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://chore-dedupe-csquery-fn--aem-boilerplate-commerce--hlxsites.aem.live/
