### PR TITLE
refactor: update product details to use lastPayload method for event …

### DIFF
--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -29,8 +29,7 @@ import '../../scripts/initializers/cart.js';
 import { rootLink } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
-  // eslint-disable-next-line no-underscore-dangle
-  const product = events._lastEvent?.['pdp/data']?.payload ?? null;
+  const product = events.lastPayload('pdp/data') ?? null;
   const labels = await fetchPlaceholders();
 
   // Layout


### PR DESCRIPTION
Use the new `lastEvent` method.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/youth-tee/ADB150
- After: https://lastevents--aem-boilerplate-commerce--hlxsites.aem.live/products/youth-tee/ADB150
