### PR TITLE
hotfix: default analytics env should be testing

### DIFF
--- a/demo-config.json
+++ b/demo-config.json
@@ -18,7 +18,7 @@
       },
       "analytics": {
         "base-currency-code": "USD",
-        "environment": "Production",
+        "environment": "Testing",
         "environment-id": "f38a0de0-764b-41fa-bd2c-5bc2f3c7b39a",
         "store-code": "main_website_store",
         "store-id": 1,


### PR DESCRIPTION
The demo-config using `Production` is causing analytics pipeline issues as test/demo sites are being interpreted as production. Also, pre-prod sites are polluting their production environment with incorrect events.

Make the default "Testing".

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://demo-config-test-env--aem-boilerplate-commerce--hlxsites.aem.page/
