### PR TITLE
fix: quick fix for overlap of plp/prex divs

### DIFF
--- a/blocks/product-recommendations/product-recommendations.css
+++ b/blocks/product-recommendations/product-recommendations.css
@@ -1,6 +1,7 @@
 .product-recommendations {
     overflow: hidden;
     min-height: 512px;
+    margin-top: 30px;
 }
 
 .product-recommendations .scrollable {
@@ -61,7 +62,7 @@
     scroll-snap-align: start;
 }
 
-@media (width >= 900px) {
+@media (width >=900px) {
     .product-recommendations {
         min-height: 534px;
     }


### PR DESCRIPTION
Divs for plp and product recs were overlapping.
Quick fix just adds margin top to the recs div.

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/e0d5b6f3-6be6-420f-9e55-0992a05ab3a0" />

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://fix-recs-overlap--aem-boilerplate-commerce--hlxsites.aem.live/
