### PR TITLE
LYNX-736: Displaying only one dynamic block for each specified type

### DIFF
--- a/blocks/dynamic-block/dynamic-block.css
+++ b/blocks/dynamic-block/dynamic-block.css
@@ -1,3 +1,0 @@
-.dynamic-block > div:not(:last-child) {
-    display: none;
-}

--- a/blocks/targeted-block/targeted-block.css
+++ b/blocks/targeted-block/targeted-block.css
@@ -1,0 +1,3 @@
+.targeted-block > div:not(:last-child) {
+    display: none;
+}

--- a/blocks/targeted-block/targeted-block.js
+++ b/blocks/targeted-block/targeted-block.js
@@ -86,7 +86,7 @@ const updateTargetedBlocksVisibility = async () => {
     const index = blocks.indexOf(blockConfig);
     const { fragment, type } = blockConfig;
     if (displayedBlockTypes.includes(type)) {
-      return false;
+      return;
     }
 
     const block = document.querySelector(`[data-targeted-block-key="${index}"]`);

--- a/blocks/targeted-block/targeted-block.js
+++ b/blocks/targeted-block/targeted-block.js
@@ -5,6 +5,7 @@ import { readBlockConfig } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 
 const blocks = [];
+const displayedBlockTypes = [];
 
 const getActiveRules = async () => {
   try {
@@ -77,16 +78,21 @@ const conditionsMatched = (activeRules, blockConfig) => {
   return true;
 };
 
-const updateDynamicBlocksVisibility = async () => {
+const updateTargetedBlocksVisibility = async () => {
   const activeRules = await getActiveRules();
 
+  displayedBlockTypes.length = 0;
   blocks.forEach(async (blockConfig) => {
     const index = blocks.indexOf(blockConfig);
-    const { fragment } = blockConfig;
+    const { fragment, type } = blockConfig;
+    if (displayedBlockTypes.includes(type)) {
+      return false;
+    }
 
-    const block = document.querySelector(`[data-dynamic-block-key="${index}"]`);
+    const block = document.querySelector(`[data-targeted-block-key="${index}"]`);
     block.style.display = 'none';
     if (conditionsMatched(activeRules, blockConfig)) {
+      displayedBlockTypes.push(type);
       if (fragment !== undefined) {
         const content = await loadFragment(fragment);
         const blockContent = document.createElement('div');
@@ -102,12 +108,12 @@ const updateDynamicBlocksVisibility = async () => {
 export default function decorate(block) {
   block.style.display = 'none';
   blocks.push(readBlockConfig(block));
-  block.setAttribute('data-dynamic-block-key', blocks.length - 1);
+  block.setAttribute('data-targeted-block-key', blocks.length - 1);
 }
 
 events.on('cart/initialized', () => {
-  updateDynamicBlocksVisibility();
+  updateTargetedBlocksVisibility();
 });
 events.on('cart/updated', () => {
-  updateDynamicBlocksVisibility();
+  updateTargetedBlocksVisibility();
 });


### PR DESCRIPTION
Resolves:
 - [LYNX-736](https://jira.corp.adobe.com/browse/LYNX-736): Displaying only one dynamic block for each specified type
 - [LYNX-737](https://jira.corp.adobe.com/browse/LYNX-737): Rename Dynamic Block to Targeted Block

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://lynx-736--aem-boilerplate-commerce--hlxsites.aem.live/
