### PR TITLE
Copy da library

### DIFF
--- a/tools/site-creator/create-site.js
+++ b/tools/site-creator/create-site.js
@@ -42,6 +42,7 @@ async function checkCodeBus(data) {
 
 async function previewOrPublishPages(data, action, setStatus) {
   const parent = getDestinationPath(data.repo, data.org);
+  const libraryPath = `${parent}/docs/library`;
 
   const label = action === 'preview' ? 'Previewing' : 'Publishing';
 
@@ -49,16 +50,14 @@ async function previewOrPublishPages(data, action, setStatus) {
 
   const callback = async (item) => {
     if (item.path.endsWith('.svg') || item.path.endsWith('.png') || item.path.endsWith('.jpg')) return;
+    // skip publishing library
+    if (item.path.startsWith(libraryPath)) return;
     setStatus({ message: `${label}: ${item.path.replace(parent, '').replace('.html', '')}` });
     const aemPath = item.path.replace(parent, `${parent}/main`).replace('.html', '');
     const resp = await fetch(`${AEM_ORIGIN}/${action}${aemPath}`, opts);
     if (!resp.ok) throw new Error(`Could not preview ${aemPath}`);
   };
 
-  // Get the library
-  crawl({
-    path: `${parent}/.da`, callback, concurrent: 5, throttle: 250,
-  });
   const { results, getCallbackErrors } = crawl({
     path: parent, callback, concurrent: 5, throttle: 250,
   });


### PR DESCRIPTION
Prevents publishing files under `/docs/library`.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://copy-da-library--aem-boilerplate-commerce--hlxsites.aem.live/
