### PR TITLE
chore: adds carousel and cards list blocks

### DIFF
--- a/blocks/cards-list/cards-list.css
+++ b/blocks/cards-list/cards-list.css
@@ -1,0 +1,70 @@
+.cards-list {
+    display: flex;
+    flex-flow: column wrap;
+}
+
+.cards-list p {
+    margin: 0;
+}
+
+.cards-list > div {
+    flex-direction: column;
+    border-radius: var(--shape-border-radius-2);
+    background-color: var(--color-neutral-50);
+}
+
+.card-item {
+    position: relative;
+    padding: 0 0 var(--spacing-xbig);
+}
+
+.cards-list > div h3 {
+    font-weight: bold;
+    color: var(--color-neutral-900);
+    line-height: 1em;
+    display: block;
+    width: 100%;
+    padding-bottom: var(--spacing-xsmall);
+}
+
+.cards-list .desc {
+    margin-top: var(--spacing-small);
+    font: var(--type-body-1-strong-font);
+    letter-spacing: var(--type-body-1-strong-letter-spacing);
+    color: var(--color-neutral-900);
+}
+
+.cards-list > div img {
+    display: block;
+    width: 100%;
+    object-fit: cover;
+    object-position: top;
+    height: calc(300px + (650 - 300) * ((100vw - 320px) / (1920 - 320)));
+    max-height: 650px;
+}
+
+.cards-list > div h4 {
+    padding: calc(12px + (20 - 12) * ((100vw - 320px) / (1920 - 320))) 0;
+    font-weight: 500;
+    padding-bottom: 0;
+}
+
+@media (min-width: 768px) {
+    .cards-list {
+        flex-direction: row;
+    }
+
+    .cards-list-container .cards-list-wrapper {
+        padding: 0;
+    }
+
+    .card-item {
+        padding-right: var(--spacing-medium);
+        flex: 1 1 calc(50% - var(--spacing-medium));
+    }
+
+    .card-item:nth-child(2) {
+        padding-left: var(--spacing-small);
+        padding-right: 0;
+    }
+}

--- a/blocks/cards-list/cards-list.js
+++ b/blocks/cards-list/cards-list.js
@@ -1,0 +1,20 @@
+export default function decorate(block) {
+  const directChildren = block.querySelectorAll(':scope > div');
+
+  directChildren.forEach((child) => {
+    child.classList.add('card-item');
+    const secondDiv = child.querySelectorAll(':scope > div')[1];
+
+    if (secondDiv) {
+      const pTag = secondDiv.querySelector('p');
+      if (pTag) {
+        pTag.classList.add('desc');
+      }
+    }
+  });
+
+  const links = block.querySelectorAll('a');
+  links.forEach((link) => {
+    link.classList.add('button', 'alt');
+  });
+}

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,0 +1,172 @@
+main > .section .carousel-wrapper {
+    max-width: unset;
+    padding: 0;
+}
+
+.carousel-container h2, .carousel-container p {
+    padding: 0 var(--spacing-xxlarge);
+    text-align: center;
+}
+
+.carousel .carousel-slides-container {
+    position: relative;
+}
+
+.carousel .carousel-slides,
+.carousel .carousel-slide-indicators {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.carousel .carousel-slides {
+    display: flex;
+    scroll-behavior: smooth;
+    scroll-snap-type: x mandatory;
+    overflow: scroll clip;
+    height: 40vw;
+}
+
+.carousel .carousel-slides::-webkit-scrollbar {
+    display: none;
+}
+
+.carousel .carousel-slide {
+    flex: 0 0 100%;
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    position: relative;
+    width: 100%;
+    min-height: min(50vw, calc(100dvh - var(--header-height)));
+}
+
+.carousel .carousel-slide:has(.carousel-slide-content[data-align='center']) {
+    align-items: center;
+}
+
+.carousel .carousel-slide:has(.carousel-slide-content[data-align='right']) {
+    align-items: flex-end;
+}
+
+.carousel .carousel-slide .carousel-slide-image picture {
+    position: absolute;
+    inset: 0;
+}
+
+.carousel .carousel-slide .carousel-slide-image picture > img {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+}
+
+.carousel .carousel-slide .carousel-slide-content {
+    z-index: 1;
+    margin: 68px;
+    padding: var(--spacing-small);
+    color: white;
+    background-color: rgb(19 19 19 / 75%);
+    position: relative;
+    width: var(--slide-content-width, auto);
+}
+
+.carousel nav {
+    position: relative;
+}
+
+.carousel .carousel-slide-indicators {
+    position: absolute;
+    bottom: var(--spacing-small);
+    text-align: center;
+    font-size: .25em;
+    font-weight: bold;
+    color: transparent;
+    z-index: 2;
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+    display: flex;
+    padding: 0;
+    line-height: 0;
+}
+
+.carousel .carousel-slide-indicator {
+    display: inline-block;
+    margin: 0 var(--spacing-xsmall) 0 var(--spacing-xxsmall);
+    border-radius: var(--shape-border-radius-2);
+}
+
+.carousel .carousel-slide-indicator button {
+    text-indent: -9999px;
+    width: 8px;
+    height: 8px;
+    outline: 0;
+    border: 0 none;
+    border-radius: 50%;
+    text-decoration: none;
+    background-color: var(--color-neutral-400);
+    margin: 0;
+    padding: 0;
+    transition: background-color 0.2s;
+}
+
+.carousel .carousel-slide-indicator button:disabled,
+.carousel .carousel-slide-indicator button:hover,
+.carousel .carousel-slide-indicator button:focus-visible {
+    background-color: var(--color-neutral-700);
+}
+
+.carousel .carousel-navigation-buttons {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 12px;
+    right: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 1;
+}
+
+
+.carousel .carousel-navigation-buttons button:hover,
+.carousel .carousel-navigation-buttons button:focus-visible {
+    background-color: rgb(19 19 19 / 75%);
+}
+
+.carousel .carousel-navigation-buttons button::after {
+    display: block;
+    content: '';
+    border-bottom: 0;
+    border-left: 0;
+    height: 12px;
+    width: 12px;
+    position: absolute;
+    top: 50%;
+    left: calc(50% + 2px);
+    transform: translate(-50%, -50%) rotate(-135deg);
+}
+
+.carousel .carousel-navigation-buttons button.slide-next::after {
+    transform: translate(-50%, -50%) rotate(45deg);
+    left: calc(50% - 2px);
+}
+
+@media (min-width: 600px) {
+    .carousel .carousel-navigation-buttons {
+        left: 24px;
+        right: 24px;
+    }
+
+    .carousel .carousel-slide .carousel-slide-content {
+        --slide-content-width: calc((100% - 184px) / 2);
+
+        margin: 92px;
+    }
+
+    .carousel .carousel-slide .carousel-slide-content[data-align='justify'] {
+        --slide-content-width: auto;
+    }
+}

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -1,0 +1,170 @@
+import { fetchPlaceholders } from '../../scripts/commerce.js';
+
+function updateActiveSlide(slide) {
+  const block = slide.closest('.carousel');
+  const slideIndex = parseInt(slide.dataset.slideIndex, 10);
+  block.dataset.activeSlide = slideIndex;
+
+  const slides = block.querySelectorAll('.carousel-slide');
+
+  slides.forEach((aSlide, idx) => {
+    aSlide.setAttribute('aria-hidden', idx !== slideIndex);
+    aSlide.querySelectorAll('a').forEach((link) => {
+      if (idx !== slideIndex) {
+        link.setAttribute('tabindex', '-1');
+      } else {
+        link.removeAttribute('tabindex');
+      }
+    });
+  });
+
+  const indicators = block.querySelectorAll('.carousel-slide-indicator');
+  indicators.forEach((indicator, idx) => {
+    if (idx !== slideIndex) {
+      indicator.querySelector('button').removeAttribute('disabled');
+    } else {
+      indicator.querySelector('button').setAttribute('disabled', 'true');
+    }
+  });
+}
+
+function showSlide(block, slideIndex = 0) {
+  const slides = block.querySelectorAll('.carousel-slide');
+  let realSlideIndex = slideIndex < 0 ? slides.length - 1 : slideIndex;
+  if (slideIndex >= slides.length) realSlideIndex = 0;
+  const activeSlide = slides[realSlideIndex];
+
+  activeSlide
+    .querySelectorAll('a')
+    .forEach((link) => link.removeAttribute('tabindex'));
+  block.querySelector('.carousel-slides').scrollTo({
+    top: 0,
+    left: activeSlide.offsetLeft,
+    behavior: 'smooth',
+  });
+}
+
+function bindEvents(block) {
+  const slideIndicators = block.querySelector('.carousel-slide-indicators');
+  if (!slideIndicators) return;
+
+  slideIndicators.querySelectorAll('button').forEach((button) => {
+    button.addEventListener('click', (e) => {
+      const slideIndicator = e.currentTarget.parentElement;
+      showSlide(block, parseInt(slideIndicator.dataset.targetSlide, 10));
+    });
+  });
+
+  const slideObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) updateActiveSlide(entry.target);
+      });
+    },
+    { threshold: 0.5 },
+  );
+  block.querySelectorAll('.carousel-slide').forEach((slide) => {
+    slideObserver.observe(slide);
+  });
+}
+
+function startAutoplay(block, interval = 6000) {
+  const slides = block.querySelectorAll('.carousel-slide');
+
+  if (slides.length < 2) return;
+  let currentIndex = parseInt(block.dataset.activeSlide || '0', 10);
+  setInterval(() => {
+    const nextIndex = (currentIndex + 1) % slides.length;
+    showSlide(block, nextIndex);
+    currentIndex = nextIndex;
+  }, interval);
+}
+
+function createSlide(row, slideIndex, carouselId) {
+  const slide = document.createElement('li');
+  slide.dataset.slideIndex = slideIndex;
+  slide.setAttribute('id', `carousel-${carouselId}-slide-${slideIndex}`);
+  slide.classList.add('carousel-slide');
+
+  row.querySelectorAll(':scope > div').forEach((column, colIdx) => {
+    column.classList.add(
+      `carousel-slide-${colIdx === 0 ? 'image' : 'content'}`,
+    );
+    slide.append(column);
+  });
+
+  const labeledBy = slide.querySelector('h1, h2, h3, h4, h5, h6');
+  if (labeledBy) {
+    slide.setAttribute('aria-labelledby', labeledBy.getAttribute('id'));
+  }
+
+  return slide;
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+let carouselId = 0;
+export default async function decorate(block) {
+  carouselId += 1;
+  block.setAttribute('id', `carousel-${carouselId}`);
+  const rows = Array.from(block.querySelectorAll(':scope > div'));
+  const isSingleSlide = rows.length < 2;
+
+  const placeholders = await fetchPlaceholders();
+
+  block.setAttribute('role', 'region');
+  block.setAttribute(
+    'aria-roledescription',
+    placeholders.carousel || 'Carousel',
+  );
+
+  const container = document.createElement('div');
+  container.classList.add('carousel-slides-container');
+
+  const slidesWrapper = document.createElement('ul');
+  slidesWrapper.classList.add('carousel-slides');
+  block.prepend(slidesWrapper);
+
+  let slideIndicators;
+  if (!isSingleSlide) {
+    const slideIndicatorsNav = document.createElement('nav');
+    slideIndicatorsNav.setAttribute(
+      'aria-label',
+      placeholders.carouselSlideControls || 'Carousel Slide Controls',
+    );
+    slideIndicators = document.createElement('ol');
+    slideIndicators.classList.add('carousel-slide-indicators');
+    slideIndicatorsNav.append(slideIndicators);
+    block.append(slideIndicatorsNav);
+  }
+
+  shuffleArray(rows);
+
+  rows.forEach((row, idx) => {
+    const slide = createSlide(row, idx, carouselId);
+    slidesWrapper.append(slide);
+
+    if (slideIndicators) {
+      const indicator = document.createElement('li');
+      indicator.classList.add('carousel-slide-indicator');
+      indicator.dataset.targetSlide = idx;
+      indicator.innerHTML = `<button type="button" aria-label="${
+        placeholders.showSlide || 'Show Slide'
+      } ${idx + 1} ${placeholders.of || 'of'} ${rows.length}"></button>`;
+      slideIndicators.append(indicator);
+    }
+    row.remove();
+  });
+
+  container.append(slidesWrapper);
+  block.prepend(container);
+  if (!isSingleSlide) {
+    bindEvents(block);
+    startAutoplay(block);
+  }
+}


### PR DESCRIPTION
The "adobe store" demo theme uses carousel and cards list, so adding these blocks in support of content-based themes.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://carouselcardslist--aem-boilerplate-commerce--hlxsites.aem.live/
