### PR TITLE
chore: if config is missing or invalid, show a relevant error view

### DIFF
--- a/418.html
+++ b/418.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Invalid Site Configuration</title>
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none';"
+    move-to-http-header="true"
+  >
+  <script nonce="aem" type="text/javascript">
+    window.isErrorPage = true;
+    window.errorCode = '418';
+  </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="Invalid Site Configuration">
+  <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
+  <link rel="stylesheet" href="/styles/styles.css">
+  <style>
+    main.error {
+      align-items: center;
+      display: flex;
+      margin: 0 auto;
+      max-width: 1264px;
+      min-height: calc(100vh - var(--nav-height));
+      padding: 0 32px;
+      width: 100%;
+    }
+
+    main.error .error-number {
+      width: 100%;
+    }
+
+    main.error .error-number text {
+      font-family: monospace;
+    }
+  </style>
+  <link rel="stylesheet" href="/styles/lazy-styles.css">
+</head>
+
+<body>
+  <header></header>
+  <main class="error">
+    <div class="section">
+      <h2 class="error-message">Configuration Error</h2>
+      <p class="error-message">Your site configuration is either missing or invalid. Please see the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/" target="_blank">Commerce Configuration Guide</a> for more information.</p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+
+</html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,6 +18,7 @@ import {
   initializeCommerce,
   applyTemplates,
   decorateLinks,
+  loadErrorPage,
 } from './commerce.js';
 
 /**
@@ -82,10 +83,15 @@ async function loadEager(doc) {
 
   const main = doc.querySelector('main');
   if (main) {
-    await initializeCommerce();
-    decorateMain(main);
-    applyTemplates(doc);
-    await loadCommerceEager();
+    try {
+      await initializeCommerce();
+      decorateMain(main);
+      applyTemplates(doc);
+      await loadCommerceEager();
+    } catch (e) {
+      console.error('Error initializing commerce configuration:', e);
+      loadErrorPage(418);
+    }
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
   }


### PR DESCRIPTION
A missing or invalid configuration results in a "blank page" which is jarring and not helpful. Usually, missing or invalid configuration is a development issue and is found during development. For example if a dev is setting up a new site and does not have config.json locally or in their helix publicConfig.

A missing config resulted in uncaught errors in `initializeCommerce`. An invalid config (empty JSON object) would also result in errors during page decoration or other loading.

In order to handle these issues, we add a try-catch and use a "soft error" page to inform the developer or user that the site configuration is invalid.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://graceful-cfg-fail--aem-boilerplate-commerce--hlxsites.aem.page/
