### PR TITLE
dnm: adds config override for accs boilerplate env

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,35 @@
+{
+  "public": {
+    "default": {
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
+      "headers": {
+        "all": {
+          "Store": "default"
+        },
+        "cs": {
+          "Magento-Customer-Group": "b6589fc6ab0dc82cf12099d1c2d40ab994e8410c",
+          "Magento-Store-Code": "main_website_store",
+          "Magento-Store-View-Code": "default",
+          "Magento-Website-Code": "base"
+        }
+      },
+      "analytics": {
+        "base-currency-code": "USD",
+        "environment": "Production",
+        "store-id": 1,
+        "store-name": "ACCS Demo",
+        "store-url": "https://www.aemshop.net",
+        "store-view-id": 1,
+        "store-view-name": "Default Store View",
+        "website-id": 1,
+        "website-name": "Main Website"
+      },
+      "plugins": {
+        "picker": {
+           "rootCategory": 2
+         }
+      }
+    }
+  }
+}


### PR DESCRIPTION
For development against boilerplate, we are switching the "main" backend to an Adobe Commerce Cloud Services environment rather than the PaaS env we have been using.

This PR uses a config override (though the same could be accomplished with a new site/config.

We can use this to validate the change.

Note: I also created a config-based site for this too, at https://main--boilerplate-accs--adobe-commerce.aem.live/

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://accs--aem-boilerplate-commerce--hlxsites.aem.live/
