### PR TITLE
spike: Config Generator

### DIFF
--- a/tools/config-generator/config-generator.css
+++ b/tools/config-generator/config-generator.css
@@ -1,0 +1,135 @@
+.subheader {
+  text-align: center;
+  margin-bottom: 48px;
+  color: #616161;
+}
+
+.inputgroup,
+.fieldgroup {
+  margin-bottom: 16px;
+}
+
+.inputgroup label,
+.fieldgroup label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: #333;
+}
+
+.input-group {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input-group input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.input-group button {
+  padding: 8px 16px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.input-group button:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #0066cc;
+}
+
+.input-group button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.input-group button[type="submit"] {
+  background: #0066cc;
+  color: white;
+  border-color: #0066cc;
+}
+
+.input-group button[type="submit"]:hover:not(:disabled) {
+  background: #0052a3;
+}
+
+.status {
+  margin: 24px 0px 0px;
+  font-weight: 700;
+  font-style: italic;
+  background: var(--s2-green);
+  padding: 6px 12px;
+  color: rgb(255, 255, 255);
+  border-radius: 8px;
+}
+
+.status.error {
+  background-color: var(--s2-red);
+}
+
+.status.success {
+  background-color: var(--s2-blue-800);
+}
+
+.success-panel {
+  padding: 16px;
+  background: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  margin-top: 24px;
+}
+
+.config-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+pre {
+  background: #f4f4f4;
+  padding: 10px;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 0;
+  line-height: 1.2;
+  font-size: 13px;
+}
+
+:root {
+  --s2-green: #1473e6;
+  --s2-red-800: #e60000;
+  --s2-blue-800: #1473e6;
+}
+
+.radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.radio-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #333;
+}
+
+.radio-label input[type="radio"] {
+  margin: 0;
+}
+
+.radio-label:hover {
+  color: #0066cc;
+}

--- a/tools/config-generator/config-generator.html
+++ b/tools/config-generator/config-generator.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Config Generator - Adobe Commerce</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <link rel="stylesheet" href="https://da.live/nx/styles/nexter.css">
+  <link rel="stylesheet" href="/tools/config-generator/index.css">
+  <script type="importmap">
+    {
+      "imports": {
+        "da-lit": "https://da.live/deps/lit/dist/index.js"
+      }
+    }
+  </script>
+  <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
+  <script src="/tools/config-generator/config-generator.js" type="module"></script>
+  <link rel="icon" href="data:,">
+</head>
+<body>
+<main>
+  <div class="header">
+    <h1>Generate Commerce Config</h1>
+  </div>
+  <p class="subheader">This tool will generate a configuration object based on your GraphQL API endpoint. You can copy the output and use it in either your code repo as config.json, or use it in your site <a href="https://www.aem.live/docs/admin.html#schema/PublicConfig" target="_blank">public config</a>. Enter your GraphQL API URL below to get started.</p>
+  <da-config-generator></da-config-generator>
+</main>
+</body>
+</html>

--- a/tools/config-generator/config-generator.js
+++ b/tools/config-generator/config-generator.js
@@ -1,0 +1,149 @@
+/* eslint-disable import/no-unresolved */
+
+import getStyle from 'https://da.live/nx/utils/styles.js';
+import { LitElement, html, nothing } from 'da-lit';
+import { fetchStoreConfig } from './schema.js';
+import { generateConfig } from './config.js';
+
+const style = await getStyle(import.meta.url);
+
+class ConfigGenerator extends LitElement {
+  static properties = {
+    _loading: { state: true },
+    _status: { state: true },
+    _config: { state: true },
+    _endpoint: { state: true },
+  };
+
+  async connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [style];
+  }
+
+  handleEnvironmentTypeChange(e) {
+    const environmentType = e.target.value;
+    const endpointInput = this.renderRoot.querySelector('input[name="endpoint"]');
+
+    const defaultEndpoints = {
+      paas: 'https://www.aemshop.net/graphql',
+      saas: 'https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql',
+      aco: 'https://na1-sandbox.api.commerce.adobe.com/Fwus6kdpvYCmeEdcCX7PZg/graphql',
+    };
+
+    if (endpointInput) {
+      endpointInput.value = defaultEndpoints[environmentType] || defaultEndpoints.paas;
+    }
+  }
+
+  async handleSubmit(e) {
+    e.preventDefault();
+    this._loading = true;
+    this._status = null;
+    this._config = null;
+
+    const endpoint = this.renderRoot.querySelector('input[name="endpoint"]').value;
+    const environmentType = this.renderRoot
+      .querySelector('input[name="environmentType"]:checked')?.value
+      || 'paas';
+
+    if (!endpoint) {
+      this._status = { type: 'error', message: 'Please enter a GraphQL endpoint URL.' };
+      this._loading = false;
+      return;
+    }
+
+    try {
+      // Fetch store configuration using hardcoded query
+      this._status = { type: 'note', message: 'Fetching store configuration...' };
+      const data = await fetchStoreConfig(endpoint);
+
+      const { storeConfig, dataServicesStorefrontInstanceContext } = data;
+      this._config = generateConfig(endpoint, storeConfig, dataServicesStorefrontInstanceContext, environmentType);
+      this._endpoint = endpoint;
+      this._status = { type: 'success', message: 'Configuration generated successfully!' };
+    } catch (err) {
+      this._status = { type: 'error', message: `Error: ${err.message}` };
+      this._config = null;
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  copyToClipboard() {
+    if (!this._config) return;
+    const configStr = JSON.stringify(this._config, null, 2);
+    navigator.clipboard.writeText(configStr);
+    this._status = { type: 'success', message: 'Configuration copied to clipboard!' };
+  }
+
+  render() {
+    return html`
+      <form @submit=${this.handleSubmit} autocomplete="off">
+        <div class="inputgroup">
+          <label for="endpoint">GraphQL API Endpoint</label>
+          <div class="input-group">
+            <input
+              id="endpoint"
+              name="endpoint"
+              type="text"
+              value="https://www.aemshop.net/graphql"
+              placeholder="Enter GraphQL API URL (e.g. https://your-store.com/graphql)"
+            />
+            <button
+              type="submit"
+              ?disabled=${this._loading}
+            >Generate</button>
+            <button
+              type="button"
+              ?disabled=${!this._config}
+              @click=${this.copyToClipboard}
+            >Copy</button>
+          </div>
+        </div>
+        <div class="fieldgroup">
+          <label>Environment Type</label>
+          <div class="radio-group">
+            <label class="radio-label">
+              <input
+                type="radio"
+                name="environmentType"
+                value="paas"
+                checked
+                @change=${this.handleEnvironmentTypeChange}
+              />
+              PaaS (Magento Commerce Cloud)
+            </label>
+            <label class="radio-label">
+              <input
+                type="radio"
+                name="environmentType"
+                value="saas"
+                @change=${this.handleEnvironmentTypeChange}
+              />
+              SaaS (Commerce Services - ACCS)
+            </label>
+            <!-- Temporarily disabled ACO option due to inability to query without valid headers
+            <label class="radio-label">
+              <input
+                type="radio"
+                name="environmentType"
+                value="aco"
+                @change=${this.handleEnvironmentTypeChange}
+              />
+              ACO (Adobe Commerce Operations)
+            </label>
+            -->
+          </div>
+        </div>
+        ${this._status ? html`<p class="status ${this._status?.type || 'note'}">${this._status?.message}</p>` : nothing}
+        ${this._config ? html`
+          <div class="success-panel">
+            <pre><code>${JSON.stringify(this._config, null, 2)}</code></pre>
+          </div>
+        ` : nothing}
+      </form>
+    `;
+  }
+}
+
+customElements.define('da-config-generator', ConfigGenerator);

--- a/tools/config-generator/config.js
+++ b/tools/config-generator/config.js
@@ -1,0 +1,101 @@
+export function generateConfig(endpoint, storeConfig, dataServicesContext, environmentType = 'paas') {
+  // Decode base64 root_category_uid to get the actual category ID
+  const decodeBase64 = (str) => {
+    try {
+      return atob(str);
+    } catch (e) {
+      return str; // Return original if decoding fails
+    }
+  };
+
+  // Extract environment ID from URL pattern .../HERE/graphql
+  const extractEnvironmentId = (url) => {
+    const match = url.match(/\/([^/]+)\/graphql$/);
+    return match ? match[1] : '';
+  };
+
+  const rootCategoryId = storeConfig.root_category_uid
+    ? decodeBase64(storeConfig.root_category_uid)
+    : '2';
+
+  // Determine environment ID: prefer dataServices context, fallback to URL extraction
+  const environmentId = dataServicesContext?.environment_id || extractEnvironmentId(endpoint) || 'UNKNOWN';
+
+  // Generate headers based on environment type
+  const generateHeaders = () => {
+    const baseHeaders = {
+      all: {
+        Store: 'default',
+      },
+    };
+
+    switch (environmentType) {
+      case 'aco':
+        return {
+          ...baseHeaders,
+          cs: {
+            'ac-channel-id': 'UNKNOWN',
+            'ac-environment-id': environmentId,
+            'ac-price-book-id': 'UNKNOWN',
+            'ac-scope-locale': 'en-US',
+          },
+        };
+
+      case 'saas':
+        return {
+          ...baseHeaders,
+          cs: {
+            'Magento-Customer-Group': 'b6589fc6ab0dc82cf12099d1c2d40ab994e8410c',
+            'Magento-Store-Code': storeConfig.store_group_code || 'UNKNOWN',
+            'Magento-Store-View-Code': storeConfig.store_code || 'UNKNOWN',
+            'Magento-Website-Code': storeConfig.website_code || 'UNKNOWN',
+            // Note: x-api-key and Magento-Environment-Id are not required for SAAS
+          },
+        };
+
+      case 'paas':
+      default:
+        return {
+          ...baseHeaders,
+          cs: {
+            'Magento-Customer-Group': 'b6589fc6ab0dc82cf12099d1c2d40ab994e8410c',
+            'Magento-Store-Code': storeConfig.store_group_code || 'UNKNOWN',
+            'Magento-Store-View-Code': storeConfig.store_code || 'UNKNOWN',
+            'Magento-Website-Code': storeConfig.website_code || 'UNKNOWN',
+            'x-api-key': dataServicesContext?.api_key || 'UNKNOWN',
+            'Magento-Environment-Id': environmentId,
+          },
+        };
+    }
+  };
+
+  return {
+    public: {
+      default: {
+        'commerce-core-endpoint': endpoint,
+        'commerce-endpoint': endpoint,
+        headers: generateHeaders(),
+        analytics: {
+          'base-currency-code': storeConfig.base_currency_code || 'USD',
+          environment: dataServicesContext?.environment || 'Production',
+          'environment-id': environmentId,
+          'store-code': storeConfig.store_group_code || 'UNKNOWN',
+          'store-id': storeConfig.store_group_code || 'UNKNOWN',
+          'store-name': storeConfig.store_name || 'UNKNOWN',
+          'store-url': storeConfig.base_url || 'UNKNOWN',
+          'store-view-code': storeConfig.store_code || 'UNKNOWN',
+          'store-view-id': storeConfig.store_code || 'UNKNOWN',
+          'store-view-name': storeConfig.store_name || 'UNKNOWN',
+          'website-code': storeConfig.website_code || 'UNKNOWN',
+          'website-id': storeConfig.website_code || 'UNKNOWN',
+          'website-name': storeConfig.website_name || 'UNKNOWN',
+        },
+        plugins: {
+          picker: {
+            rootCategory: rootCategoryId,
+          },
+        },
+      },
+    },
+  };
+}

--- a/tools/config-generator/index.css
+++ b/tools/config-generator/index.css
@@ -1,0 +1,29 @@
+body {
+  font-family: var(--s2-font-family, Arial, sans-serif);
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.logo {
+  max-width: 200px;
+  height: auto;
+  margin: 24px 0;
+}
+
+.subheader {
+  text-align: center;
+  margin-bottom: 48px;
+  color: #616161;
+}

--- a/tools/config-generator/schema.js
+++ b/tools/config-generator/schema.js
@@ -1,0 +1,106 @@
+// Full GraphQL query with both storeConfig and dataServices context
+export const FULL_STORE_CONFIG_QUERY = `
+  query {
+    storeConfig {
+      website_code
+      store_code # storeview
+      store_group_code # store
+      root_category_uid
+      store_name
+      website_name
+      base_currency_code
+      base_url
+    }
+    dataServicesStorefrontInstanceContext {
+      environment_id
+      store_id
+      website_id
+      store_view_id
+      api_key
+      environment
+      customer_group
+    }
+  }
+`;
+
+// Fallback query with just storeConfig
+export const BASIC_STORE_CONFIG_QUERY = `
+  query {
+    storeConfig {
+      website_code
+      store_code
+      store_group_code
+      root_category_uid
+      store_name
+      website_name
+      base_currency_code
+      base_url
+    }
+  }
+`;
+
+export async function fetchStoreConfig(endpoint) {
+  // Try the full query first
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: FULL_STORE_CONFIG_QUERY,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Check if there are errors related to dataServicesStorefrontInstanceContext
+    if (data.errors && data.errors.some((error) => error.message.includes('dataServicesStorefrontInstanceContext')
+      || error.message.includes('Cannot query field'))) {
+      // Fall back to basic query
+      return fetchBasicStoreConfig(endpoint);
+    }
+
+    if (data.errors) {
+      throw new Error(data.errors[0].message);
+    }
+
+    return data.data;
+  } catch (error) {
+    // If the full query fails, try the basic query
+    console.warn('Full query failed, falling back to basic query:', error.message);
+    return fetchBasicStoreConfig(endpoint);
+  }
+}
+
+async function fetchBasicStoreConfig(endpoint) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: BASIC_STORE_CONFIG_QUERY,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  if (data.errors) {
+    throw new Error(data.errors[0].message);
+  }
+
+  // Return data with null dataServicesStorefrontInstanceContext
+  return {
+    ...data.data,
+    dataServicesStorefrontInstanceContext: null,
+  };
+}


### PR DESCRIPTION
I field a lot of questions about "Storefront Configuration" and what values / structure should exist in config.json, or in public config.

While our documentation [covers these](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/) in detail, I thought it might be a cool idea to automatically generate this for a user based on the endpoint url they provide.
 
Part of the challenge though, is that not all data is retrievable by query. For example, for PaaS and ACCS environments, storeConfig can return some set of the info, but to get other things (from dataServicesStorefrontInstanceContext) you have to have a specific module installed. 

 ![image](https://github.com/user-attachments/assets/fb417741-6735-44f5-99d1-a6c285896732)
 
For now, the code will do it's best effort to create a correct config given an endpoint.

Try it: 
https://da.live/app/hlxsites/aem-boilerplate-commerce/tools/config-generator/config-generator?ref=config-generator