### PR TITLE
Reorder main initialization in `scripts.js` (#595)

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -82,9 +82,9 @@ async function loadEager(doc) {
 
   const main = doc.querySelector('main');
   if (main) {
+    await initializeCommerce();
     decorateMain(main);
     applyTemplates(doc);
-    await initializeCommerce();
     await loadCommerceEager();
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);


### PR DESCRIPTION
Fixes the racing condition in `decorateLinks`

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://hotfix-init--aem-boilerplate-commerce--hlxsites.aem.live/

