### PR TITLE
hlxignore experimentation plugin images

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -8,6 +8,7 @@ package-lock.json
 test/*
 postinstall.js
 build.mjs
-tools/picker/src/*
 cypress/
+tools/picker/src/*
 tools/pdp-metadata/*
+plugins/experimentation/documentation/images/*


### PR DESCRIPTION
Ignores images that dont need served by helix


- https://ignore-images--aem-boilerplate-commerce--hlxsites.aem.live