### PR TITLE
chore: force lowercase github url

### DIFF
--- a/tools/site-creator/site-creator.js
+++ b/tools/site-creator/site-creator.js
@@ -26,6 +26,25 @@ class SiteCreator extends LitElement {
     return `${String(crawlTime / 1000).substring(0, 4)}s`;
   }
 
+  formChanged(e) {
+    const input = e.target;
+    const value = input.value.toLowerCase();
+    input.value = value; // Update the input field with lowercase value
+
+    try {
+      const url = new URL(value);
+      const org = url.pathname.split('/')[1];
+      const repo = url.pathname.split('/')[2];
+
+      if (org && repo && url.hostname === 'github.com') {
+        this._status = null;
+        this._data = { org, repo };
+      }
+    } catch (err) {
+      // Invalid URL, ignore
+    }
+  }
+
   async handleSubmit(e) {
     e.preventDefault();
     this._time = null;
@@ -40,7 +59,7 @@ class SiteCreator extends LitElement {
     }
 
     try {
-      const url = new URL(entries.github);
+      const url = new URL(entries.github.toLowerCase());
       const org = url.pathname.split('/')[1];
       const repo = url.pathname.split('/')[2];
 
@@ -151,17 +170,6 @@ mountpoints:
       return this.renderNoFstab();
     }
     return this.renderSiteComplete();
-  }
-
-  formChanged(e) {
-    const url = new URL(e.target.value);
-    const org = url.pathname.split('/')[1];
-    const repo = url.pathname.split('/')[2];
-
-    if (org && repo && url.hostname === 'github.com') {
-      this._status = null;
-      this._data = { org, repo };
-    }
   }
 
   renderForm() {


### PR DESCRIPTION
I believe that the helix org may have some case sensitivity issues. If a github user name is used that has uppercase letters, certain things may fail.

To test this, you can try using your own github user but change the case of some letter in the org. Try it first on main

https://da.live/app/hlxsites/aem-boilerplate-commerce/tools/site-creator/site-creator

and then again on this branch

https://da.live/app/hlxsites/aem-boilerplate-commerce/tools/site-creator/site-creator?ref=sc-gh-lowrcase

Test URLs:

- https://sc-gh-lowercase--aem-boilerplate-commerce--hlxsites.aem.live
