### PR TITLE
chore: simplify sidekick config

### DIFF
--- a/demo-sidekick.json
+++ b/demo-sidekick.json
@@ -1,15 +1,5 @@
 {
-  "project": "Boilerplate",
-  "plugins": [
-    {
-      "id": "cif",
-      "title": "Commerce",
-      "environments": [
-        "edit"
-      ],
-      "url": "https://main--aem-boilerplate-commerce--hlxsites.aem.live/tools/picker/dist/index.html",
-      "isPalette": true,
-      "paletteRect": "top: 54px; left: 5px; bottom: 5px; width: 300px; height: calc(100% - 59px); border-radius: var(--hlx-sk-button-border-radius); overflow: hidden; resize: horizontal;"
-    }
-  ]
+  "project": "My Project",
+  "editUrlLabel": "Document Authoring",
+  "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}{{pathname}}"
 }


### PR DESCRIPTION
The demo sidekick config should match docs: https://experienceleague.adobe.com/developer/commerce/storefront/get-started/#link-repo-to-commerce-data 

I chose to simply apply whatever is in docs to the sidekick config. An alternative could be a combination, where we also retain the `plugins` prop + array.

Test URLs:
- https://simple-sidekick-cfg--aem-boilerplate-commerce--hlxsites.aem.live
