### PR TITLE
PAY-6260: Pass 'location' to Apple Pay in checkout block

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -60,7 +60,7 @@ import ShippingStatus from '@dropins/storefront-order/containers/ShippingStatus.
 import { render as OrderProvider } from '@dropins/storefront-order/render.js';
 
 // Payment Services Dropin
-import { PaymentMethodCode } from '@dropins/storefront-payment-services/api.js';
+import { PaymentLocation, PaymentMethodCode } from '@dropins/storefront-payment-services/api.js';
 import CreditCard from '@dropins/storefront-payment-services/containers/CreditCard.js';
 import ApplePay from '@dropins/storefront-payment-services/containers/ApplePay.js';
 import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
@@ -393,6 +393,7 @@ export default async function decorate(block) {
               }
 
               PaymentServices.render(ApplePay, {
+                location: PaymentLocation.CHECKOUT,
                 getCartId: () => ctx.cartId,
                 isVirtualCart: checkoutData.isVirtual,
                 onButtonClick: (showPaymentSheet) => {


### PR DESCRIPTION
This pull request adds the missing `location` property to the `ApplePay` container in the checkout block.

The `location` property was first introduced in https://github.com/adobe-commerce/storefront-payment-services/pull/14 and is currently available in the alpha release. It is optional for now, but we plan to make it mandatory starting with the beta release and in the final drop-in release.

https://jira.corp.adobe.com/browse/PAY-6260

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://pay-6260-j--aem-boilerplate-commerce--hlxsites.aem.live/
