### PR TITLE
[docs] Add Commerce Block README files

### DIFF
--- a/block-readme-template.md
+++ b/block-readme-template.md
@@ -1,0 +1,50 @@
+# <Block Name> Block
+
+## Overview
+
+<!-- Brief summary of the block's functionality and purpose -->
+
+## Integration
+
+### Block Configuration
+
+<!-- Configuration keys read via `readBlockConfig()` -->
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `key-name` | string | `'default'` | Description of what this config does | No | How it affects block behavior |
+
+### URL Parameters
+<!-- Any URL query parameters that affect block behavior -->
+- `param-name` - Description of parameter usage
+
+### Local Storage
+<!-- Any localStorage keys used -->
+- `storage-key` - Description of stored data
+
+### Events
+
+<!-- Event listeners and emitters -->
+
+#### Event Listeners
+- `events.on('event-name', callback)` - Description of what triggers this and what it does
+- `events.on('another-event', callback)` - Description
+
+#### Event Emitters
+- `events.emit('event-name', data)` - When this is emitted and what data is sent
+
+## Behavior Patterns
+
+### Page Context Detection
+<!-- How the block behaves in different contexts -->
+- **Context A**: When [condition], the block [behavior]
+- **Context B**: When [condition], the block [behavior]
+
+### User Interaction Flows
+<!-- Key user interaction patterns -->
+1. **Flow Name**: [Step-by-step description of user interaction]
+
+### Error Handling
+<!-- How errors are handled -->
+- **Error Type**: How it's caught and handled
+- **Fallback Behavior**: What happens when errors occur

--- a/blocks/commerce-account-header/README.md
+++ b/blocks/commerce-account-header/README.md
@@ -1,0 +1,48 @@
+# Commerce Account Header Block
+
+## Overview
+
+The Commerce Account Header block renders a standardized header component for account-related pages using the @dropins/tools Header component. It provides a consistent visual header with configurable title text for customer account sections.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `title` | string | `'My account'` | The header title text displayed to users | No | Changes the displayed header text |
+
+### URL Parameters
+
+No URL parameters affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are used by this block.
+
+### Events
+
+#### Event Listeners
+
+No event listeners are implemented in this block.
+
+#### Event Emitters
+
+No events are emitted by this block.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Account Pages**: When used on customer account pages, displays the configured title (default: "My account")
+- **All Contexts**: Consistently renders a header component regardless of page context
+
+### User Interaction Flows
+
+1. **Page Load**: Block initializes, reads configuration, clears existing content, and renders the Header component with the specified title
+
+### Error Handling
+
+- **Configuration Errors**: If `readBlockConfig()` fails, the block uses the default title "My account"
+- **Render Errors**: If the Header component fails to render, the block content remains empty
+- **Fallback Behavior**: Always falls back to the default title if no configuration is provided

--- a/blocks/commerce-account-sidebar/README.md
+++ b/blocks/commerce-account-sidebar/README.md
@@ -1,0 +1,51 @@
+# Commerce Account Sidebar Block
+
+## Overview
+
+The Commerce Account Sidebar block creates a dynamic navigation sidebar for customer account pages by loading configuration from a fragment and rendering interactive menu items with icons, titles, subtitles, and navigation arrows. It automatically detects the current page and highlights the active menu item.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. Configuration is loaded from the `/customer/sidebar-fragment` fragment.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior, but the block uses `window.location.href` to determine active menu items.
+
+### Local Storage
+
+No localStorage keys are used by this block.
+
+### Events
+
+#### Event Listeners
+
+No event listeners are implemented in this block.
+
+#### Event Emitters
+
+No events are emitted by this block.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Orders Page**: When on the orders page (`CUSTOMER_ORDERS_PATH`), the orders menu item is highlighted as active
+- **Other Account Pages**: When on other account pages, menu items are highlighted based on URL matching
+- **Fragment Loading**: Loads sidebar configuration from `/customer/sidebar-fragment` on initialization
+
+### User Interaction Flows
+
+1. **Initialization**: Block loads the sidebar fragment, parses configuration, creates menu items, and renders them
+2. **Menu Item Creation**: Each sidebar item is created with icon, title, subtitle, and chevron arrow
+3. **Active State Detection**: Compares current URL with menu item links to determine which item should be active
+4. **Navigation**: Clicking menu items navigates to the configured links
+
+### Error Handling
+
+- **Fragment Loading Errors**: If fragment loading fails, the block will not render any menu items
+- **Missing Configuration**: If sidebar fragment is missing or malformed, no menu items are created
+- **Icon Rendering Errors**: If icon rendering fails, the icon container is still created but may be empty
+- **Fallback Behavior**: Uses default values for missing configuration (title: "Default Title", link: "#", icon: "Placeholder")

--- a/blocks/commerce-addresses/README.md
+++ b/blocks/commerce-addresses/README.md
@@ -1,0 +1,54 @@
+# Commerce Addresses Block
+
+## Overview
+
+The Commerce Addresses block renders a customer address management interface using the @dropins/storefront-account Addresses container. It provides functionality for viewing, adding, editing, and deleting customer addresses with authentication protection and configurable view modes.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `minified-view` | string | `'false'` | Controls whether addresses are displayed in minified or full view mode | No | Changes the visual layout and available actions |
+
+### URL Parameters
+
+No URL parameters affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying Addresses container may use localStorage for address data persistence.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the Addresses container may listen for address-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the Addresses container may emit address management events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, renders the full address management interface
+- **Unauthenticated Users**: When user is not authenticated, redirects to the login page
+- **Minified View**: When `minified-view` is 'true', displays addresses in a compact format with limited actions
+- **Full View**: When `minified-view` is 'false', displays addresses in full format with all available actions
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If not authenticated, redirects to login page
+3. **Address Management**: If authenticated, renders address management interface with view mode based on configuration
+4. **Address Actions**: Users can view, add, edit, and delete addresses based on the configured view mode
+
+### Error Handling
+
+- **Authentication Errors**: If user is not authenticated, automatically redirects to login page
+- **Configuration Errors**: If `readBlockConfig()` fails, uses default minified view setting
+- **Render Errors**: If the Addresses container fails to render, the block content remains empty
+- **Fallback Behavior**: Always falls back to full view mode if configuration is invalid

--- a/blocks/commerce-cart/README.md
+++ b/blocks/commerce-cart/README.md
@@ -1,0 +1,67 @@
+# Commerce Cart Block
+
+## Overview
+
+The Commerce Cart block renders a comprehensive shopping cart interface with product management, order summary, gift options, and wishlist integration. It provides a full-featured cart experience with configurable options for item management, shipping estimation, and checkout flow.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `hide-heading` | string | `'false'` | Controls whether the cart heading is hidden | No | Changes visibility of cart section heading |
+| `max-items` | string | undefined | Maximum number of items to display in cart | No | Limits the number of cart items shown |
+| `hide-attributes` | string | `''` | Comma-separated list of product attributes to hide | No | Hides specified product attributes from display |
+| `enable-item-quantity-update` | string | `'false'` | Enables quantity update controls for cart items | No | Shows/hides quantity adjustment controls |
+| `enable-item-remove` | string | `'true'` | Enables remove item functionality | No | Shows/hides remove item buttons |
+| `enable-estimate-shipping` | string | `'false'` | Enables shipping estimation functionality | No | Shows/hides shipping estimation section |
+| `start-shopping-url` | string | `''` | URL for "Start Shopping" button when cart is empty | No | Sets destination for empty cart CTA |
+| `checkout-url` | string | `''` | URL for checkout button | No | Sets destination for checkout action |
+| `enable-updating-product` | string | `'false'` | Enables product editing via mini-PDP modal | No | Shows/hides edit buttons for configurable products |
+| `undo-remove-item` | string | `'false'` | Enables undo functionality when removing items | No | Shows/hides undo option after item removal |
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying cart containers may use localStorage for cart data persistence.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('cart/data', callback)` - Listens for cart data updates to refresh the cart display and toggle empty state
+- `events.on('wishlist/alert', callback)` - Listens for wishlist actions to show wishlist-related notifications
+
+#### Event Emitters
+
+- `publishShoppingCartViewEvent()` - Emits shopping cart view event for analytics tracking
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Empty Cart**: When cart has no items, shows empty cart message with start shopping CTA
+- **Populated Cart**: When cart has items, shows full cart interface with product list and order summary
+- **Configurable Products**: When configurable products are present and editing is enabled, shows edit buttons
+- **Gift Options**: Shows gift options section when cart is not empty
+
+### User Interaction Flows
+
+1. **Cart Display**: Block renders cart items, order summary, and gift options based on current cart state
+2. **Item Management**: Users can update quantities, remove items, and edit configurable products
+3. **Product Editing**: Clicking edit button opens mini-PDP modal for configurable product updates
+4. **Wishlist Integration**: Users can move items to/from wishlist with confirmation notifications
+5. **Checkout Flow**: Users can proceed to checkout via configured checkout URL
+6. **Empty Cart Handling**: When cart is empty, shows start shopping CTA and hides order summary
+
+### Error Handling
+
+- **Mini-PDP Errors**: If mini-PDP modal fails to open, shows error notification with dismiss option
+- **Cart Data Errors**: If cart data is invalid or missing, treats cart as empty
+- **Configuration Errors**: If `readBlockConfig()` fails, uses default configuration values
+- **Render Errors**: If container rendering fails, the affected section remains empty
+- **Fallback Behavior**: Always falls back to default configuration values for missing or invalid settings

--- a/blocks/commerce-checkout/README.md
+++ b/blocks/commerce-checkout/README.md
@@ -1,0 +1,64 @@
+# Commerce Checkout Block
+
+## Overview
+
+The Commerce Checkout block provides a comprehensive checkout experience with multi-step form handling, payment processing, address management, and order placement. It integrates multiple dropin containers for authentication, cart management, payment services, and order processing with dynamic UI state management and validation.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses system configuration values and dynamic state management.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior, but the block uses `window.location.href` for meta tag management.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying containers may use localStorage for data persistence.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('order/placed', callback)` - Updates page title and meta tags when order is successfully placed
+- `events.on('authenticated', callback)` - Handles user authentication state changes
+- `events.on('cart/initialized', callback)` - Handles cart initialization with eager loading
+- `events.on('checkout/initialized', callback)` - Handles checkout initialization with eager loading
+- `events.on('checkout/updated', callback)` - Handles checkout data updates
+- `events.on('checkout/values', callback)` - Handles checkout form value changes
+- `events.on('order/placed', callback)` - Handles successful order placement
+
+#### Event Emitters
+
+- `events.emit('checkout/addresses/shipping', values)` - Emits shipping address form values with debouncing
+- `events.emit('checkout/addresses/billing', values)` - Emits billing address form values with debouncing
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Checkout Flow**: Renders full checkout interface with shipping, billing, payment, and order summary
+- **Empty Cart**: When cart is empty, shows empty cart message and hides checkout forms
+- **Server Errors**: When server errors occur, shows error state and hides checkout forms
+- **Out of Stock**: When items are out of stock, shows out of stock message with cart update options
+- **Order Confirmation**: After successful order placement, transitions to order confirmation view
+
+### User Interaction Flows
+
+1. **Initialization**: Block sets up meta tags, renders checkout layout, and initializes all containers
+2. **Authentication**: Users can sign in/out via modal with form validation and success callbacks
+3. **Address Management**: Users can enter shipping/billing addresses with real-time validation and cart updates
+4. **Payment Processing**: Users can select payment methods and enter credit card information with validation
+5. **Order Placement**: Users can place orders with comprehensive form validation and payment processing
+6. **Error Handling**: Block shows appropriate error states and recovery options for various failure scenarios
+
+### Error Handling
+
+- **Form Validation Errors**: Individual form validation with scroll-to-error functionality
+- **Payment Processing Errors**: Credit card validation and payment service error handling
+- **Server Errors**: Server error display with retry functionality
+- **Cart Errors**: Empty cart and out-of-stock item handling
+- **Network Errors**: Graceful handling of network failures with user feedback
+- **Fallback Behavior**: Always falls back to appropriate error states with recovery options

--- a/blocks/commerce-confirm-account/README.md
+++ b/blocks/commerce-confirm-account/README.md
@@ -1,0 +1,52 @@
+# Commerce Confirm Account Block
+
+## Overview
+
+The Commerce Confirm Account block handles account confirmation and sign-in functionality with email confirmation support. It provides a sign-in form for users to confirm their account and displays success notifications with account management options.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying auth containers may use localStorage for authentication state.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying SignIn container may listen for authentication events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying auth containers may emit authentication events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is already authenticated, redirects to customer account page
+- **Unauthenticated Users**: When user is not authenticated, renders sign-in form with email confirmation
+- **Success State**: After successful sign-in, shows success notification with account management options
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If already authenticated, redirects to account page
+3. **Sign-In Process**: If not authenticated, renders sign-in form with email confirmation enabled
+4. **Success Handling**: After successful sign-in, shows welcome message with "My Account" and "Logout" buttons
+5. **Account Management**: Users can navigate to account page or logout from success screen
+
+### Error Handling
+
+- **Authentication Errors**: If user is already authenticated, automatically redirects to account page
+- **Sign-In Errors**: If sign-in fails, the SignIn container handles error display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to sign-in form if not authenticated

--- a/blocks/commerce-create-account/README.md
+++ b/blocks/commerce-create-account/README.md
@@ -1,0 +1,53 @@
+# Commerce Create Account Block
+
+## Overview
+
+The Commerce Create Account block provides user registration functionality with sign-up form, email confirmation, and privacy policy consent. It handles new user account creation with authentication flow integration and redirects authenticated users to their account page.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying auth containers may use localStorage for authentication state.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying SignUp container may listen for authentication events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying auth containers may emit authentication events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is already authenticated, redirects to customer account page
+- **Unauthenticated Users**: When user is not authenticated, renders sign-up form
+- **Email Confirmation**: Handles email confirmation flow with appropriate UI states
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If already authenticated, redirects to account page
+3. **Registration Process**: If not authenticated, renders sign-up form with privacy policy consent
+4. **Email Confirmation**: After registration, handles email confirmation flow
+5. **Success Redirect**: After successful sign-up and confirmation, redirects to account page
+
+### Error Handling
+
+- **Authentication Errors**: If user is already authenticated, automatically redirects to account page
+- **Registration Errors**: If sign-up fails, the SignUp container handles error display
+- **Email Confirmation Errors**: If email confirmation fails, appropriate error handling is provided
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to sign-up form if not authenticated

--- a/blocks/commerce-create-password/README.md
+++ b/blocks/commerce-create-password/README.md
@@ -1,0 +1,52 @@
+# Commerce Create Password Block
+
+## Overview
+
+The Commerce Create Password block handles password update functionality for authenticated users. It provides a password update form with success notifications and account management options, redirecting unauthenticated users to the login page.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying auth containers may use localStorage for authentication state.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying UpdatePassword container may listen for authentication events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying auth containers may emit authentication events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, renders password update form
+- **Unauthenticated Users**: When user is not authenticated, redirects to login page
+- **Success State**: After successful password update, shows success notification with account management options
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If not authenticated, redirects to login page
+3. **Password Update**: If authenticated, renders password update form
+4. **Success Handling**: After successful password update, shows success message with "My Account" and "Logout" buttons
+5. **Account Management**: Users can navigate to account page or logout from success screen
+
+### Error Handling
+
+- **Authentication Errors**: If user is not authenticated, automatically redirects to login page
+- **Password Update Errors**: If password update fails, the UpdatePassword container handles error display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to login page redirect if not authenticated

--- a/blocks/commerce-create-return/README.md
+++ b/blocks/commerce-create-return/README.md
@@ -1,0 +1,51 @@
+# Commerce Create Return Block
+
+## Overview
+
+The Commerce Create Return block provides return request functionality for orders using the @dropins/storefront-order CreateReturn container. It handles return creation with product image rendering and success redirection based on authentication status.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying CreateReturn container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit return-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, redirects to customer order details page after successful return
+- **Guest Users**: When user is not authenticated, redirects to guest order details page after successful return
+- **Return Creation**: Renders return creation form with product images and return reason selection
+
+### User Interaction Flows
+
+1. **Return Form**: Block renders return creation form with product selection and return reason options
+2. **Image Rendering**: Displays product images using AEM assets for return reason form and cart summary
+3. **Return Submission**: Users can submit return requests with selected products and reasons
+4. **Success Redirect**: After successful return creation, redirects to appropriate order details page based on authentication status
+
+### Error Handling
+
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Return Creation Errors**: If return creation fails, the CreateReturn container handles error display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to appropriate order details page based on authentication status

--- a/blocks/commerce-customer-details/README.md
+++ b/blocks/commerce-customer-details/README.md
@@ -1,0 +1,49 @@
+# Commerce Customer Details Block
+
+## Overview
+
+The Commerce Customer Details block renders customer information display using the @dropins/storefront-order CustomerDetails container. It provides a simple wrapper for displaying customer details in order-related contexts.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses default configuration for the CustomerDetails container.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying CustomerDetails container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit customer-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Order Context**: When used in order-related pages, displays customer details from order data
+- **All Contexts**: Consistently renders customer details regardless of page context
+
+### User Interaction Flows
+
+1. **Initialization**: Block initializes the order renderer and renders the CustomerDetails container
+2. **Data Display**: Displays customer information based on available order data
+3. **Read-Only View**: Provides read-only display of customer details
+
+### Error Handling
+
+- **Container Errors**: If the CustomerDetails container fails to render, the block content remains empty
+- **Data Errors**: If customer data is missing or invalid, the container handles appropriate fallback display
+- **Configuration Errors**: No configuration errors possible as block uses default configuration
+- **Fallback Behavior**: Always falls back to empty display if container rendering fails

--- a/blocks/commerce-customer-information/README.md
+++ b/blocks/commerce-customer-information/README.md
@@ -1,0 +1,51 @@
+# Commerce Customer Information Block
+
+## Overview
+
+The Commerce Customer Information block provides customer information management functionality using the @dropins/storefront-account CustomerInformation container. It requires user authentication and redirects unauthenticated users to the login page.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses default configuration for the CustomerInformation container.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying account containers may use localStorage for customer data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying CustomerInformation container may listen for account-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying account containers may emit customer information events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, renders customer information management interface
+- **Unauthenticated Users**: When user is not authenticated, redirects to login page
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If not authenticated, redirects to login page
+3. **Information Management**: If authenticated, renders customer information management interface
+4. **Data Updates**: Users can view and update their customer information
+
+### Error Handling
+
+- **Authentication Errors**: If user is not authenticated, automatically redirects to login page
+- **Container Errors**: If the CustomerInformation container fails to render, the block content remains empty
+- **Data Errors**: If customer data is missing or invalid, the container handles appropriate fallback display
+- **Configuration Errors**: No configuration errors possible as block uses default configuration
+- **Fallback Behavior**: Always falls back to login page redirect if not authenticated

--- a/blocks/commerce-forgot-password/README.md
+++ b/blocks/commerce-forgot-password/README.md
@@ -1,0 +1,52 @@
+# Commerce Forgot Password Block
+
+## Overview
+
+The Commerce Forgot Password block provides password reset functionality using the @dropins/storefront-auth ResetPassword container. It handles password reset requests and redirects authenticated users to their account page.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying auth containers may use localStorage for authentication state.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('authenticated', callback)` - Listens for authentication state changes and redirects to account page if user becomes authenticated
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying auth containers may emit authentication events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is already authenticated, redirects to customer account page
+- **Unauthenticated Users**: When user is not authenticated, renders password reset form
+- **Authentication Changes**: Monitors authentication state changes and redirects accordingly
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If already authenticated, redirects to account page
+3. **Password Reset**: If not authenticated, renders password reset form
+4. **Reset Process**: Users can enter email to request password reset
+5. **Authentication Monitoring**: Continuously monitors authentication state and redirects if user becomes authenticated
+
+### Error Handling
+
+- **Authentication Errors**: If user is already authenticated, automatically redirects to account page
+- **Reset Errors**: If password reset fails, the ResetPassword container handles error display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to password reset form if not authenticated

--- a/blocks/commerce-gift-options/README.md
+++ b/blocks/commerce-gift-options/README.md
@@ -1,0 +1,49 @@
+# Commerce Gift Options Block
+
+## Overview
+
+The Commerce Gift Options block renders gift options functionality using the @dropins/storefront-cart GiftOptions container. It provides read-only gift options display for order contexts with secondary view styling.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying cart containers may use localStorage for cart data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying GiftOptions container may listen for cart-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying cart containers may emit gift options events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Order Context**: When used in order-related pages, displays gift options from order data
+- **All Contexts**: Consistently renders gift options regardless of page context
+
+### User Interaction Flows
+
+1. **Initialization**: Block initializes the cart renderer and renders the GiftOptions container
+2. **Data Display**: Displays gift options based on available order data
+3. **Read-Only View**: Provides read-only display of gift options with secondary styling
+
+### Error Handling
+
+- **Container Errors**: If the GiftOptions container fails to render, the block content remains empty
+- **Data Errors**: If gift options data is missing or invalid, the container handles appropriate fallback display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to empty display if container rendering fails

--- a/blocks/commerce-login/README.md
+++ b/blocks/commerce-login/README.md
@@ -1,0 +1,51 @@
+# Commerce Login Block
+
+## Overview
+
+The Commerce Login block provides user authentication functionality using the @dropins/storefront-auth SignIn container. It handles user sign-in with forgot password integration and redirects authenticated users to their account page.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying auth containers may use localStorage for authentication state.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying SignIn container may listen for authentication events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying auth containers may emit authentication events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is already authenticated, redirects to customer account page
+- **Unauthenticated Users**: When user is not authenticated, renders sign-in form
+- **Forgot Password**: Provides integration with forgot password functionality
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If already authenticated, redirects to account page
+3. **Sign-In Process**: If not authenticated, renders sign-in form with forgot password link
+4. **Success Redirect**: After successful sign-in, redirects to account page
+
+### Error Handling
+
+- **Authentication Errors**: If user is already authenticated, automatically redirects to account page
+- **Sign-In Errors**: If sign-in fails, the SignIn container handles error display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to sign-in form if not authenticated

--- a/blocks/commerce-mini-cart/README.md
+++ b/blocks/commerce-mini-cart/README.md
@@ -1,0 +1,61 @@
+# Commerce Mini Cart Block
+
+## Overview
+
+The Commerce Mini Cart block provides a compact cart interface with product management, notifications, and modal integration. It renders a mini cart with configurable options for product editing, undo functionality, and navigation URLs with real-time cart update notifications.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `start-shopping-url` | string | `''` | URL for "Start Shopping" button when cart is empty | No | Sets destination for empty cart CTA |
+| `cart-url` | string | `''` | URL for cart page navigation | No | Sets destination for cart navigation |
+| `checkout-url` | string | `''` | URL for checkout navigation | No | Sets destination for checkout action |
+| `enable-updating-product` | string | `'false'` | Enables product editing via mini-PDP modal | No | Shows/hides edit buttons for configurable products |
+| `undo-remove-item` | string | `'false'` | Enables undo functionality when removing items | No | Shows/hides undo option after item removal |
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying cart containers may use localStorage for cart data persistence.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('cart/product/added', callback)` - Listens for product addition events to show success message
+- `events.on('cart/product/updated', callback)` - Listens for product update events to show update message
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying cart containers may emit cart-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Empty Cart**: When cart has no items, shows empty cart message with start shopping CTA
+- **Populated Cart**: When cart has items, shows mini cart with product list and actions
+- **Configurable Products**: When configurable products are present and editing is enabled, shows edit buttons
+- **Undo Mode**: When undo is enabled, prevents mini cart from closing during remove operations
+
+### User Interaction Flows
+
+1. **Cart Display**: Block renders mini cart with product thumbnails and basic information
+2. **Product Editing**: Clicking edit button opens mini-PDP modal for configurable product updates
+3. **Cart Updates**: Real-time notifications show when products are added or updated
+4. **Navigation**: Users can navigate to cart page, checkout, or start shopping
+5. **Undo Operations**: When enabled, users can undo item removal operations
+
+### Error Handling
+
+- **Mini-PDP Errors**: If mini-PDP modal fails to open, shows error message via notification system
+- **Cart Data Errors**: If cart data is invalid or missing, the MiniCart container handles fallback display
+- **Configuration Errors**: If `readBlockConfig()` fails, uses default configuration values
+- **Render Errors**: If container rendering fails, the block content remains empty
+- **Fallback Behavior**: Always falls back to default configuration values for missing or invalid settings

--- a/blocks/commerce-mini-pdp/README.md
+++ b/blocks/commerce-mini-pdp/README.md
@@ -1,0 +1,43 @@
+# Commerce Mini PDP Block
+
+## Overview
+
+The Commerce Mini PDP block directory exists but contains no implementation files. This block is referenced by other blocks (commerce-cart and commerce-mini-cart) for product editing functionality but is not implemented as a standalone block.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is available as this block is not implemented.
+
+### URL Parameters
+
+No URL parameters affect this block as it is not implemented.
+
+### Local Storage
+
+No localStorage keys are used as this block is not implemented.
+
+### Events
+
+#### Event Listeners
+
+No event listeners are implemented as this block is not implemented.
+
+#### Event Emitters
+
+No events are emitted as this block is not implemented.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Not Implemented**: This block is not implemented and should not be used directly
+
+### User Interaction Flows
+
+1. **Not Implemented**: This block is not implemented and should not be used directly
+
+### Error Handling
+
+- **Not Implemented**: This block is not implemented and should not be used directly

--- a/blocks/commerce-order-cost-summary/README.md
+++ b/blocks/commerce-order-cost-summary/README.md
@@ -1,0 +1,49 @@
+# Commerce Order Cost Summary Block
+
+## Overview
+
+The Commerce Order Cost Summary block renders order cost information using the @dropins/storefront-order OrderCostSummary container. It provides a simple wrapper for displaying order cost details in order-related contexts.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses default configuration for the OrderCostSummary container.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying OrderCostSummary container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit order cost events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Order Context**: When used in order-related pages, displays order cost summary from order data
+- **All Contexts**: Consistently renders order cost summary regardless of page context
+
+### User Interaction Flows
+
+1. **Initialization**: Block initializes the order renderer and renders the OrderCostSummary container
+2. **Data Display**: Displays order cost information based on available order data
+3. **Read-Only View**: Provides read-only display of order cost details
+
+### Error Handling
+
+- **Container Errors**: If the OrderCostSummary container fails to render, the block content remains empty
+- **Data Errors**: If order cost data is missing or invalid, the container handles appropriate fallback display
+- **Configuration Errors**: No configuration errors possible as block uses default configuration
+- **Fallback Behavior**: Always falls back to empty display if container rendering fails

--- a/blocks/commerce-order-header/README.md
+++ b/blocks/commerce-order-header/README.md
@@ -1,0 +1,51 @@
+# Commerce Order Header Block
+
+## Overview
+
+The Commerce Order Header block renders a dynamic header for order-related pages with conditional back navigation and order number display. It provides a standardized header that updates based on order data and page context.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values and dynamic order data.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior, but the block uses `window.location.href` to determine if back navigation should be shown.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('order/data', callback)` - Listens for order data updates to update header title with order number
+
+#### Event Emitters
+
+No events are emitted by this block.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Order Details Page**: When on order details page (`CUSTOMER_ORDER_DETAILS_PATH`), shows back navigation link to orders list
+- **Other Order Pages**: When on other order pages, shows standard order header without back navigation
+- **Order Data Available**: When order data is available, updates header title to show order number
+
+### User Interaction Flows
+
+1. **Initialization**: Block renders header with default "Order" title
+2. **Back Navigation**: If on order details page, adds back navigation link to orders list
+3. **Order Data Update**: When order data is received, updates header title to show order number
+4. **Navigation**: Users can click back link to return to orders list
+
+### Error Handling
+
+- **Placeholder Errors**: If placeholders fail to load, back navigation text may be missing
+- **Order Data Errors**: If order data is invalid, header falls back to default "Order" title
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to default "Order" title if order data is unavailable

--- a/blocks/commerce-order-product-list/README.md
+++ b/blocks/commerce-order-product-list/README.md
@@ -1,0 +1,52 @@
+# Commerce Order Product List Block
+
+## Overview
+
+The Commerce Order Product List block renders a list of products from an order using the @dropins/storefront-order OrderProductList container. It provides product display with image rendering, gift options, and product detail navigation.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses default configuration for the OrderProductList container.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying OrderProductList container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit order product events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Order Context**: When used in order-related pages, displays products from order data
+- **All Contexts**: Consistently renders product list regardless of page context
+
+### User Interaction Flows
+
+1. **Initialization**: Block initializes the order renderer and renders the OrderProductList container
+2. **Product Display**: Displays order products with images, names, and details
+3. **Image Rendering**: Renders product images using AEM assets with product detail links
+4. **Gift Options**: Shows gift options for each product item
+5. **Product Navigation**: Users can click on product images to view product details
+
+### Error Handling
+
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Container Errors**: If the OrderProductList container fails to render, the block content remains empty
+- **Data Errors**: If order product data is missing or invalid, the container handles appropriate fallback display
+- **Configuration Errors**: No configuration errors possible as block uses default configuration
+- **Fallback Behavior**: Always falls back to empty display if container rendering fails

--- a/blocks/commerce-order-returns/README.md
+++ b/blocks/commerce-order-returns/README.md
@@ -1,0 +1,53 @@
+# Commerce Order Returns Block
+
+## Overview
+
+The Commerce Order Returns block renders return information for orders using the @dropins/storefront-order OrderReturns container. It provides return tracking, product images, and navigation with authentication-aware routing.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values and authentication status.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior, but the block uses URL search parameters for order references.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying OrderReturns container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit return-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, uses customer return details path and order number for routing
+- **Guest Users**: When user is not authenticated, uses guest return details path and token for routing
+- **Return Tracking**: Provides tracking links with UPS-specific handling
+
+### User Interaction Flows
+
+1. **Initialization**: Block checks authentication status and sets appropriate routing paths
+2. **Return Display**: Renders return information with product images and tracking details
+3. **Image Rendering**: Displays return product images using AEM assets
+4. **Tracking Navigation**: Users can click tracking links to view shipping status
+5. **Return Details**: Users can navigate to return details pages with appropriate authentication routing
+
+### Error Handling
+
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Authentication Errors**: If authentication status is unclear, falls back to guest routing
+- **URL Parameter Errors**: If order references are missing, uses fallback values
+- **Container Errors**: If the OrderReturns container fails to render, the block content remains empty
+- **Fallback Behavior**: Always falls back to appropriate routing based on authentication status

--- a/blocks/commerce-order-status/README.md
+++ b/blocks/commerce-order-status/README.md
@@ -1,0 +1,52 @@
+# Commerce Order Status Block
+
+## Overview
+
+The Commerce Order Status block renders order status information using the @dropins/storefront-order OrderStatus container. It provides order status display with return creation functionality and authentication-aware routing.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values and authentication status.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior, but the block uses URL search parameters for order references.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying OrderStatus container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit order status events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, uses customer create return path and order number for routing
+- **Guest Users**: When user is not authenticated, uses guest create return path and token for routing
+- **Order Status**: Displays current order status and available actions
+
+### User Interaction Flows
+
+1. **Initialization**: Block checks authentication status and sets appropriate routing paths
+2. **Status Display**: Renders order status information and available actions
+3. **Return Creation**: Users can create returns with appropriate authentication routing
+4. **Success Navigation**: After successful actions, redirects to cart page
+
+### Error Handling
+
+- **Authentication Errors**: If authentication status is unclear, falls back to guest routing
+- **URL Parameter Errors**: If order references are missing, uses fallback values
+- **Container Errors**: If the OrderStatus container fails to render, the block content remains empty
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to appropriate routing based on authentication status

--- a/blocks/commerce-orders-list/README.md
+++ b/blocks/commerce-orders-list/README.md
@@ -1,0 +1,56 @@
+# Commerce Orders List Block
+
+## Overview
+
+The Commerce Orders List block renders a list of customer orders using the @dropins/storefront-account OrdersList container. It provides order management with product images, tracking links, and navigation with authentication protection and configurable view modes.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `minified-view` | string | `'false'` | Controls whether orders are displayed in minified or full view mode | No | Changes the visual layout and available actions |
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying account containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying OrdersList container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying account containers may emit order-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, renders the full orders list interface
+- **Unauthenticated Users**: When user is not authenticated, redirects to login page
+- **Minified View**: When `minified-view` is 'true', displays orders in a compact format
+- **Full View**: When `minified-view` is 'false', displays orders in full format with all details
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If not authenticated, redirects to login page
+3. **Orders Display**: If authenticated, renders orders list with product images and tracking
+4. **Navigation**: Users can navigate to order details, return details, and product pages
+5. **Tracking**: Users can click tracking links to view shipping status
+
+### Error Handling
+
+- **Authentication Errors**: If user is not authenticated, automatically redirects to login page
+- **Configuration Errors**: If `readBlockConfig()` fails, uses default minified view setting
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Container Errors**: If the OrdersList container fails to render, the block content remains empty
+- **Fallback Behavior**: Always falls back to full view mode if configuration is invalid

--- a/blocks/commerce-return-header/README.md
+++ b/blocks/commerce-return-header/README.md
@@ -1,0 +1,52 @@
+# Commerce Return Header Block
+
+## Overview
+
+The Commerce Return Header block renders a dynamic header for return-related pages with conditional back navigation and return number display. It provides a standardized header that updates based on return data and page context.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values and dynamic return data.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior, but the block uses `window.location.href` to determine if back navigation should be shown and URL search parameters for return references.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('order/data', callback)` - Listens for order data updates to update header title with return number
+
+#### Event Emitters
+
+No events are emitted by this block.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Return Details Page**: When on return details page (`CUSTOMER_RETURN_DETAILS_PATH`), shows back navigation link to returns list
+- **Other Return Pages**: When on other return pages, shows standard return header without back navigation
+- **Return Data Available**: When return data is available, updates header title to show return number
+
+### User Interaction Flows
+
+1. **Initialization**: Block renders header with default "Return" title
+2. **Back Navigation**: If on return details page, adds back navigation link to returns list
+3. **Return Data Update**: When order data is received, extracts return number and updates header title
+4. **Navigation**: Users can click back link to return to returns list
+
+### Error Handling
+
+- **Placeholder Errors**: If placeholders fail to load, back navigation text may be missing
+- **Return Data Errors**: If return data is invalid or missing, header falls back to default "Return" title
+- **URL Parameter Errors**: If return reference is missing from URL, header shows default title
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to default "Return" title if return data is unavailable

--- a/blocks/commerce-returns-list/README.md
+++ b/blocks/commerce-returns-list/README.md
@@ -1,0 +1,56 @@
+# Commerce Returns List Block
+
+## Overview
+
+The Commerce Returns List block renders a list of customer returns using the @dropins/storefront-order ReturnsList container. It provides return management with product images, tracking links, and navigation with authentication protection and configurable view modes.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `minified-view` | string | `'false'` | Controls whether returns are displayed in minified or full view mode | No | Changes the visual layout and available actions |
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying ReturnsList container may listen for return-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit return-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, renders the full returns list interface
+- **Unauthenticated Users**: When user is not authenticated, redirects to login page
+- **Minified View**: When `minified-view` is 'true', displays returns in a compact format
+- **Full View**: When `minified-view` is 'false', displays returns in full format with all details
+
+### User Interaction Flows
+
+1. **Authentication Check**: Block first verifies user authentication status
+2. **Redirect Flow**: If not authenticated, redirects to login page
+3. **Returns Display**: If authenticated, renders returns list with product images and tracking
+4. **Navigation**: Users can navigate to return details, order details, and product pages
+5. **Tracking**: Users can click tracking links to view shipping status
+
+### Error Handling
+
+- **Authentication Errors**: If user is not authenticated, automatically redirects to login page
+- **Configuration Errors**: If `readBlockConfig()` fails, uses default minified view setting
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Container Errors**: If the ReturnsList container fails to render, the block content remains empty
+- **Fallback Behavior**: Always falls back to full view mode if configuration is invalid

--- a/blocks/commerce-search-order/README.md
+++ b/blocks/commerce-search-order/README.md
@@ -1,0 +1,53 @@
+# Commerce Search Order Block
+
+## Overview
+
+The Commerce Search Order block provides order search functionality using the @dropins/storefront-order OrderSearch container. It handles both authenticated and guest order searches with dynamic sign-in form rendering and authentication-aware routing.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values and authentication status.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying auth and order containers may use localStorage for authentication and order data.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('order/data', callback)` - Listens for order data updates to re-render the search interface
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying containers may emit order-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, provides direct order search functionality
+- **Unauthenticated Users**: When user is not authenticated, shows sign-in form for order access
+- **Order Data Available**: When order data is available, re-renders the search interface
+
+### User Interaction Flows
+
+1. **Initialization**: Block renders order search interface based on authentication status
+2. **Guest Search**: Unauthenticated users can search for orders by email and order number
+3. **Sign-In Flow**: When guest search requires authentication, shows sign-in form
+4. **Authenticated Search**: Authenticated users can search for their orders directly
+5. **Order Navigation**: After successful search, users can navigate to order details
+
+### Error Handling
+
+- **Authentication Errors**: If authentication status is unclear, falls back to guest search mode
+- **Search Errors**: If order search fails, the OrderSearch container handles error display
+- **Sign-In Errors**: If sign-in fails, the SignIn container handles error display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to appropriate search mode based on authentication status

--- a/blocks/commerce-shipping-status/README.md
+++ b/blocks/commerce-shipping-status/README.md
@@ -1,0 +1,52 @@
+# Commerce Shipping Status Block
+
+## Overview
+
+The Commerce Shipping Status block renders shipping status information using the @dropins/storefront-order ShippingStatus container. It provides shipping tracking, product images, and navigation with UPS-specific tracking integration.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses hardcoded configuration values.
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying order containers may use localStorage for order data.
+
+### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block, but the underlying ShippingStatus container may listen for order-related events.
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying order containers may emit shipping status events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Order Context**: When used in order-related pages, displays shipping status from order data
+- **All Contexts**: Consistently renders shipping status regardless of page context
+
+### User Interaction Flows
+
+1. **Initialization**: Block initializes the order renderer and renders the ShippingStatus container
+2. **Status Display**: Displays shipping status information with product images and tracking details
+3. **Image Rendering**: Renders product images using AEM assets for various shipping status cards
+4. **Tracking Navigation**: Users can click tracking links to view shipping status (UPS-specific handling)
+5. **Product Navigation**: Users can navigate to product detail pages
+
+### Error Handling
+
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Container Errors**: If the ShippingStatus container fails to render, the block content remains empty
+- **Data Errors**: If shipping status data is missing or invalid, the container handles appropriate fallback display
+- **Configuration Errors**: No configuration errors possible as block uses hardcoded values
+- **Fallback Behavior**: Always falls back to empty display if container rendering fails

--- a/blocks/commerce-wishlist/README.md
+++ b/blocks/commerce-wishlist/README.md
@@ -1,0 +1,56 @@
+# Commerce Wishlist Block
+
+## Overview
+
+The Commerce Wishlist block provides wishlist management functionality using the @dropins/storefront-wishlist Wishlist container. It handles product wishlist operations with authentication modal integration, product data fetching, and cart integration.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `start-shopping-url` | string | `''` | URL for "Start Shopping" button when wishlist is empty | No | Sets destination for empty wishlist CTA |
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying wishlist containers may use localStorage for wishlist data.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('wishlist/alert', callback)` - Listens for wishlist action alerts to scroll to top of page
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying wishlist containers may emit wishlist-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Authenticated Users**: When user is authenticated, provides full wishlist management functionality
+- **Unauthenticated Users**: When user is not authenticated, shows authentication modal for wishlist access
+- **Empty Wishlist**: When wishlist is empty, shows start shopping CTA
+
+### User Interaction Flows
+
+1. **Initialization**: Block initializes wishlist renderer and sets up product data API endpoints
+2. **Wishlist Display**: Renders wishlist items with product images and management options
+3. **Authentication Flow**: When unauthenticated users try to access wishlist, shows sign-in modal
+4. **Product Management**: Users can add/remove products from wishlist and move items to cart
+5. **Product Navigation**: Users can navigate to product detail pages
+6. **Alert Handling**: Shows wishlist action alerts and scrolls to top of page
+
+### Error Handling
+
+- **Authentication Errors**: If user is not authenticated, shows authentication modal
+- **API Errors**: If product data API fails, the Wishlist container handles error display
+- **Configuration Errors**: If `readBlockConfig()` fails, uses default configuration values
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Fallback Behavior**: Always falls back to default configuration values for missing or invalid settings

--- a/blocks/product-details/README.md
+++ b/blocks/product-details/README.md
@@ -1,0 +1,60 @@
+# Product Details Block
+
+## Overview
+
+The Product Details block provides comprehensive product detail page functionality using multiple @dropins/storefront-pdp containers. It handles product display, configuration, cart operations, wishlist integration, and SEO optimization with dynamic mode switching between add and update operations.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. The block uses dynamic product data and URL parameters.
+
+### URL Parameters
+
+- `itemUid` - Item UID for cart update mode (when present, enables update mode instead of add mode)
+- `optionsUIDs` - Product option UIDs for wishlist context
+
+### Local Storage
+
+No localStorage keys are directly used by this block, but the underlying containers may use localStorage for product and cart data.
+
+### Events
+
+#### Event Listeners
+
+- `events.on('pdp/valid', callback)` - Listens for product configuration validity changes to enable/disable add to cart button
+- `events.on('pdp/values', callback)` - Listens for product option value changes to update wishlist context
+- `events.on('wishlist/alert', callback)` - Listens for wishlist action alerts to show notifications
+- `events.on('cart/data', callback)` - Listens for cart data changes to determine update mode
+- `events.on('aem/lcp', callback)` - Listens for AEM LCP event to set JSON-LD and meta tags
+
+#### Event Emitters
+
+No events are emitted by this block, but the underlying containers may emit product-related events.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Add Mode**: When no itemUid in URL, operates in add-to-cart mode
+- **Update Mode**: When itemUid in URL, operates in update-cart mode with different button text and behavior
+- **Product Configuration**: Validates product options and enables/disables add to cart button accordingly
+- **Wishlist Context**: Updates wishlist context based on current product configuration
+
+### User Interaction Flows
+
+1. **Initialization**: Block renders product gallery, header, price, options, quantity, and action buttons
+2. **Product Configuration**: Users can select product options with real-time validation
+3. **Add to Cart**: Users can add products to cart or update existing cart items
+4. **Wishlist Management**: Users can add/remove products from wishlist
+5. **Image Gallery**: Users can view product images in desktop thumbnail or mobile carousel format
+6. **SEO Optimization**: Sets JSON-LD structured data and meta tags for search engines
+
+### Error Handling
+
+- **Configuration Errors**: If product configuration is invalid, disables add to cart button
+- **API Errors**: If cart operations fail, shows error alerts with dismiss functionality
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **JSON-LD Errors**: If structured data generation fails, falls back to basic meta tags
+- **Fallback Behavior**: Always falls back to appropriate mode based on URL parameters and cart state

--- a/blocks/product-recommendations/README.md
+++ b/blocks/product-recommendations/README.md
@@ -1,0 +1,60 @@
+# Product Recommendations Block
+
+## Overview
+
+The Product Recommendations block provides personalized product recommendations using the @dropins/storefront-recommendations ProductList container. It handles recommendation loading with intersection observer, context tracking, and dynamic reloading based on user behavior and page changes.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Type | Default | Description | Required | Side Effects |
+|-------------------|------|---------|-------------|----------|--------------|
+| `currentsku` | string | undefined | Current product SKU for recommendation context | No | Sets the current product context for recommendations |
+| `recid` | string | undefined | Recommendation ID for targeting specific recommendation types | No | Identifies which recommendation algorithm to use |
+
+### URL Parameters
+
+No URL parameters directly affect this block's behavior.
+
+### Local Storage
+
+- `{storeViewCode}:productViewHistory` - Stores user's product view history for recommendation context
+- `{storeViewCode}:purchaseHistory` - Stores user's purchase history for recommendation context
+
+### Events
+
+#### Event Listeners
+
+- `events.on('recommendations/data', callback)` - Listens for recommendation data updates with eager loading
+- Adobe Data Layer event listeners for page context, product context, category context, and shopping cart context changes
+
+#### Event Emitters
+
+- `publishRecsItemAddToCartClick()` - Emits recommendation analytics events when items are added to cart
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Mobile Devices**: Uses intersection observer to load recommendations when section becomes visible
+- **Desktop Devices**: Loads recommendations immediately on page load
+- **Context Changes**: Reloads recommendations when significant context changes occur (product, category, page type)
+- **Cart Changes**: Updates recommendation context when cart contents change
+
+### User Interaction Flows
+
+1. **Initialization**: Block sets up recommendation context and loads initial recommendations
+2. **Lazy Loading**: On mobile, recommendations load when section becomes visible
+3. **Context Tracking**: Monitors page, product, category, and cart changes to update recommendations
+4. **Product Actions**: Users can add products to cart or navigate to product details
+5. **Wishlist Integration**: Users can add/remove products from wishlist
+6. **Dynamic Reloading**: Recommendations reload when significant context changes occur
+
+### Error Handling
+
+- **Context Errors**: If context data is invalid, falls back to empty arrays for view/purchase history
+- **API Errors**: If recommendation API fails, the ProductList container handles error display
+- **Configuration Errors**: If `readBlockConfig()` fails, uses undefined values for configuration
+- **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
+- **Fallback Behavior**: Always falls back to appropriate default values for missing or invalid configuration


### PR DESCRIPTION
This PR adds a standardized (see the `block-readme-template`) documentation for each of the commerce blocks. The documentation was generated with Cursor and the prompt:

```
For each `block` that starts with` commerce-*`, and for product-recommendations, product-details blocks add a README in the format of the README TEMPLATE below. Each block has a unique behavior and should be documented accordingly. Do not deviate from the template structure. Do not add new markdown headers or sections.

README TEMPLATE: @block-readme-template.md
```

Before this PR is merged, we should validate the output and edit in this PR.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://block-readmes--aem-boilerplate-commerce--hlxsites.aem.live/
