### PR TITLE
ACAP-1017: add AEM Assets script/plugin for image slots

### DIFF
--- a/scripts/assets.js
+++ b/scripts/assets.js
@@ -1,0 +1,158 @@
+import { provider as UI, Image } from '@dropins/tools/components.js';
+import { getConfigValue } from './configs.js';
+
+/** Reports whether AEM Assets are being used as the asset source. */
+export async function isAemAssetsEnabled() {
+  const config = await getConfigValue('commerce-assets-enabled');
+  return config === 'true';
+}
+
+/**
+ * The default optimization parameters used globally, unless overriden (per use case).
+ * @returns {AemAssetsImageOptimizationParams}
+ */
+export function getDefaultAemAssetsOptimizationParams() {
+  // See: https://adobe-aem-assets-delivery-experimental.redoc.ly/
+  return {
+    quality: 80,
+    format: 'webp',
+  };
+}
+
+/**
+ * Generates an optimized URL for AEM Assets.
+ * @param {string} url - The base URL of the asset.
+ * @param {string} alias - The alias (i.e. seoName) of the asset.
+ * @param {AemAssetsImageOptimizationParams} params - The parameters to be applied to the asset.
+ */
+export function generateAemAssetsOptimizedUrl(url, alias, params = {}) {
+  const defaultParams = getDefaultAemAssetsOptimizationParams();
+  const mergedParams = { ...defaultParams, ...params };
+
+  // Destructure the ones that need special handling
+  const {
+    format,
+    crop,
+    size,
+    ...optimizedParams
+  } = mergedParams;
+
+  const searchParams = new URLSearchParams(optimizedParams);
+
+  if (crop) {
+    const [xOrigin, yOrigin] = [crop.xOrigin || 0, crop.yOrigin || 0];
+    const [width, height] = [crop.width || 100, crop.height || 100];
+
+    const cropTransform = `${xOrigin}p,${yOrigin}p,${width}p,${height}p`;
+    searchParams.set('crop', cropTransform);
+  }
+
+  // Both values must be present
+  if (size && size.width && size.height) {
+    searchParams.set('size', `${size.width},${size.height}`);
+  }
+
+  return `${url}/as/${alias}.${format}?${searchParams.toString()}`;
+}
+
+/**
+ * Returns a slot that renders an AEM Assets image
+ * @param {AemAssetsImageSlotConfig} config - The config of the slot.
+ */
+export function makeAemAssetsImageSlot(
+  config,
+) {
+  return (ctx) => {
+    const {
+      wrapper,
+      alias,
+      params,
+      imageProps,
+      src,
+    } = config;
+
+    const container = wrapper ?? document.createElement('div');
+    const imageSrc = generateAemAssetsOptimizedUrl(src, alias, params);
+
+    UI.render(Image, {
+      ...imageProps,
+
+      src: imageSrc,
+      params: {
+        width: params.width,
+        height: params.height,
+
+        // If not null, they will be applied by default.
+        // And they are not compatible with the AEM Assets API.
+        crop: null,
+        fit: null,
+        auto: null,
+      },
+    })(container);
+
+    ctx.replaceWith(container);
+  };
+}
+
+/**
+ * Returns a function that renders an AEM Assets image with the given parameters.
+ * @template T
+ * @param {T} ctx - The context of the slot.
+ * @param {AemAssetsImageSlotConfig} config - The config of the slot.
+ */
+export async function tryRenderAemAssetsImage(ctx, config) {
+  const assetsEnabled = await isAemAssetsEnabled();
+
+  if (!(assetsEnabled)) {
+    // No-op, doesn't do anything.
+    return;
+  }
+
+  makeAemAssetsImageSlot(config)(ctx);
+}
+
+/**
+ * @typedef {'gif' | 'jpg' | 'jpeg' | 'png' | 'webp'} AemAssetsImageFormat
+ * @typedef {90 | 180 | 270} AemAssetsImageRotation
+ * @typedef {'h' | 'v' | 'hv'} AemAssetsImageFlip
+ * @typedef {'true' | 'false' | '1' | '0'} AemAssetsImageIsAttachment
+ */
+
+/**
+ * @typedef {Object} AemAssetsCropSettings
+ * @property {number} [xOrigin] - The (relative) x origin of the crop (between 0 and 100)
+ * @property {number} [yOrigin] - The (relative) y origin of the crop (between 0 and 100)
+ * @property {number} [width] - The width of the crop (between 0 and 100)
+ * @property {number} [height] - The height of the crop (between 0 and 100)
+ */
+
+/**
+ * @typedef {Object} AemAssetsSizeSettings
+ * @property {number} width - The width of the image
+ * @property {number} height - The height of the image
+ */
+
+/**
+ * @typedef {Object} AemAssetsImageOptimizationParams
+ * @property {AemAssetsImageFormat} format - The format of the image
+ * @property {AemAssetsImageRotation} [rotation] - The rotation of the image
+ * @property {AemAssetsImageFlip} [flip] - The flip of the image
+ * @property {AemAssetsCropSettings} [crop] - The crop settings of the image
+ * @property {AemAssetsSizeSettings} [size] - The size settings of the image
+ * @property {AemAssetsImageIsAttachment} [attachment] - Force a download prompt for the image
+ * @property {number} [width] - The width of the image
+ * @property {number} [height] - The height of the image
+ * @property {number} [quality] - The quality of the image (between 0 and 100)
+ * @property {string} [smartCrop] - The smart crop of the image (e.g. QHD)
+ */
+
+/**
+ * @typedef {Object} AemAssetsImageSlotConfig
+ * @property {string} src - The source URL of the image
+ * @property {string} alias - The alias (i.e. seoName) of the image
+ * @property {HTMLElement} [wrapper] - The wrapper element
+ * @property {Omit<AemAssetsImageOptimizationParams, 'size'> & {width: number}} params -
+ *  The parameters to be applied to the asset (known width required when using a slot).
+ * @property {Omit<import('@dropins/tools/components.js').ImageProps,
+ *  'params' | 'src' | 'onLoad' | 'width' | 'height'>} [imageProps] - The image props
+ */


### PR DESCRIPTION
## Context

This PR enables a set of functions/utilities that will be used in subsequent PRs to support AEM Asset images in the different dropins slots, and URL construction for those that currently don't have them, namely PLP, PREX and LiveSearch.

> [!NOTE]
> I wanted to provide a type safe experience, so I wrote a bunch of JSDoc `typedef` declarations at the bottom of the file. I would have liked a `.d.ts` better but that's out of the scope of this PR.

## Jira Ticket

[ACAP-1017](https://jira.corp.adobe.com/browse/ACAP-1017)

## Requirements

@sirugh To add the `commerce-assets-enabled` in the default starter content sheet configs.

## Example Usages

### For Slots
For slots, a `width` is required, and the `size` optimization parameter is dropped to avoid confusion (see L154).

```js
// Other imports ...
import { tryRenderAemAssetsImage } from '../../scripts/assets.js';

// Some dropin container...
slots: {
  Thumbnail: async (ctx) => {
    await tryRenderAemAssetsImage(ctx, {
      alias: 'my-seo-name',
      params: {
        width: 200,
        // other params...
      },
      src: "raw image src",
      // wrapper: optional wrapper -> document.createElement('a')
    });
  },
  }
//
```

### URL Construction
URL construction allows to use any parameters you want, given an `url` and an `alias` and you get the AEM Assets compatible url back.

```js
// Other imports ...
import { generateAemAssetsOptimizedUrl } from '../../scripts/assets.js';

// Some other code...
const aemAssetsOptimizedUrl = generateAemAssetsOptimizedUrl(aemAssetsImageSrc, 'my-seo-name', {
  format: 'png',
  flip: 'v',
  rotate: 180,
  size: {
    width: 200,
    height: 600
  }
});
```

