### PR TITLE
USF-2666: Server error does not appear in Safari browser

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.css
+++ b/blocks/commerce-checkout/commerce-checkout.css
@@ -43,6 +43,27 @@
     border-bottom: var(--shape-border-width-3) solid var(--color-neutral-400);
 }
 
+/* Server error visibility */
+.checkout__server-error {
+    display: none;
+}
+
+/* Show when it contains actual error content */
+.checkout__server-error:has(.dropin-illustrated-message) {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
+/* Safari fallback: show when not empty, but this may show empty divs briefly */
+@supports not selector(:has(*)) {
+    .checkout__server-error:not(:empty) {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+    }
+}
+
 /* Hide empty blocks */
 .checkout__block:empty {
     display: none;
@@ -72,7 +93,6 @@
 }
 
 /* Hide blocks with empty divs */
-.checkout__server-error:has(> :empty),
 .checkout__out-of-stock:has(> :empty),
 .checkout__merged-cart-banner:has(> :empty),
 .checkout__delivery:has(> div:first-child:empty),


### PR DESCRIPTION
The Server Error container doesn't properly render in Safari browser.

Steps to reproduce

Use Safari and go to https://www.aemshop.net/checkout

- Fill the following
-- Name: CCREJECT
-- Last name: REFUSED
-- Street: CCREJECT-REFUSED
-- State: Arizona
-- City: CCREJECT-REFUSED
- Select Credit Card (Payment Services)
-- Number: 4012888888881881
-- Any exp data and CVV
- Submit
- See the Server error is in the DOM, the div is not empty but it's hidden

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://USF-2666--aem-boilerplate-commerce--hlxsites.aem.live/
