### PR TITLE
chore: improvements from sf-builder for ue compat

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,0 +1,61 @@
+.accordion details {
+	border: 1px solid #dadada;
+  }
+
+  /* stylelint-disable-next-line no-descending-specificity */
+  .accordion details + details {
+	margin-top: 24px;
+  }
+
+  .accordion details p {
+	margin-bottom: 0.8em;
+  }
+
+  .accordion details summary {
+	position: relative;
+	padding: 0 16px;
+	padding-right: 46px;
+	cursor: pointer;
+	list-style: none;
+	overflow: auto;
+	transition: background-color 0.2s;
+  }
+
+  .accordion details[open] summary {
+	background-color: var(--light-color);
+  }
+
+  .accordion details summary:focus,
+  .accordion details summary:hover {
+	background-color: var(--light-color);
+  }
+
+  .accordion details summary::-webkit-details-marker {
+	display: none;
+  }
+
+  .accordion details summary::after {
+	content: '';
+	position: absolute;
+	top: 50%;
+	right: 18px;
+	transform: translateY(-50%) rotate(135deg);
+	width: 6px;
+	height: 6px;
+	border: 2px solid;
+	border-width: 2px 2px 0 0;
+	transition: transform 0.2s;
+  }
+
+  .accordion details[open] summary::after {
+	transform: translateY(-50%) rotate(-45deg);
+  }
+
+  .accordion details .accordion-item-body {
+	padding: 0 16px;
+  }
+
+  .accordion details[open] .accordion-item-body {
+	border-top: 1px solid #dadada;
+	background-color: var(--background-color);
+  }

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,61 +1,61 @@
 .accordion details {
-	border: 1px solid #dadada;
-  }
+    border: 1px solid #dadada;
+}
 
-  /* stylelint-disable-next-line no-descending-specificity */
-  .accordion details + details {
-	margin-top: 24px;
-  }
+/* stylelint-disable-next-line no-descending-specificity */
+.accordion details + details {
+    margin-top: 24px;
+}
 
-  .accordion details p {
-	margin-bottom: 0.8em;
-  }
+.accordion details p {
+    margin-bottom: 0.8em;
+}
 
-  .accordion details summary {
-	position: relative;
-	padding: 0 16px;
-	padding-right: 46px;
-	cursor: pointer;
-	list-style: none;
-	overflow: auto;
-	transition: background-color 0.2s;
-  }
+.accordion details summary {
+    position: relative;
+    padding: 0 16px;
+    padding-right: 46px;
+    cursor: pointer;
+    list-style: none;
+    overflow: auto;
+    transition: background-color 0.2s;
+}
 
-  .accordion details[open] summary {
-	background-color: var(--light-color);
-  }
+.accordion details[open] summary {
+    background-color: var(--light-color);
+}
 
-  .accordion details summary:focus,
-  .accordion details summary:hover {
-	background-color: var(--light-color);
-  }
+.accordion details summary:focus,
+.accordion details summary:hover {
+    background-color: var(--light-color);
+}
 
-  .accordion details summary::-webkit-details-marker {
-	display: none;
-  }
+.accordion details summary::-webkit-details-marker {
+    display: none;
+}
 
-  .accordion details summary::after {
-	content: '';
-	position: absolute;
-	top: 50%;
-	right: 18px;
-	transform: translateY(-50%) rotate(135deg);
-	width: 6px;
-	height: 6px;
-	border: 2px solid;
-	border-width: 2px 2px 0 0;
-	transition: transform 0.2s;
-  }
+.accordion details summary::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 18px;
+    transform: translateY(-50%) rotate(135deg);
+    width: 6px;
+    height: 6px;
+    border: 2px solid;
+    border-width: 2px 2px 0 0;
+    transition: transform 0.2s;
+}
 
-  .accordion details[open] summary::after {
-	transform: translateY(-50%) rotate(-45deg);
-  }
+.accordion details[open] summary::after {
+    transform: translateY(-50%) rotate(-45deg);
+}
 
-  .accordion details .accordion-item-body {
-	padding: 0 16px;
-  }
+.accordion details .accordion-item-body {
+    padding: 0 16px;
+}
 
-  .accordion details[open] .accordion-item-body {
-	border-top: 1px solid #dadada;
-	background-color: var(--background-color);
-  }
+.accordion details[open] .accordion-item-body {
+    border-top: 1px solid #dadada;
+    background-color: var(--background-color);
+}

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,0 +1,23 @@
+/*
+ * Accordion Block
+ * Recreate an accordion
+ * https://www.hlx.live/developer/block-collection/accordion
+ */
+
+export default function decorate(block) {
+  [...block.children].forEach((row) => {
+    // decorate accordion item label
+    const label = row.children[0];
+    const summary = document.createElement('summary');
+    summary.className = 'accordion-item-label';
+    summary.append(...label.childNodes);
+    // decorate accordion item body
+    const body = row.children[1];
+    body.className = 'accordion-item-body';
+    // decorate accordion item
+    const details = document.createElement('details');
+    details.className = 'accordion-item';
+    details.append(summary, body);
+    row.replaceWith(details);
+  });
+}

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -13,6 +13,5 @@ export default function decorate(block) {
     ul.append(li);
   });
   ul.querySelectorAll('picture > img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
-  block.textContent = '';
-  block.append(ul);
+  block.replaceChildren(ul);
 }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -297,9 +297,9 @@ function createOptimizedPicture(
   eager = false,
   breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }],
 ) {
-  const url = new URL(src, window.location.href);
+  const url = !src.startsWith('http') ? new URL(src, window.location.href) : new URL(src);
   const picture = document.createElement('picture');
-  const { pathname } = url;
+  const { origin, pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);
 
   // webp
@@ -307,7 +307,7 @@ function createOptimizedPicture(
     const source = document.createElement('source');
     if (br.media) source.setAttribute('media', br.media);
     source.setAttribute('type', 'image/webp');
-    source.setAttribute('srcset', `${pathname}?width=${br.width}&format=webply&optimize=medium`);
+    source.setAttribute('srcset', `${origin}${pathname}?width=${br.width}&format=webply&optimize=medium`);
     picture.appendChild(source);
   });
 
@@ -316,14 +316,14 @@ function createOptimizedPicture(
     if (i < breakpoints.length - 1) {
       const source = document.createElement('source');
       if (br.media) source.setAttribute('media', br.media);
-      source.setAttribute('srcset', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      source.setAttribute('srcset', `${origin}${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
       picture.appendChild(source);
     } else {
       const img = document.createElement('img');
       img.setAttribute('loading', eager ? 'eager' : 'lazy');
       img.setAttribute('alt', alt);
       picture.appendChild(img);
-      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      img.setAttribute('src', `${origin}${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
     }
   });
 

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -297,9 +297,9 @@ function createOptimizedPicture(
   eager = false,
   breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }],
 ) {
-  const url = !src.startsWith('http') ? new URL(src, window.location.href) : new URL(src);
+  const url = new URL(src, window.location.href);
   const picture = document.createElement('picture');
-  const { origin, pathname } = url;
+  const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);
 
   // webp
@@ -307,7 +307,7 @@ function createOptimizedPicture(
     const source = document.createElement('source');
     if (br.media) source.setAttribute('media', br.media);
     source.setAttribute('type', 'image/webp');
-    source.setAttribute('srcset', `${origin}${pathname}?width=${br.width}&format=webply&optimize=medium`);
+    source.setAttribute('srcset', `${pathname}?width=${br.width}&format=webply&optimize=medium`);
     picture.appendChild(source);
   });
 
@@ -316,14 +316,14 @@ function createOptimizedPicture(
     if (i < breakpoints.length - 1) {
       const source = document.createElement('source');
       if (br.media) source.setAttribute('media', br.media);
-      source.setAttribute('srcset', `${origin}${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      source.setAttribute('srcset', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
       picture.appendChild(source);
     } else {
       const img = document.createElement('img');
       img.setAttribute('loading', eager ? 'eager' : 'lazy');
       img.setAttribute('alt', alt);
       picture.appendChild(img);
-      img.setAttribute('src', `${origin}${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
     }
   });
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -138,7 +138,7 @@
 }
 
 html, body {
-  height: 100%;
+  min-height: 100%;
 }
 
 html {


### PR DESCRIPTION
Adds some changes that were made in `sf-builder`. The `sf-builder` branch is not being merged, as UE integration is, for the time being, to be a manual step for merchants and developers. They will have to clone the boilerplate, and then apply changes from [sf-builder](https://github.com/hlxsites/aem-boilerplate-commerce/pull/421/files), or documented changes from https://main--docket--da-pilot.aem.live/developers/guides/setup-universal-editor.

In that case, to minimize the amount of changes, I am adding some minor patches to files in the boilerplate that were necessary but should have no functional impact.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://uesupport--aem-boilerplate-commerce--hlxsites.aem.live/
