### PR TITLE
USF 2382 - In cart flavor & size editing

### DIFF
--- a/blocks/commerce-cart/commerce-cart.css
+++ b/blocks/commerce-cart/commerce-cart.css
@@ -71,6 +71,16 @@
   margin-top: var(--spacing-medium);
 }
 
+#mini-pdp-modal .mini-pdp__alert {
+  margin-top: var(--spacing-medium);
+  margin-right: var(--spacing-xxlarge);
+  margin-bottom: var(--spacing-small);
+}
+
+#mini-pdp-modal .mini-pdp__alert:empty {
+  display: none;
+}
+
 #mini-pdp-modal .mini-pdp__left-column {
   grid-column: 1 / span 4;
 }

--- a/blocks/commerce-cart/commerce-cart.css
+++ b/blocks/commerce-cart/commerce-cart.css
@@ -62,6 +62,7 @@
     width: fit-content;
 }
 
+/* Mini PDP Modal */
 #mini-pdp-modal .mini-pdp__wrapper {
   font-family: var(--type-base-font-family);
   display: grid;
@@ -74,10 +75,91 @@
   grid-column: 1 / span 4;
 }
 
-
-#mini-pdp-modal .mini-pdp__right-column { 
+#mini-pdp-modal .mini-pdp__right-column {
   grid-column: 1 / span 4;
   color: var(--color-neutral-800);
+  margin-top: var(--spacing-small);
+}
+
+#mini-pdp-modal .mini-pdp__quantity-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+  margin-bottom: var(--spacing-medium);
+}
+
+#mini-pdp-modal .mini-pdp__quantity {
+  display: grid;
+  grid-template-columns: repeat(var(--grid-1-columns), 1fr);
+}
+
+#mini-pdp-modal .mini-pdp__quantity .dropin-quantity-picker {
+  grid-column: 1 / span 2;
+}
+
+#mini-pdp-modal .mini-pdp__configuration {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+}
+
+#mini-pdp-modal .mini-pdp__header {
+  grid-column: 1 / span 4;
+  font: var(--type-headline-2-default-font);
+  letter-spacing: var(--type-headline-2-default-letter-spacing);
+  color: var(--color-neutral-900);
+  margin-bottom: 0;
+}
+
+#mini-pdp-modal .mini-pdp__header a {
+  font: var(--type-headline-2-default-font);
+  letter-spacing: var(--type-headline-2-default-letter-spacing);
+  color: inherit;
+  text-decoration: none;
+}
+
+#mini-pdp-modal .mini-pdp__price {
+  grid-column: 1 / span 4;
+  font: var(--type-body-1-default-font);
+  letter-spacing: var(--type-body-1-default-letter-spacing);
+  color: var(--color-neutral-900);
+  margin-top: var(--spacing-xsmall);
+  margin-bottom: var(--spacing-small);
+}
+
+#mini-pdp-modal .mini-pdp__price .pdp-price {
+  margin: 0;
+}
+
+#mini-pdp-modal .mini-pdp__price .dropin-price {
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+#mini-pdp-modal .mini-pdp__quantity-label {
+  font: var(--type-details-caption-1-font);
+  letter-spacing: var(--type-details-caption-1-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+#mini-pdp-modal .mini-pdp__options .dropin-product-option__label {
+  font: var(--type-body-1-strong-font);
+  letter-spacing: var(--type-body-1-strong-letter-spacing);
+  color: var(--color-neutral-800);
+}
+
+#mini-pdp-modal .mini-pdp__buttons {
+  grid-column: 1 / span 4;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+  margin-top: var(--spacing-xsmall);
+}
+
+#mini-pdp-modal .mini-pdp__buttons .dropin-button {
+  width: 100%;
 }
 
 @media (min-width: 768px) {
@@ -97,12 +179,48 @@
     flex-basis: auto;
   }
 
+  #mini-pdp-modal .mini-pdp__wrapper {
+    grid-template-columns: repeat(var(--grid-2-columns), 1fr);
+    grid-gap: var(--grid-2-gutters) var(--grid-2-gutters);
+  }
+
+  #mini-pdp-modal .mini-pdp__header {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  #mini-pdp-modal .mini-pdp__price {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    margin-top: calc(var(--spacing-xsmall) * -1);
+  }
+
   #mini-pdp-modal .mini-pdp__left-column {
     grid-column: 1 / span 6;
+    grid-row: 3;
   }
 
   #mini-pdp-modal .mini-pdp__right-column {
     grid-column: 7 / span 6;
+    grid-row: 3;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-medium);
+    padding-left: var(--spacing-medium);
+    margin-top: 0;
+  }
+
+  #mini-pdp-modal .mini-pdp__buttons {
+    grid-column: 1 / -1;
+    grid-row: 4;
+    margin-top: var(--spacing-small);
+  }
+
+  #mini-pdp-modal .mini-pdp__quantity {
+    grid-template-columns: repeat(var(--grid-2-columns), 1fr);
+  }
+
+  #mini-pdp-modal .mini-pdp__quantity .dropin-quantity-picker {
+    grid-column: 1 / span 4;
   }
 }
-

--- a/blocks/commerce-cart/commerce-cart.css
+++ b/blocks/commerce-cart/commerce-cart.css
@@ -62,6 +62,24 @@
     width: fit-content;
 }
 
+#mini-pdp-modal .mini-pdp__wrapper {
+  font-family: var(--type-base-font-family);
+  display: grid;
+  grid-template-columns: repeat(var(--grid-1-columns), 1fr);
+  grid-column-gap: var(--grid-1-gutters);
+  margin-top: var(--spacing-medium);
+}
+
+#mini-pdp-modal .mini-pdp__left-column {
+  grid-column: 1 / span 4;
+}
+
+
+#mini-pdp-modal .mini-pdp__right-column { 
+  grid-column: 1 / span 4;
+  color: var(--color-neutral-800);
+}
+
 @media (min-width: 768px) {
   .cart__wrapper {
     flex-direction: row;
@@ -77,6 +95,14 @@
   .cart__right-column {
     flex: 1;
     flex-basis: auto;
+  }
+
+  #mini-pdp-modal .mini-pdp__left-column {
+    grid-column: 1 / span 6;
+  }
+
+  #mini-pdp-modal .mini-pdp__right-column {
+    grid-column: 7 / span 6;
   }
 }
 

--- a/blocks/commerce-cart/commerce-cart.js
+++ b/blocks/commerce-cart/commerce-cart.js
@@ -108,7 +108,30 @@ export default async function decorate(block) {
       const miniPDPContent = await createMiniPDP(
         cartItem,
         (_updateData) => {
-          // Empty callback - cart refresh handled internally by mini PDP
+          // Show success message when mini-PDP updates item
+          const productName = cartItem.name
+            || cartItem.product?.name
+            || placeholders?.Global?.CartUpdatedProductName;
+          const message = placeholders?.Global?.CartUpdatedProductMessage?.replace(
+            '{product}',
+            productName,
+          );
+
+          UI.render(InLineAlert, {
+            heading: message,
+            type: 'success',
+            variant: 'primary',
+            icon: h(Icon, { source: 'CheckWithCircle' }),
+            'aria-live': 'assertive',
+            role: 'alert',
+            onDismiss: () => {
+              $notification.innerHTML = '';
+            },
+          })($notification);
+
+          setTimeout(() => {
+            $notification.innerHTML = '';
+          }, 5000);
         },
         () => {
           // Handle modal close
@@ -280,36 +303,6 @@ export default async function decorate(block) {
   events.on(
     'cart/data',
     (cartData) => {
-      const urlParams = new URLSearchParams(window.location.search);
-      const itemUid = urlParams.get('itemUid');
-
-      if (itemUid && cartData?.items) {
-        const itemExists = cartData.items.some((item) => item.uid === itemUid);
-        if (itemExists) {
-          const updatedItem = cartData.items.find((item) => item.uid === itemUid);
-          const productName = updatedItem.name
-            || updatedItem.product?.name
-            || placeholders?.Global?.CartUpdatedProductName;
-          const message = placeholders?.Global?.CartUpdatedProductMessage?.replace('{product}', productName);
-
-          UI.render(InLineAlert, {
-            heading: message,
-            type: 'success',
-            variant: 'primary',
-            icon: h(Icon, { source: 'CheckWithCircle' }),
-            'aria-live': 'assertive',
-            role: 'alert',
-            onDismiss: () => {
-              $notification.innerHTML = '';
-            },
-          })($notification);
-        }
-
-        if (window.location.search) {
-          window.history.replaceState({}, document.title, window.location.pathname);
-        }
-      }
-
       toggleEmptyCart(isCartEmpty(cartData));
 
       if (!cartViewEventPublished) {

--- a/blocks/commerce-cart/commerce-cart.js
+++ b/blocks/commerce-cart/commerce-cart.js
@@ -134,7 +134,6 @@ export default async function decorate(block) {
           }, 5000);
         },
         () => {
-          // Handle modal close
           if (currentModal) {
             currentModal.removeModal();
             currentModal = null;
@@ -145,7 +144,6 @@ export default async function decorate(block) {
       // Create and show modal
       currentModal = await createModal([miniPDPContent]);
 
-      // Set ID on the modal block for styling
       if (currentModal.block) {
         currentModal.block.setAttribute('id', 'mini-pdp-modal');
       }
@@ -157,8 +155,7 @@ export default async function decorate(block) {
       // Show error notification
       UI.render(InLineAlert, {
         heading:
-          placeholders?.Global?.ProductLoadError
-          || 'Failed to load product details',
+          placeholders?.Global?.ProductLoadError,
         type: 'error',
         variant: 'primary',
         icon: h(Icon, { source: 'AlertWithCircle' }),

--- a/blocks/commerce-cart/commerce-cart.js
+++ b/blocks/commerce-cart/commerce-cart.js
@@ -121,6 +121,12 @@ export default async function decorate(block) {
 
       // Create and show modal
       currentModal = await createModal([miniPDPContent]);
+
+      // Set ID on the modal block for styling
+      if (currentModal.block) {
+        currentModal.block.setAttribute('id', 'mini-pdp-modal');
+      }
+
       currentModal.showModal();
     } catch (error) {
       console.error('Error opening mini PDP modal:', error);

--- a/blocks/commerce-mini-cart/commerce-mini-cart.js
+++ b/blocks/commerce-mini-cart/commerce-mini-cart.js
@@ -103,7 +103,6 @@ export default async function decorate(block) {
           showMessage(message);
         },
         () => {
-          // Handle modal close
           if (currentModal) {
             currentModal.removeModal();
             currentModal = null;
@@ -113,7 +112,6 @@ export default async function decorate(block) {
 
       currentModal = await createModal([miniPDPContent]);
 
-      // Set ID on the modal block for styling
       if (currentModal.block) {
         currentModal.block.setAttribute('id', 'mini-pdp-modal');
       }
@@ -124,8 +122,7 @@ export default async function decorate(block) {
 
       // Show error message using mini-cart's message system
       showMessage(
-        placeholders?.Global?.ProductLoadError
-          || 'Failed to load product details',
+        placeholders?.Global?.ProductLoadError,
       );
     }
   }

--- a/blocks/commerce-mini-cart/commerce-mini-cart.js
+++ b/blocks/commerce-mini-cart/commerce-mini-cart.js
@@ -6,6 +6,7 @@ import {
   InLineAlert,
   Icon,
   provider as UI,
+  Button,
 } from '@dropins/tools/components.js';
 import { h } from '@dropins/tools/preact.js';
 
@@ -168,15 +169,18 @@ export default async function decorate(block) {
           const editLinkContainer = document.createElement('div');
           editLinkContainer.className = 'cart-item-edit-container';
 
-          const editButton = document.createElement('button');
-          editButton.className = 'cart-item-edit-link';
-          editButton.textContent = 'Edit';
+          const editLink = document.createElement('div');
+          editLink.className = 'cart-item-edit-link';
 
-          editButton.addEventListener('click', () => {
-            handleEditButtonClick(item);
-          });
+          UI.render(Button, {
+            children: placeholders?.Global?.CartEditButton,
+            variant: 'tertiary',
+            size: 'medium',
+            icon: h(Icon, { source: 'Edit' }),
+            onClick: () => handleEditButtonClick(item),
+          })(editLink);
 
-          editLinkContainer.appendChild(editButton);
+          editLinkContainer.appendChild(editLink);
           ctx.appendChild(editLinkContainer);
         }
       },

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.css
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.css
@@ -1,5 +1,3 @@
-/* stylelint-disable no-empty-source */
-
 /* Mini PDP Alert positioning - base styles for non-modal usage */
 .commerce-mini-pdp .mini-pdp__alert {
     margin-bottom: var(--spacing-small);

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.css
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.css
@@ -1,189 +1,32 @@
-.commerce-mini-pdp {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 0;
+/* stylelint-disable no-empty-source */
+
+/* Mini PDP Alert positioning - base styles for non-modal usage */
+.commerce-mini-pdp .mini-pdp__alert {
+    margin-bottom: var(--spacing-small);
+    margin-top: var(--spacing-small);
 }
 
-.mini-pdp__alert {
-    margin-bottom: 1rem;
+.commerce-mini-pdp .mini-pdp__alert:empty {
+    display: none;
 }
 
-.mini-pdp__wrapper {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-    align-items: start;
+/* Error state - used for fallback error display */
+.commerce-mini-pdp--error {
+    padding: var(--spacing-medium);
+    text-align: center;
 }
 
-.mini-pdp__left-column {
-    display: flex;
-    flex-direction: column;
+.mini-pdp__error h3 {
+    color: var(--color-alert-content);
+    margin-bottom: var(--spacing-small);
 }
 
-.mini-pdp__right-column {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.mini-pdp__gallery {
-    width: 100%;
-    max-width: 400px;
-}
-
-.mini-pdp__header h1 {
-    font-size: 1.5rem;
-    margin: 0 0 0.5rem 0;
-    line-height: 1.3;
-}
-
-.mini-pdp__price {
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-}
-
-.mini-pdp__options {
-    margin-bottom: 1rem;
-}
-
-.mini-pdp__quantity {
-    margin-bottom: 1.5rem;
-}
-
-.mini-pdp__actions {
-    display: flex;
-    gap: 1rem;
-    margin-top: auto;
-    padding-top: 1rem;
-}
-
-.mini-pdp__actions button {
-    flex: 1;
-    min-height: 48px;
-    border-radius: 4px;
-    font-weight: 600;
+.mini-pdp__close-button {
+    background: var(--color-button-active);
+    color: var(--color-button-content);
+    border: none;
+    padding: var(--spacing-small) var(--spacing-medium);
+    border-radius: var(--shape-border-radius-1);
     cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.mini-pdp__update-button button {
-    background-color: var(--color-brand-primary, #007bff);
-    color: white;
-    border: 2px solid var(--color-brand-primary, #007bff);
-}
-
-.mini-pdp__update-button button:hover:not(:disabled) {
-    background-color: var(--color-brand-primary-hover, #0056b3);
-    border-color: var(--color-brand-primary-hover, #0056b3);
-}
-
-.mini-pdp__update-button button:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
-.mini-pdp__cancel-button button {
-    background-color: transparent;
-    color: var(--color-text-primary, #333);
-    border: 2px solid var(--color-border-primary, #ccc);
-}
-
-.mini-pdp__cancel-button button:hover {
-    background-color: var(--color-background-secondary, #f8f9fa);
-    border-color: var(--color-border-hover, #999);
-}
-
-/* Mobile responsive design */
-@media (max-width: 768px) {
-    .mini-pdp__wrapper {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
-
-    .mini-pdp__gallery {
-        max-width: 100%;
-    }
-
-    .mini-pdp__actions {
-        flex-direction: column;
-    }
-
-    .mini-pdp__actions button {
-        width: 100%;
-    }
-}
-
-/* Small mobile */
-@media (max-width: 480px) {
-    .commerce-mini-pdp {
-        padding: 0 1rem;
-    }
-
-    .mini-pdp__wrapper {
-        gap: 1rem;
-    }
-
-    .mini-pdp__right-column {
-        gap: 0.75rem;
-    }
-
-    .mini-pdp__header h1 {
-        font-size: 1.25rem;
-    }
-
-    .mini-pdp__price {
-        font-size: 1.125rem;
-    }
-}
-
-/* Integration with existing modal styles */
-.modal-content .commerce-mini-pdp {
-    width: 100%;
-    max-width: none;
-}
-
-/* Ensure proper spacing in modal */
-.modal-content {
-    padding: 2rem;
-}
-
-@media (max-width: 768px) {
-    .modal-content {
-        padding: 1.5rem;
-    }
-}
-
-@media (max-width: 480px) {
-    .modal-content {
-        padding: 1rem;
-    }
-}
-
-/* PDP component specific adjustments for modal */
-.commerce-mini-pdp .dropin-product-gallery {
-    max-height: 400px;
-    overflow: hidden;
-}
-
-.commerce-mini-pdp .dropin-product-options {
-    max-height: 200px;
-    overflow-y: auto;
-}
-
-/* Alert styling */
-.mini-pdp__alert .dropin-inline-alert {
-    margin-bottom: 1rem;
-}
-
-.mini-pdp__alert .dropin-inline-alert--success {
-    background-color: var(--color-success-background, #d4edda);
-    border-color: var(--color-success-border, #c3e6cb);
-    color: var(--color-success-text, #155724);
-}
-
-.mini-pdp__alert .dropin-inline-alert--error {
-    background-color: var(--color-error-background, #f8d7da);
-    border-color: var(--color-error-border, #f5c6cb);
-    color: var(--color-error-text, #721c24);
+    margin-top: var(--spacing-small);
 }

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.css
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.css
@@ -1,0 +1,189 @@
+.commerce-mini-pdp {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0;
+}
+
+.mini-pdp__alert {
+    margin-bottom: 1rem;
+}
+
+.mini-pdp__wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: start;
+}
+
+.mini-pdp__left-column {
+    display: flex;
+    flex-direction: column;
+}
+
+.mini-pdp__right-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.mini-pdp__gallery {
+    width: 100%;
+    max-width: 400px;
+}
+
+.mini-pdp__header h1 {
+    font-size: 1.5rem;
+    margin: 0 0 0.5rem 0;
+    line-height: 1.3;
+}
+
+.mini-pdp__price {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.mini-pdp__options {
+    margin-bottom: 1rem;
+}
+
+.mini-pdp__quantity {
+    margin-bottom: 1.5rem;
+}
+
+.mini-pdp__actions {
+    display: flex;
+    gap: 1rem;
+    margin-top: auto;
+    padding-top: 1rem;
+}
+
+.mini-pdp__actions button {
+    flex: 1;
+    min-height: 48px;
+    border-radius: 4px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.mini-pdp__update-button button {
+    background-color: var(--color-brand-primary, #007bff);
+    color: white;
+    border: 2px solid var(--color-brand-primary, #007bff);
+}
+
+.mini-pdp__update-button button:hover:not(:disabled) {
+    background-color: var(--color-brand-primary-hover, #0056b3);
+    border-color: var(--color-brand-primary-hover, #0056b3);
+}
+
+.mini-pdp__update-button button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.mini-pdp__cancel-button button {
+    background-color: transparent;
+    color: var(--color-text-primary, #333);
+    border: 2px solid var(--color-border-primary, #ccc);
+}
+
+.mini-pdp__cancel-button button:hover {
+    background-color: var(--color-background-secondary, #f8f9fa);
+    border-color: var(--color-border-hover, #999);
+}
+
+/* Mobile responsive design */
+@media (max-width: 768px) {
+    .mini-pdp__wrapper {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .mini-pdp__gallery {
+        max-width: 100%;
+    }
+
+    .mini-pdp__actions {
+        flex-direction: column;
+    }
+
+    .mini-pdp__actions button {
+        width: 100%;
+    }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+    .commerce-mini-pdp {
+        padding: 0 1rem;
+    }
+
+    .mini-pdp__wrapper {
+        gap: 1rem;
+    }
+
+    .mini-pdp__right-column {
+        gap: 0.75rem;
+    }
+
+    .mini-pdp__header h1 {
+        font-size: 1.25rem;
+    }
+
+    .mini-pdp__price {
+        font-size: 1.125rem;
+    }
+}
+
+/* Integration with existing modal styles */
+.modal-content .commerce-mini-pdp {
+    width: 100%;
+    max-width: none;
+}
+
+/* Ensure proper spacing in modal */
+.modal-content {
+    padding: 2rem;
+}
+
+@media (max-width: 768px) {
+    .modal-content {
+        padding: 1.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .modal-content {
+        padding: 1rem;
+    }
+}
+
+/* PDP component specific adjustments for modal */
+.commerce-mini-pdp .dropin-product-gallery {
+    max-height: 400px;
+    overflow: hidden;
+}
+
+.commerce-mini-pdp .dropin-product-options {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+/* Alert styling */
+.mini-pdp__alert .dropin-inline-alert {
+    margin-bottom: 1rem;
+}
+
+.mini-pdp__alert .dropin-inline-alert--success {
+    background-color: var(--color-success-background, #d4edda);
+    border-color: var(--color-success-border, #c3e6cb);
+    color: var(--color-success-text, #155724);
+}
+
+.mini-pdp__alert .dropin-inline-alert--error {
+    background-color: var(--color-error-background, #f8d7da);
+    border-color: var(--color-error-border, #f5c6cb);
+    color: var(--color-error-text, #721c24);
+}

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.js
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.js
@@ -122,16 +122,16 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
     const fragment = document.createRange().createContextualFragment(`
       <div class="mini-pdp__wrapper">
         <div class="mini-pdp__alert"></div>
+        <div class="mini-pdp__header">
+          <a href="/products/${product.urlKey}/${product.sku}" class="quick-view__close">
+          ${product.name}
+          </a>
+        </div>
+        <div class="mini-pdp__price"></div>
         <div class="mini-pdp__left-column">
           <div class="mini-pdp__gallery"></div>
         </div>
         <div class="mini-pdp__right-column">
-          <div class="mini-pdp__header">
-            <a href="/products/${product.urlKey}/${product.sku}" class="quick-view__close">
-            ${product.name}
-            </a>
-          </div>
-          <div class="mini-pdp__price"></div>
           <div class="mini-pdp__configuration">
             <div class="mini-pdp__options"></div>
             <div class="mini-pdp__quantity-wrapper">
@@ -140,22 +140,23 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
               </div>
               <div class="mini-pdp__quantity"></div>
             </div>
-            <div class="mini-pdp__buttons">
-              <div class="mini-pdp__update-button"></div>
-              <div class="mini-pdp__cancel-button"></div>
-              <div class="mini-pdp__buttons__redirect-to-pdp">
-                <a href="/products/${product.urlKey}/${product.sku}">
-                </a>
-              </div>
-            </div>
+          </div>
+        </div>
+        <div class="mini-pdp__buttons">
+          <div class="mini-pdp__update-button"></div>
+          <div class="mini-pdp__cancel-button"></div>
+          <div class="mini-pdp__buttons__redirect-to-pdp">
+            <a href="/products/${product.urlKey}/${product.sku}">
+            </a>
           </div>
         </div>
       </div>
     `);
 
     const $alert = fragment.querySelector('.mini-pdp__alert');
-    const $gallery = fragment.querySelector('.mini-pdp__gallery');
+    const $header = fragment.querySelector('.mini-pdp__header');
     const $price = fragment.querySelector('.mini-pdp__price');
+    const $gallery = fragment.querySelector('.mini-pdp__gallery');
     const $options = fragment.querySelector('.mini-pdp__options');
     const $quantity = fragment.querySelector('.mini-pdp__quantity');
     const $updateButton = fragment.querySelector('.mini-pdp__update-button');
@@ -175,6 +176,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
     // Render components
     const [
       _galleryInstance,
+      _headerInstance,
       _priceInstance,
       _optionsInstance,
       _quantityInstance,
@@ -194,6 +196,9 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
         },
       })($gallery),
 
+      // Header - just set the content, no special rendering needed
+      Promise.resolve($header),
+
       // Price
       pdpRender.render(ProductPrice, {})($price),
 
@@ -211,7 +216,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
       UI.render(Button, {
         children: placeholders?.Global?.UpdateProductInCart || 'Update Cart',
         variant: 'primary',
-        size: 'large',
+        size: 'medium',
         onClick: async () => {
           if (isLoading) return;
 
@@ -292,7 +297,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
       UI.render(Button, {
         children: placeholders?.Global?.Cancel || 'Cancel',
         variant: 'secondary',
-        size: 'large',
+        size: 'medium',
         onClick: onClose,
       })($cancelButton),
 
@@ -300,7 +305,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
       UI.render(Button, {
         children: placeholders?.Global?.ViewAllDetails || 'View all details',
         variant: 'tertiary',
-        size: 'large',
+        size: 'medium',
         onClick: () => {
           // Close modal first
           onClose();

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.js
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.js
@@ -1,0 +1,314 @@
+import { events } from '@dropins/tools/event-bus.js';
+import { render as pdpRender } from '@dropins/storefront-pdp/render.js';
+import * as pdpApi from '@dropins/storefront-pdp/api.js';
+import { initializers } from '@dropins/tools/initializer.js';
+import { getHeaders } from '@dropins/tools/lib/aem/configs.js';
+import {
+  InLineAlert,
+  Icon,
+  Button,
+  Image,
+  provider as UI,
+} from '@dropins/tools/components.js';
+import * as Cart from '@dropins/storefront-cart/api.js';
+
+// PDP Containers for Mini PDP
+import ProductPrice from '@dropins/storefront-pdp/containers/ProductPrice.js';
+import ProductOptions from '@dropins/storefront-pdp/containers/ProductOptions.js';
+import ProductQuantity from '@dropins/storefront-pdp/containers/ProductQuantity.js';
+
+// Initializers
+import '../../scripts/initializers/cart.js';
+
+import {
+  fetchPlaceholders,
+  commerceEndpointWithQueryParams,
+} from '../../scripts/commerce.js';
+
+/**
+ * Creates a mini PDP component for modal display
+ * @param {Object} cartItem - The cart item to edit
+ * @param {Function} onUpdate - Callback when item is updated
+ * @param {Function} onClose - Callback when modal should close
+ * @returns {Promise<HTMLElement>} The mini PDP element
+ */
+
+// Helper functions for alerts
+function showAlert(type, message, $alert) {
+  const existingAlert = $alert.querySelector('.dropin-alert');
+  if (existingAlert) {
+    existingAlert.remove();
+  }
+
+  const iconSource = type === 'success' ? 'CheckWithCircle' : 'AlertWithCircle';
+
+  return UI.render(InLineAlert, {
+    heading: message,
+    type,
+    variant: 'primary',
+    icon: Icon({ source: iconSource }),
+    'aria-live': 'assertive',
+    role: 'alert',
+    onDismiss: () => {
+      const alert = $alert.querySelector('.dropin-alert');
+      if (alert) alert.remove();
+    },
+  })($alert);
+}
+
+export default async function createMiniPDP(cartItem, onUpdate, onClose) {
+  const placeholders = await fetchPlaceholders();
+
+  // Initialize PDP API with the product SKU
+  const sku = cartItem.topLevelSku || cartItem.sku;
+
+  const langDefinitions = {
+    default: placeholders,
+  };
+
+  const models = {
+    ProductDetails: {
+      fallbackData: (parent, refinedData) => ({
+        ...parent,
+        ...refinedData,
+        images:
+          refinedData.images?.length > 0 ? refinedData.images : parent.images,
+        description:
+          refinedData.description && refinedData.description !== ''
+            ? refinedData.description
+            : parent.description,
+      }),
+    },
+  };
+
+  try {
+    // Configure PDP API endpoint and headers (same as main PDP initializer)
+    pdpApi.setEndpoint(await commerceEndpointWithQueryParams());
+    pdpApi.setFetchGraphQlHeaders((prev) => ({ ...prev, ...getHeaders('cs') }));
+
+    // Fetch product data first
+    const productData = await pdpApi.fetchProductData(sku, {
+      skipTransform: true,
+    });
+
+    if (!productData?.sku) {
+      throw new Error('Product data not available');
+    }
+
+    // Update models with the fetched product data
+    models.ProductDetails.initialData = { ...productData };
+
+    // Initialize PDP API
+    await initializers.mountImmediately(pdpApi.initialize, {
+      sku,
+      langDefinitions,
+      models,
+      acdl: false,
+      persistURLParams: false,
+    });
+
+    // Get product data from PDP API
+    const product = events.lastPayload('pdp/data');
+
+    if (!product) {
+      throw new Error('Product data not available');
+    }
+
+    // Create the mini PDP container
+    const miniPDPContainer = document.createElement('div');
+    miniPDPContainer.className = 'commerce-mini-pdp';
+
+    // Layout structure
+    const fragment = document.createRange().createContextualFragment(`
+      <div class="mini-pdp__wrapper">
+        <div class="mini-pdp__alert"></div>
+        <div class="mini-pdp__left-column">
+          <div class="mini-pdp__gallery"></div>
+        </div>
+        <div class="mini-pdp__right-column">
+          <div class="mini-pdp__header">
+            <h3>${product.name}</h3>
+          </div>
+          <div class="mini-pdp__price"></div>
+          <div class="mini-pdp__options"></div>
+          <div class="mini-pdp__quantity-wrapper">
+            <div class="mini-pdp__quantity-label">Quantity</div>
+            <div class="mini-pdp__quantity"></div>
+          </div>
+          <div class="mini-pdp__actions">
+            <div class="mini-pdp__update-button"></div>
+            <div class="mini-pdp__cancel-button"></div>
+          </div>
+        </div>
+      </div>
+    `);
+
+    const $alert = fragment.querySelector('.mini-pdp__alert');
+    const $gallery = fragment.querySelector('.mini-pdp__gallery');
+    const $price = fragment.querySelector('.mini-pdp__price');
+    const $options = fragment.querySelector('.mini-pdp__options');
+    const $quantity = fragment.querySelector('.mini-pdp__quantity');
+    const $updateButton = fragment.querySelector('.mini-pdp__update-button');
+    const $cancelButton = fragment.querySelector('.mini-pdp__cancel-button');
+
+    miniPDPContainer.appendChild(fragment);
+
+    // State management
+    let isLoading = false;
+    let inlineAlert = null;
+
+    // Render components
+    const [
+      _galleryInstance,
+      _priceInstance,
+      _optionsInstance,
+      _quantityInstance,
+      updateButton,
+      _cancelButton,
+    ] = await Promise.all([
+      // Gallery - Simple image for now
+      UI.render(Image, {
+        src: product.images?.[0]?.url || cartItem.image,
+        alt: product.images?.[0]?.label || product.name,
+        width: 400,
+        height: 400,
+        imageParams: {
+          width: 400,
+          height: 400,
+        },
+      })($gallery),
+
+      // Price
+      pdpRender.render(ProductPrice, {})($price),
+
+      // Options
+      pdpRender.render(ProductOptions, {
+        hideSelectedValue: false,
+      })($options),
+
+      // Quantity
+      pdpRender.render(ProductQuantity, {
+        initialValue: cartItem.quantity || 1,
+      })($quantity),
+
+      // Update button
+      UI.render(Button, {
+        children: placeholders?.Global?.UpdateProductInCart || 'Update Cart',
+        variant: 'primary',
+        size: 'large',
+        onClick: async () => {
+          if (isLoading) return;
+
+          try {
+            isLoading = true;
+            updateButton.setProps((prev) => ({
+              ...prev,
+              children: placeholders?.Global?.Updating || 'Updating...',
+              disabled: true,
+            }));
+
+            // Get current product configuration
+            const values = pdpApi.getProductConfigurationValues();
+            const valid = pdpApi.isProductConfigurationValid();
+
+            if (!valid) {
+              throw new Error('Please select all required options');
+            }
+
+            // Update cart item with new configuration
+            const updateData = {
+              uid: cartItem.uid,
+              quantity: values.quantity || cartItem.quantity,
+              ...(values.optionsUIDs
+                && values.optionsUIDs.length > 0 && {
+                optionsUIDs: values.optionsUIDs,
+              }),
+            };
+
+            const updateResponse = await Cart.updateProductsFromCart([
+              updateData,
+            ]);
+
+            // Trigger cart refresh to ensure UI updates
+            events.emit('cart/updated', updateResponse);
+
+            // Show success message
+            inlineAlert?.remove();
+            inlineAlert = showAlert(
+              'success',
+              placeholders?.Global?.CartUpdatedProductMessage?.replace(
+                '{product}',
+                product.name,
+              ) || 'Product updated successfully',
+              $alert,
+            );
+
+            // Notify parent component
+            if (onUpdate) {
+              onUpdate(updateData);
+            }
+
+            // Close modal after short delay
+            setTimeout(() => {
+              onClose();
+            }, 1000);
+          } catch (error) {
+            inlineAlert?.remove();
+            inlineAlert = showAlert(
+              'error',
+              error.message || 'Failed to update product',
+              $alert,
+            );
+          } finally {
+            isLoading = false;
+            updateButton.setProps((prev) => ({
+              ...prev,
+              children:
+                placeholders?.Global?.UpdateProductInCart || 'Update Cart',
+              disabled: false,
+            }));
+          }
+        },
+        disabled: isLoading,
+      })($updateButton),
+
+      // Cancel button
+      UI.render(Button, {
+        children: placeholders?.Global?.Cancel || 'Cancel',
+        variant: 'secondary',
+        size: 'large',
+        onClick: onClose,
+      })($cancelButton),
+    ]);
+
+    // Handle PDP validation events
+    events.on(
+      'pdp/valid',
+      (valid) => {
+        updateButton.setProps((prev) => ({
+          ...prev,
+          disabled: !valid || isLoading,
+        }));
+      },
+      { eager: true },
+    );
+
+    return miniPDPContainer;
+  } catch (error) {
+    // Create error container
+    const errorContainer = document.createElement('div');
+    errorContainer.className = 'commerce-mini-pdp commerce-mini-pdp--error';
+    errorContainer.innerHTML = `
+      <div class="mini-pdp__error">
+        <h3>Error</h3>
+        <p>${error.message || 'Failed to load product details'}</p>
+        <button onclick="arguments[0]()" class="mini-pdp__close-button">Close</button>
+      </div>
+    `;
+
+    const closeButton = errorContainer.querySelector('.mini-pdp__close-button');
+    closeButton.onclick = onClose;
+
+    return errorContainer;
+  }
+}

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.js
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.js
@@ -163,6 +163,11 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
 
     miniPDPContainer.appendChild(fragment);
 
+    // Get the redirect button after fragment is appended otherwise it will be null
+    const $redirectButton = miniPDPContainer.querySelector(
+      '.mini-pdp__buttons__redirect-to-pdp',
+    );
+
     // State management
     let isLoading = false;
     let inlineAlert = null;
@@ -175,6 +180,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
       _quantityInstance,
       updateButton,
       _cancelButton,
+      _viewDetailsButton,
     ] = await Promise.all([
       // Gallery - Simple image for now
       UI.render(Image, {
@@ -289,6 +295,19 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
         size: 'large',
         onClick: onClose,
       })($cancelButton),
+
+      // View all details button
+      UI.render(Button, {
+        children: placeholders?.Global?.ViewAllDetails || 'View all details',
+        variant: 'tertiary',
+        size: 'large',
+        onClick: () => {
+          // Close modal first
+          onClose();
+          // Navigate to full PDP page
+          window.location.href = `/products/${product.urlKey}/${product.sku}`;
+        },
+      })($redirectButton),
     ]);
 
     // Handle PDP validation events

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.js
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.js
@@ -114,7 +114,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
             <div class="mini-pdp__options"></div>
             <div class="mini-pdp__quantity-wrapper">
               <div class="mini-pdp__quantity-label">
-                Quantity
+                ${placeholders?.Global?.quantityLabel}
               </div>
               <div class="mini-pdp__quantity"></div>
             </div>

--- a/blocks/commerce-mini-pdp/commerce-mini-pdp.js
+++ b/blocks/commerce-mini-pdp/commerce-mini-pdp.js
@@ -127,17 +127,27 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
         </div>
         <div class="mini-pdp__right-column">
           <div class="mini-pdp__header">
-            <h3>${product.name}</h3>
+            <a href="/products/${product.urlKey}/${product.sku}" class="quick-view__close">
+            ${product.name}
+            </a>
           </div>
           <div class="mini-pdp__price"></div>
-          <div class="mini-pdp__options"></div>
-          <div class="mini-pdp__quantity-wrapper">
-            <div class="mini-pdp__quantity-label">Quantity</div>
-            <div class="mini-pdp__quantity"></div>
-          </div>
-          <div class="mini-pdp__actions">
-            <div class="mini-pdp__update-button"></div>
-            <div class="mini-pdp__cancel-button"></div>
+          <div class="mini-pdp__configuration">
+            <div class="mini-pdp__options"></div>
+            <div class="mini-pdp__quantity-wrapper">
+              <div class="mini-pdp__quantity-label">
+                Quantity
+              </div>
+              <div class="mini-pdp__quantity"></div>
+            </div>
+            <div class="mini-pdp__buttons">
+              <div class="mini-pdp__update-button"></div>
+              <div class="mini-pdp__cancel-button"></div>
+              <div class="mini-pdp__buttons__redirect-to-pdp">
+                <a href="/products/${product.urlKey}/${product.sku}">
+                </a>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -234,14 +244,14 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
 
             // Show success message
             inlineAlert?.remove();
-            inlineAlert = showAlert(
-              'success',
-              placeholders?.Global?.CartUpdatedProductMessage?.replace(
-                '{product}',
-                product.name,
-              ) || 'Product updated successfully',
-              $alert,
-            );
+            // inlineAlert = showAlert(
+            //   'success',
+            //   placeholders?.Global?.CartUpdatedProductMessage?.replace(
+            //     '{product}',
+            //     product.name,
+            //   ) || 'Product updated successfully',
+            //   $alert,
+            // );
 
             // Notify parent component
             if (onUpdate) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix Ticket: https://jira.corp.adobe.com/browse/USF-2382

## Overview

This PR enhances the cart and mini-cart user experience by implementing in-place product editing through a modal interface. The key improvement replaces the previous redirect-to-PDP workflow with a contextual mini-PDP modal that opens directly from cart edit buttons, allowing users to modify product configurations without leaving their current page. The implementation includes comprehensive success messaging that appears in both cart locations simultaneously, auto-dismissing notifications for better UX, and proper internationalization support. Additionally, the PR introduces configuration-based edit button visibility, where main cart shows edit buttons by default while mini-cart requires explicit configuration, ensuring flexible deployment options across different commerce implementations.


## Key Features

### Mini-PDP Modal Integration
- **Mini-cart now opens mini-PDP modal** instead of redirecting to full PDP when clicking "Edit"
- Consistent behavior between main cart and mini-cart edit functionality
- Modal opens with current cart item's selected options and quantity already configured
- Modal includes product configuration options, quantity selection, and price display
- Multiple ways to close modal without making changes (cancel button, close button)
- View all details button redirects users to full PDP page
### Configuration-Based Edit Button Display
- Edit button shows by default in main cart for configurable products
- Edit button does NOT show by default in mini-cart
### Enhanced Success Message System
- **Auto-dismissal**: Success messages automatically disappear after 5 seconds (cart) / 3 seconds (mini-cart)
- **Dual messaging**: Product updates show success messages in both main cart page and mini-cart simultaneously
- **Manual dismiss**: Users can manually close messages before auto-timeout
- **Loading states**: Update button shows "Updating..." text and disabled state during API calls

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://USF-2382--aem-boilerplate--adobe.aem.live/
https://USF-2382--aem-boilerplate--adobe.aem.live/cart
