### PR TITLE
chore: Add picker config for root category to site public config

### DIFF
--- a/default-site.json
+++ b/default-site.json
@@ -31,6 +31,9 @@
       "commerce-core-endpoint": "{ENDPOINT}",
       "commerce-endpoint": "{CS_ENDPOINT}",
       "headers": {
+        "all": {
+          "Store": "default"
+        },
         "cs": {
           "Magento-Customer-Group": "b6589fc6ab0dc82cf12099d1c2d40ab994e8410c",
           "Magento-Store-Code": "{STORE_CODE}",
@@ -50,6 +53,11 @@
         "store-view-name": "Default Store View",
         "website-id": "{WEBSITE_ID}",
         "website-name": "Main Website"
+      },
+      "plugins": {
+        "picker": {
+           "rootCategory": 2
+         }
       }
     }
   },

--- a/demo-config.json
+++ b/demo-config.json
@@ -26,6 +26,11 @@
         "store-view-name": "Default Store View",
         "website-id": 1,
         "website-name": "Main Website"
+      },
+      "plugins": {
+        "picker": {
+           "rootCategory": 2
+         }
       }
     }
   }


### PR DESCRIPTION


Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://hannessolo-patch-1--aem-boilerplate-commerce--hlxsites.aem.live/
