### PR TITLE
Update commerce endpoint to include store view code in cache-buster q…

### DIFF
--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export, import/no-cycle */
 import { getMetadata } from './aem.js';
 import {
+  getHeaders,
   getConfigValue,
   getCookie,
-  getHeaders,
   getRootPath,
 } from './configs.js';
 import { getConsent } from './scripts.js';
@@ -88,10 +88,32 @@ export const priceFieldsFragment = `fragment priceFields on ProductViewPrice {
   }
 }`;
 
+/**
+ * Creates a short hash from an object by sorting its entries and hashing them.
+ * @param {Object} obj - The object to hash
+ * @param {number} [length=8] - Length of the resulting hash
+ * @returns {string} A short hash string
+ */
+function createHashFromObject(obj, length = 8) {
+  // Sort entries by key and create a string of key-value pairs
+  const objString = Object.entries(obj)
+    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+    .map(([key, value]) => `${key}:${value}`)
+    .join('|');
+
+  // Create a short hash using a simple string manipulation
+  return objString
+    .split('')
+    .reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) % 2147483647, 0)
+    .toString(36)
+    .slice(0, length);
+}
+
 export async function commerceEndpointWithQueryParams() {
   const urlWithQueryParams = new URL(getConfigValue('commerce-endpoint'));
-  // Set some query parameters for use as a cache-buster. No other purpose.
-  urlWithQueryParams.searchParams.append('ac-storecode', `${getConfigValue('headers.cs.Magento-Store-Code')}-${getConfigValue('headers.cs.Magento-Store-View-Code')}`);
+  const headers = getHeaders('cs');
+  const shortHash = createHashFromObject(headers);
+  urlWithQueryParams.searchParams.append('cache-buster', shortHash);
   return urlWithQueryParams;
 }
 

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -91,7 +91,7 @@ export const priceFieldsFragment = `fragment priceFields on ProductViewPrice {
 export async function commerceEndpointWithQueryParams() {
   const urlWithQueryParams = new URL(getConfigValue('commerce-endpoint'));
   // Set some query parameters for use as a cache-buster. No other purpose.
-  urlWithQueryParams.searchParams.append('ac-storecode', getConfigValue('headers.cs.Magento-Store-Code'));
+  urlWithQueryParams.searchParams.append('ac-storecode', `${getConfigValue('headers.cs.Magento-Store-Code')}-${getConfigValue('headers.cs.Magento-Store-View-Code')}`);
   return urlWithQueryParams;
 }
 

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -91,10 +91,10 @@ export const priceFieldsFragment = `fragment priceFields on ProductViewPrice {
 /**
  * Creates a short hash from an object by sorting its entries and hashing them.
  * @param {Object} obj - The object to hash
- * @param {number} [length=8] - Length of the resulting hash
+ * @param {number} [length=5] - Length of the resulting hash
  * @returns {string} A short hash string
  */
-function createHashFromObject(obj, length = 8) {
+function createHashFromObject(obj, length = 5) {
   // Sort entries by key and create a string of key-value pairs
   const objString = Object.entries(obj)
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
@@ -113,7 +113,7 @@ export async function commerceEndpointWithQueryParams() {
   const urlWithQueryParams = new URL(getConfigValue('commerce-endpoint'));
   const headers = getHeaders('cs');
   const shortHash = createHashFromObject(headers);
-  urlWithQueryParams.searchParams.append('cache-buster', shortHash);
+  urlWithQueryParams.searchParams.append('cb', shortHash);
   return urlWithQueryParams;
 }
 

--- a/tools/pdp-metadata/pdp-metadata.js
+++ b/tools/pdp-metadata/pdp-metadata.js
@@ -3,26 +3,21 @@ import fs from 'fs';
 import he from 'he';
 import productSearchQuery from './queries/products.graphql.js';
 import { variantsFragment } from './queries/variants.graphql.js';
-
 const basePath = 'https://www.aemshop.net';
-const configFile = `${basePath}/configs.json?sheet=prod`;
+const configFile = `${basePath}/config.json?sheet=prod`;
 
 export async function commerceEndpointWithQueryParams(config) {
   const urlWithQueryParams = new URL(config['commerce-endpoint']);
   // Set some query parameters for use as a cache-buster. No other purpose.
-  urlWithQueryParams.searchParams.append('ac-storecode', `${config['commerce.headers.cs.Magento-Store-Code']}-${config['commerce.headers.cs.Magento-Store-View-Code']}`);
+  const hash = createHashFromObject(config.headers?.cs ?? {});
+  urlWithQueryParams.searchParams.append('cache-buster', hash);
   return urlWithQueryParams;
 }
 
 async function performCatalogServiceQuery(config, query, variables) {
   const headers = {
     'Content-Type': 'application/json',
-    'x-api-key': config['commerce.headers.cs.x-api-key'],
-    'Magento-Customer-Group': config['commerce.headers.cs.Magento-Customer-Group'],
-    'Magento-Environment-Id': config['commerce.headers.cs.Magento-Environment-Id'],
-    'Magento-Store-Code': config['commerce.headers.cs.Magento-Store-Code'],
-    'Magento-Store-View-Code': config['commerce.headers.cs.Magento-Store-View-Code'],
-    'Magento-Website-Code': config['commerce.headers.cs.Magento-Website-Code'],
+    ...config.headers?.cs,
   };
 
   const apiCall = await commerceEndpointWithQueryParams(config);
@@ -43,6 +38,27 @@ async function performCatalogServiceQuery(config, query, variables) {
   const queryResponse = await response.json();
 
   return queryResponse.data;
+}
+
+/**
+ * Creates a short hash from an object by sorting its entries and hashing them.
+ * @param {Object} obj - The object to hash
+ * @param {number} [length=8] - Length of the resulting hash
+ * @returns {string} A short hash string
+ */
+function createHashFromObject(obj, length = 8) {
+  // Sort entries by key and create a string of key-value pairs
+  const objString = Object.entries(obj)
+    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+    .map(([key, value]) => `${key}:${value}`)
+    .join('|');
+
+  // Create a short hash using a simple string manipulation
+  return objString
+    .split('')
+    .reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) % 2147483647, 0)
+    .toString(36)
+    .slice(0, length);
 }
 
 function getJsonLd(product, { variants }) {
@@ -193,16 +209,13 @@ async function addVariantsToProducts(products, config) {
 }
 
 (async () => {
-  const config = {};
-  try {
-    const resp = await fetch(configFile).then((res) => res.json());
-    resp.data.forEach((item) => {
-      config[item.key] = item.value;
+  const config = await fetch(configFile)
+    .then((res) => res.json())
+    .then((data) => data.public.default)
+    .catch((err) => {
+      console.error(err);
+      return {};
     });
-  } catch (err) {
-    console.error(err);
-    return;
-  }
 
   const products = await getProducts(config, 1);
 

--- a/tools/pdp-metadata/pdp-metadata.js
+++ b/tools/pdp-metadata/pdp-metadata.js
@@ -10,7 +10,7 @@ const configFile = `${basePath}/configs.json?sheet=prod`;
 export async function commerceEndpointWithQueryParams(config) {
   const urlWithQueryParams = new URL(config['commerce-endpoint']);
   // Set some query parameters for use as a cache-buster. No other purpose.
-  urlWithQueryParams.searchParams.append('ac-storecode', config['commerce.headers.cs.Magento-Store-Code']);
+  urlWithQueryParams.searchParams.append('ac-storecode', `${config['commerce.headers.cs.Magento-Store-Code']}-${config['commerce.headers.cs.Magento-Store-View-Code']}`);
   return urlWithQueryParams;
 }
 

--- a/tools/pdp-metadata/pdp-metadata.js
+++ b/tools/pdp-metadata/pdp-metadata.js
@@ -4,19 +4,20 @@ import he from 'he';
 import productSearchQuery from './queries/products.graphql.js';
 import { variantsFragment } from './queries/variants.graphql.js';
 const basePath = 'https://www.aemshop.net';
-const configFile = `${basePath}/config.json?sheet=prod`;
+const configFile = `${basePath}/config.json`;
 
 export async function commerceEndpointWithQueryParams(config) {
   const urlWithQueryParams = new URL(config['commerce-endpoint']);
   // Set some query parameters for use as a cache-buster. No other purpose.
   const hash = createHashFromObject(config.headers?.cs ?? {});
-  urlWithQueryParams.searchParams.append('cache-buster', hash);
+  urlWithQueryParams.searchParams.append('cb', hash);
   return urlWithQueryParams;
 }
 
 async function performCatalogServiceQuery(config, query, variables) {
   const headers = {
     'Content-Type': 'application/json',
+    ...config.headers?.all,
     ...config.headers?.cs,
   };
 
@@ -43,10 +44,10 @@ async function performCatalogServiceQuery(config, query, variables) {
 /**
  * Creates a short hash from an object by sorting its entries and hashing them.
  * @param {Object} obj - The object to hash
- * @param {number} [length=8] - Length of the resulting hash
+ * @param {number} [length=5] - Length of the resulting hash
  * @returns {string} A short hash string
  */
-function createHashFromObject(obj, length = 8) {
+function createHashFromObject(obj, length = 5) {
   // Sort entries by key and create a string of key-value pairs
   const objString = Object.entries(obj)
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))


### PR DESCRIPTION
## 🛠 Changes

- Renamed the `ac-store` query parameter to `cache-buster` for clarity.
- Introduced a short hash generator based on the configuration header content:
  - Ensures uniqueness per config change
  - Keeps URL lengths short to avoid browser GET limits. **Example:**  `https://www.aemshop.net/cs-graphql?cb=3cy4z&query=...`
- Fixed `tools/pdp-metadata`, which was broken after the last update to the storefront config.

### TODO

- [x] Update documentation https://github.com/commerce-docs/microsite-commerce-storefront/pull/296

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://cache-busting--aem-boilerplate-commerce--hlxsites.aem.live/