### PR TITLE
chore: add .map files to .hlxignore

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -1,6 +1,7 @@
 .*
 *.md
 *.d.ts
+*.map
 karma.config.js
 LICENSE
 package.json


### PR DESCRIPTION
Test URLs:
- Before: http://main--aem-boilerplate-commerce--hlxsites.aem.live
- After: http://ignore-sourcemap--aem-boilerplate-commerce--hlxsites.aem.live
