### PR TITLE
chore: oops, not md

### DIFF
--- a/tools/site-creator/site-creator.html
+++ b/tools/site-creator/site-creator.html
@@ -22,7 +22,7 @@
     <h1>Initialize your storefront content</h1>
     <img width="2000" height="558" class="logo" src="./Logo-Adobe-Commerce.png" />
   </div>
-  <p class="subheader">This tool will clone the content behind <a href="https://www.aemshop.net" target="_blank">aemshop.net</a> to your own content directory. After you create the GitHub repository, please make sure that you install the [AEM Code Sync bot](https://github.com/apps/aem-code-sync) and that you onboard your site to <a href="https://www.aem.live/docs/config-service-setup" target="_blank">AEM config service</a>, or commit a <a href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/default-fstab.yaml" target="_blank">fstab.yaml</a> with your org and site name to your code repo.</p>
+  <p class="subheader">This tool will clone the content behind <a href="https://www.aemshop.net" target="_blank">aemshop.net</a> to your own content directory. After you create the GitHub repository, please make sure that you install the <a href="https://github.com/apps/aem-code-sync">AEM Code Sync bot</a> and that you onboard your site to <a href="https://www.aem.live/docs/config-service-setup" target="_blank">AEM config service</a>, or commit a <a href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/default-fstab.yaml" target="_blank">fstab.yaml</a> with your org and site name to your code repo.</p>
   <da-site-creator></da-site-creator>
 </main>
 </body>


### PR DESCRIPTION
Oops - fixes to use html, not md syntax.

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/ddfbe744-bc45-4fac-8f63-8accbe143b65" />

Test URLs:
- https://fix-cc-2--aem-boilerplate-commerce--hlxsites.aem.live
