### PR TITLE
LYNX-920: Headers for personalization

### DIFF
--- a/scripts/initializers/personalization.js
+++ b/scripts/initializers/personalization.js
@@ -5,5 +5,5 @@ import { initializeDropin } from './index.js';
 
 await initializeDropin(async () => {
   setFetchGraphQlHeaders((prev) => ({ ...prev, ...getHeaders('cart') }));
-  initializers.mountImmediately(initialize, {});
+  return initializers.mountImmediately(initialize, {});
 })();


### PR DESCRIPTION
The personalization data request is based on the cart id/data, so the same headers as for cart requests have to be passed

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://headers-for-personalization--aem-boilerplate-commerce--hlxsites.aem.live/
