### PR TITLE
ACAP-1061: Add AEM asset support for wishlist dropin

### DIFF
--- a/cypress/src/tests/e2eTests/verifyAemAssets.spec.js
+++ b/cypress/src/tests/e2eTests/verifyAemAssets.spec.js
@@ -411,6 +411,42 @@ describe('AEM Assets enabled', () => {
       }
     });
   });
+
+  it('[Wishlist Dropin]: should load and show AEM Assets optimized images', () => {
+    visitWithEagerImages('/products/denim-apron/ADB119');
+    cy.get('.product-details__buttons__add-to-wishlist button')
+      .should('be.visible')
+      .click();
+    cy.wait(2000);
+
+    visitWithEagerImages('/wishlist');
+    cy.wait(3000);
+
+    const expectedOptions = {
+      protocol: 'https://',
+      environment: aemAssetsEnvironment,
+      format: 'webp',
+      quality: 80,
+      width: 288,
+      height: 288,
+    };
+
+    waitForAemAssetImages('.wishlist-wishlist img', (images) => {
+      for (const image of images) {
+        expectAemAssetsImage(image.src, expectedOptions);
+
+        for (const { url, screenWidth, density } of image.srcsetEntries) {
+          expect(density).to.be.undefined;
+          expect(screenWidth).to.be.a('number');
+
+          expectAemAssetsImage(url, {
+            ...expectedOptions,
+            width: (expectedOptions.width * screenWidth) / 1920,
+          })
+        }
+      }
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/ACAP-1061

Add support in wishlist dropin in boilerplate for AEM Assets

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
