### PR TITLE
fix: add store header to all

### DIFF
--- a/demo-config.json
+++ b/demo-config.json
@@ -4,6 +4,9 @@
       "commerce-core-endpoint": "https://www.aemshop.net/graphql",
       "commerce-endpoint": "https://www.aemshop.net/cs-graphql",
       "headers": {
+        "all": {
+          "Store": "default"
+        },
         "cs": {
           "Magento-Customer-Group": "b6589fc6ab0dc82cf12099d1c2d40ab994e8410c",
           "Magento-Store-Code": "main_website_store",


### PR DESCRIPTION
Forgot to add this to the demo config.

Test URLs:
https://storeheader--aem-boilerplate-commerce--hlxsites.aem.page/
