### PR TITLE
updated checkout drop-in to 2.0.0-beta6

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -299,7 +299,6 @@ export default async function decorate(block) {
 
     CheckoutProvider.render(BillToShippingAddress, {
       onChange: (checked) => {
-        $billingForm.style.display = checked ? 'none' : 'block';
         if (!checked && billingFormRef?.current) {
           const { formData, isDataValid } = billingFormRef.current;
 
@@ -671,9 +670,6 @@ export default async function decorate(block) {
 
       const storeConfig = checkoutApi.getStoreConfigCache();
 
-      if (!data.isVirtual) {
-        $billingForm.style.display = 'none';
-      }
       billingForm = await AccountProvider.render(AddressForm, {
         addressesFormTitle: 'Billing address',
         className: 'checkout-billing-form__address-form',
@@ -1008,6 +1004,11 @@ export default async function decorate(block) {
     removeModal();
   }
 
+  function handleCheckoutValues(payload) {
+    const { isBillToShipping } = payload;
+    $billingForm.style.display = isBillToShipping ? 'none' : 'block';
+  }
+
   async function handleOrderPlaced(orderData) {
     // Clear address form data
     sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
@@ -1033,6 +1034,7 @@ export default async function decorate(block) {
   events.on('cart/initialized', handleCartInitialized, { eager: true });
   events.on('checkout/initialized', handleCheckoutInitialized, { eager: true });
   events.on('checkout/updated', handleCheckoutUpdated);
+  events.on('checkout/values', handleCheckoutValues);
   events.on('order/placed', handleOrderPlaced);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dropins/storefront-account": "~1.0.7-beta2",
         "@dropins/storefront-auth": "~2.0.3",
         "@dropins/storefront-cart": "1.4.0-beta3",
-        "@dropins/storefront-checkout": "~2.0.0-beta5",
+        "@dropins/storefront-checkout": "~2.0.0-beta6",
         "@dropins/storefront-order": "~1.2.0-beta2",
         "@dropins/storefront-payment-services": "~1.0.1",
         "@dropins/storefront-pdp": "1.2.0-beta5",
@@ -1911,9 +1911,9 @@
       "integrity": "sha512-EltmYzrGQmDPKc9KjI9DsWLJ990vMAnSI6zaU0S6Eyra1arTseKqdzdI7H2utKPy1EdkjzxaFVmzYJadSxNIag=="
     },
     "node_modules/@dropins/storefront-checkout": {
-      "version": "2.0.0-beta5",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-checkout/-/storefront-checkout-2.0.0-beta5.tgz",
-      "integrity": "sha512-bH3pYdQTOSbpFfvt3hvQtkCOPS3mudI5TiETBwGT/AXlHbHpReKvjDeOzTFrREfCF7uaT9xvLmghSVYMB0xVFw=="
+      "version": "2.0.0-beta6",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-checkout/-/storefront-checkout-2.0.0-beta6.tgz",
+      "integrity": "sha512-rcynmOokq6UFLBH1IUp+CVvOe+SE40SQshV+Z/jmSEyF+Ka/nZEFuUmZcOHaePqwlCCBDSEUgjYsKSF7PDamFQ=="
     },
     "node_modules/@dropins/storefront-order": {
       "version": "1.2.0-beta2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@dropins/storefront-account": "~1.0.7-beta2",
     "@dropins/storefront-auth": "~2.0.3",
     "@dropins/storefront-cart": "1.4.0-beta3",
-    "@dropins/storefront-checkout": "~2.0.0-beta5",
+    "@dropins/storefront-checkout": "~2.0.0-beta6",
     "@dropins/storefront-order": "~1.2.0-beta2",
     "@dropins/storefront-payment-services": "~1.0.1",
     "@dropins/storefront-pdp": "1.2.0-beta5",


### PR DESCRIPTION
Fix #[USF-2451](https://github.com/adobe-commerce/storefront-checkout/pull/72)

Billing form shows when checkbox is checked after reload or sign-in

Test URLs:
- Before: https://suite-release2--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://checkout-beta6--aem-boilerplate-commerce--hlxsites.aem.live/