### PR TITLE
unskip wishlist cypress saas tests

### DIFF
--- a/cypress/cypress.paas.config.js
+++ b/cypress/cypress.paas.config.js
@@ -18,6 +18,7 @@ module.exports = defineConfig({
     stateBillingId: "NY,129",
     productImageName: "/ADB150.jpg",
     productImageNameConfigurable: "/adb124.jpg",
+    productWithOptionImageNameConfigurable: "/adb192.jpg",
 
     aemAssetsConfig: {
       commerceConfig: {

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -18,6 +18,7 @@ module.exports = defineConfig({
     stateBillingId: "NY,43",
     productImageName: "/adb150.jpg",
     productImageNameConfigurable: "/adb124_1.jpg",
+    productWithOptionImageNameConfigurable: "/adb192_1.jpg",
 
     aemAssetsConfig: {
       commerceConfig: {

--- a/cypress/src/tests/e2eTests/verifyAuthUserWishlistFeature.spec.js
+++ b/cypress/src/tests/e2eTests/verifyAuthUserWishlistFeature.spec.js
@@ -15,7 +15,7 @@ import {
 } from "../../actions";
 import { products } from "../../fixtures";
 
-describe("Verify auth user can manage products across wishlist and cart", { tags: "@skipSaas" }, () => {
+describe("Verify auth user can manage products across wishlist and cart", () => {
   it("Successfully add simple product to wishlist, move it to cart, return this to wishlist and remove it", () => {
     cy.visit("/customer/create");
     cy.fixture("userInfo").then(({ sign_up }) => {
@@ -170,7 +170,7 @@ describe("Verify auth user can manage products across wishlist and cart", { tags
       "/products/cypress-configurable-product-latest-red/CYPRESS456"
     )(".commerce-wishlist-wrapper");
 
-    assertWishlistProductImage("/adb192.jpg")(".commerce-wishlist-wrapper");
+    assertWishlistProductImage(Cypress.env('productWithOptionImageNameConfigurable'))(".commerce-wishlist-wrapper");
 
     assertWishlistItemHasOptions('color', 'red')(".wishlist-wishlist__content");
 

--- a/cypress/src/tests/e2eTests/verifyGuestUserWishlistFeature.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserWishlistFeature.spec.js
@@ -13,7 +13,7 @@ import {
 import { products } from "../../fixtures";
 import { signUpUser } from "../../actions";
 
-describe("Verify guest user can manage products across wishlist and cart", { tags: "@skipSaas" }, () => {
+describe("Verify guest user can manage products across wishlist and cart", () => {
   beforeEach(() => {
     cy.visit("");
     cy.get(".wishlist-wrapper").should('be.visible').click();
@@ -151,7 +151,7 @@ describe("Verify guest user can manage products across wishlist and cart", { tag
       "/products/cypress-configurable-product-latest-red/CYPRESS456"
     )(".commerce-wishlist-wrapper");
 
-    assertWishlistProductImage("/adb192.jpg")(".commerce-wishlist-wrapper");
+    assertWishlistProductImage(Cypress.env('productWithOptionImageNameConfigurable'))(".commerce-wishlist-wrapper");
 
     assertWishlistItemHasOptions('color', 'red')(".wishlist-wishlist__content");
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

This PR is to unskip saas tests for wishlist as now accs is supported

Test URLs:
- Before: https://suite-release3--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://unskip-wishlist-saas-tests--aem-boilerplate-commerce--hlxsites.aem.live/
