### PR TITLE
ACAP-1139: Converts decimal dimensions to integers for AEM Assets compatibility

### DIFF
--- a/scripts/initializers/index.js
+++ b/scripts/initializers/index.js
@@ -8,6 +8,8 @@ import {
   setFetchGraphQlHeader,
 } from '@dropins/tools/fetch-graphql.js';
 import * as authApi from '@dropins/storefront-auth/api.js';
+import { initializers } from '@dropins/tools/initializer.js';
+import { isAemAssetsEnabled } from '@dropins/tools/lib/aem/assets.js';
 import { fetchPlaceholders } from '../commerce.js';
 
 export const getUserTokenCookie = () => getCookie('auth_dropin_user_token');
@@ -31,6 +33,20 @@ const persistCartDataInSession = (data) => {
   }
 };
 
+const setupAemAssetsImageParams = () => {
+  if (isAemAssetsEnabled()) {
+    // Convert decimal values to integers for AEM Assets compatibility
+    initializers.setImageParamKeys({
+      width: (value) => ['width', Math.floor(value)],
+      height: (value) => ['height', Math.floor(value)],
+      quality: 'quality',
+      auto: 'auto',
+      crop: 'crop',
+      fit: 'fit',
+    });
+  }
+};
+
 export default async function initializeDropins() {
   const init = async () => {
     // Set auth headers on authenticated event
@@ -48,6 +64,9 @@ export default async function initializeDropins() {
     events.enableLogger(true);
     // Set Fetch Endpoint (Global)
     setEndpoint(getConfigValue('commerce-core-endpoint') || getConfigValue('commerce-endpoint'));
+
+    // Set up AEM Assets image parameter conversion
+    setupAemAssetsImageParams();
 
     // Fetch global placeholders
     await fetchPlaceholders('placeholders/global.json');


### PR DESCRIPTION
Fix AEM Assets decimal dimension compatibility issue to proactively prevent failed image requests when AEM Assets integration is enabled. 

JIRA Ticket: https://jira.corp.adobe.com/browse/ACAP-1139 

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://acap-1139--aem-boilerplate-commerce--hlxsites.aem.page/