### PR TITLE
PAY-6255: Hide "Fastlane" payment method on checkout

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -372,6 +372,9 @@ export default async function decorate(block) {
             },
             enabled: false,
           },
+          [PaymentMethodCode.FASTLANE]: {
+            enabled: false,
+          },
           [PaymentMethodCode.SMART_BUTTONS]: {
             enabled: false,
           },


### PR DESCRIPTION
We added "Fastlane" in the backend for our Luma integration. However, the payment method is not functional in EDS and should be hidden.

<img width="429" height="201" alt="image" src="https://github.com/user-attachments/assets/11b7cf93-95c2-4e3a-8914-11fe5a368a73" />

https://jira.corp.adobe.com/browse/pay-6255

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://pay-6255-j--aem-boilerplate-commerce--hlxsites.aem.live/
