### PR TITLE
Add Conditional Navigation Support to Commerce Account Header ("Tabs")

### DIFF
--- a/blocks/commerce-account-header/commerce-account-header.css
+++ b/blocks/commerce-account-header/commerce-account-header.css
@@ -1,3 +1,28 @@
 body.columns main > .section > div.commerce-account-header-wrapper {
     margin-bottom: 0;
 }
+
+.commerce-account-header-navigation {
+    margin-top: calc(var(--spacing-small) * -1);
+    margin-bottom: var(--spacing-medium);
+    
+}
+
+.commerce-account-header-navigation > ul,
+.commerce-account-header-navigation > ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    padding-left: 0;
+    display: flex;
+    gap: var(--spacing-medium);
+    overflow: auto;
+}
+
+.commerce-account-header-navigation li {
+    white-space: nowrap;
+}
+
+.commerce-account-header-navigation--current {
+    font-weight: 600;
+}

--- a/blocks/commerce-account-header/commerce-account-header.js
+++ b/blocks/commerce-account-header/commerce-account-header.js
@@ -1,12 +1,28 @@
 import { Header, provider as UI } from '@dropins/tools/components.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const {
     title = 'My account',
   } = readBlockConfig(block);
 
+  const navigation = [...block.querySelectorAll(':scope > div')]
+    ?.find((div) => div.querySelector(':scope > div').textContent?.toLowerCase() === 'navigation')
+    ?.querySelector(':scope > div + div')
+
   block.innerHTML = '';
 
-  return UI.render(Header, { title })(block);
+  await UI.render(Header, { title })(block);
+
+  if (navigation) {
+    navigation.classList.add('commerce-account-header-navigation');
+
+    navigation.querySelectorAll('li').forEach((li) => {
+      if (!li.querySelector('a')) {
+        li.classList.add('commerce-account-header-navigation--current');
+      }
+    });
+
+    block.appendChild(navigation);
+  }
 }


### PR DESCRIPTION
## Summary
Enhanced the `commerce-account-header` block to support conditional subnavigation functionality, allowing content authors to add navigation items that will be rendered below the main account header.

## Usage
Content authors can now add navigation to the commerce-account-header block by including a structure like:
---

<img width="841" height="248" alt="image" src="https://github.com/user-attachments/assets/f2c8fdb8-a7ee-4be5-85ba-6c7f05b6f12b" />

<img width="1118" height="265" alt="image" src="https://github.com/user-attachments/assets/f2b231ab-803b-4139-a207-43bed7cea102" />

Document: https://da.live/edit#/adobe-commerce/boilerplate-b2b/drafts/carlos/subnavs

---

Test URLs:
- Before: https://main--boilerplate-b2b--adobe-commerce.aem.live/
- After: https://subnavs--boilerplate-b2b--adobe-commerce.aem.live/
