### PR TITLE
Change mountpoint to da.live on aco branch

### DIFF
--- a/default-fstab.yaml
+++ b/default-fstab.yaml
@@ -1,5 +1,7 @@
 mountpoints:
-  /: {YOUR_MOUNTPOINT_URL}
+  /:
+    url: https://content.da.live/{org}/{site}/
+    type: markup
 
 folders:
   /products/: /products/default


### PR DESCRIPTION
Change mountpoint to use content.da.live URL

Fix # [USF-2278-starter-content](https://jira.corp.adobe.com/browse/USF-2278)

