### PR TITLE
LYNX-745: Targeted Block not being displayed due to events order issue

### DIFF
--- a/blocks/targeted-block/targeted-block.js
+++ b/blocks/targeted-block/targeted-block.js
@@ -112,7 +112,7 @@ export default function decorate(block) {
 
 events.on('cart/initialized', () => {
   updateTargetedBlocksVisibility();
-});
+}, { eager: true });
 events.on('cart/updated', () => {
   updateTargetedBlocksVisibility();
-});
+}, { eager: true });


### PR DESCRIPTION
Resolves [LYNX-745](https://jira.corp.adobe.com/browse/LYNX-745) Targeted Block not being displayed due to events order issue

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://lynx-745--aem-boilerplate-commerce--hlxsites.aem.live/
