### PR TITLE
bugfix: align nav items center

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -222,7 +222,8 @@ header nav .nav-sections ul > li:empty {
     align-self: unset;
   }
 
-  header .nav-drop:nth-child(1) {
+  header .nav-drop > p,
+  header .nav-drop > *:not(.submenu-wrapper)::before {
     align-self: center;
   }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -222,7 +222,7 @@ header nav .nav-sections ul > li:empty {
     align-self: unset;
   }
 
-  header .nav-drop > li:nth-child(1), header .nav-drop > li:nth-child(2) {
+  header .nav-drop:nth-child(1) {
     align-self: center;
   }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -222,6 +222,10 @@ header nav .nav-sections ul > li:empty {
     align-self: unset;
   }
 
+  header .nav-drop > li:nth-child(1), header .nav-drop > li:nth-child(2) {
+    align-self: center;
+  }
+
   header nav .nav-sections .default-content-wrapper > ul > li,
   header nav .nav-sections .nav-drop {
     border-radius: 4px;
@@ -230,10 +234,6 @@ header nav .nav-sections ul > li:empty {
 
   header nav .nav-sections .nav-drop {
     cursor: pointer;
-  }
-
-  header .nav-drop > li:nth-child(1), header .nav-drop > li:nth-child(2) {
-    align-self: center;
   }
 
   header nav .nav-sections .default-content-wrapper > ul > li a {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -222,8 +222,7 @@ header nav .nav-sections ul > li:empty {
     align-self: unset;
   }
 
-  header .nav-drop > p,
-  header .nav-drop > *:not(.submenu-wrapper)::before {
+  header .nav-drop {
     align-self: center;
   }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -232,7 +232,7 @@ header nav .nav-sections ul > li:empty {
     cursor: pointer;
   }
 
-  header .nav-drop > li:nth-child(1) {
+  header .nav-drop > li:nth-child(1), header .nav-drop > li:nth-child(2) {
     align-self: center;
   }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -48,6 +48,7 @@ header nav[aria-expanded='true'] {
     gap: 0 32px;
     max-width: 1264px;
     padding: 0 32px;
+    align-items: center;
   }
 
   header nav[aria-expanded='true'] {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -48,7 +48,6 @@ header nav[aria-expanded='true'] {
     gap: 0 32px;
     max-width: 1264px;
     padding: 0 32px;
-    align-items: center;
   }
 
   header nav[aria-expanded='true'] {
@@ -241,6 +240,7 @@ header nav .nav-sections ul > li:empty {
     display: flex;
     gap: 24px;
     margin: 0;
+    align-items: center;
   }
 
   header nav .nav-sections .default-content-wrapper > ul > li ul {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -240,7 +240,10 @@ header nav .nav-sections ul > li:empty {
     display: flex;
     gap: 24px;
     margin: 0;
-    align-items: center;
+  }
+
+  header .nav-drop > li:nth-child(1) {
+    align-self: center;
   }
 
   header nav .nav-sections .default-content-wrapper > ul > li ul {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -232,6 +232,10 @@ header nav .nav-sections ul > li:empty {
     cursor: pointer;
   }
 
+  header .nav-drop > li:nth-child(1) {
+    align-self: center;
+  }
+
   header nav .nav-sections .default-content-wrapper > ul > li a {
     text-decoration: none;
   }
@@ -240,10 +244,6 @@ header nav .nav-sections ul > li:empty {
     display: flex;
     gap: 24px;
     margin: 0;
-  }
-
-  header .nav-drop > li:nth-child(1) {
-    align-self: center;
   }
 
   header nav .nav-sections .default-content-wrapper > ul > li ul {


### PR DESCRIPTION
live and preview nav.plain.html differ from content. While that's being worked on, we can add a small change to the nav css to better align the content regardless.

![image](https://github.com/user-attachments/assets/605ca0f4-e6dc-4f3e-8f82-efbcb1727f65)

![image](https://github.com/user-attachments/assets/1ffc1256-b78e-4239-a965-c9e4126719ac)


Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://fix-preview-nav--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://fix-preview-nav--aem-boilerplate-commerce--hlxsites.aem.page/
