### PR TITLE
chore: Check meta sku first

### DIFF
--- a/blocks/enrichment/enrichment.js
+++ b/blocks/enrichment/enrichment.js
@@ -1,5 +1,5 @@
 import { readBlockConfig } from '../../scripts/aem.js';
-import { getSkuFromUrl, fetchIndex } from '../../scripts/commerce.js';
+import { getProductSku, fetchIndex } from '../../scripts/commerce.js';
 import { loadFragment } from '../fragment/fragment.js';
 
 export default async function decorate(block) {
@@ -8,7 +8,7 @@ export default async function decorate(block) {
   try {
     const filters = {};
     if (type === 'product') {
-      const productSku = getSkuFromUrl();
+      const productSku = getProductSku();
       if (!productSku) {
         throw new Error('No product SKU found in URL');
       }

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -573,7 +573,7 @@ export async function commerceEndpointWithQueryParams() {
  * Extracts the SKU from the current URL path.
  * @returns {string|null} The SKU extracted from the URL, or null if not found
  */
-export function getSkuFromUrl() {
+function getSkuFromUrl() {
   const path = window.location.pathname;
   const result = path.match(/\/products\/[\w|-]+\/([\w|-]+)$/);
   return result?.[1];

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -580,6 +580,14 @@ export function getSkuFromUrl() {
 }
 
 /**
+ * Gets the product SKU from metadata or URL fallback.
+ * @returns {string|null} The SKU from metadata or URL, or null if not found
+ */
+export function getProductSku() {
+  return getMetadata('sku') || getSkuFromUrl();
+}
+
+/**
  * Extracts option UIDs from the URL search parameters.
  * @returns {string[]|undefined} Array of option UIDs, or undefined if not found
  */

--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -12,7 +12,7 @@ import {
   fetchPlaceholders,
   commerceEndpointWithQueryParams,
   getOptionsUIDsFromUrl,
-  getSkuFromUrl,
+  getProductSku,
   loadErrorPage,
   preloadFile,
 } from '../commerce.js';
@@ -49,7 +49,7 @@ await initializeDropin(async () => {
   // Set Fetch Headers (Service)
   setFetchGraphQlHeaders((prev) => ({ ...prev, ...getHeaders('cs') }));
 
-  const sku = getSkuFromUrl();
+  const sku = getProductSku();
   const optionsUIDs = getOptionsUIDsFromUrl();
 
   const [product, labels] = await Promise.all([


### PR DESCRIPTION
SKU in URL is:
- not great for SEO
- complicated with EDS requirements (only lowercase document paths)
- doesn't make sense with urlKey-only product urls

This change checks metadata first, for a given PDP. This can exist via bulk-metadata, or if metadata table exists per document with the value (ie on products/some-url-key.md, there is metadata block with sku).

This change should be backwards compatible. This change is already in `integration` but we need it sooner than later in main.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://check-meta--aem-boilerplate-commerce--hlxsites.aem.page/
