### PR TITLE
Checkout v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dropins/storefront-account": "~1.2.0",
         "@dropins/storefront-auth": "~2.1.1",
         "@dropins/storefront-cart": "~1.5.1",
-        "@dropins/storefront-checkout": "~2.1.0-beta4",
+        "@dropins/storefront-checkout": "~2.1.0",
         "@dropins/storefront-order": "~1.4.0",
         "@dropins/storefront-payment-services": "~1.0.2",
         "@dropins/storefront-pdp": "~1.3.5",
@@ -1918,9 +1918,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-checkout": {
-      "version": "2.1.0-beta4",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-checkout/-/storefront-checkout-2.1.0-beta4.tgz",
-      "integrity": "sha512-FZmPCAJYXJ8mJPVTieBbb2UJHtyF0Y64ENEunHn3EThEWGahrK5/pDjjHEPi3NApnlvWSVYhb3qAWb+kv1Pidg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-checkout/-/storefront-checkout-2.1.0.tgz",
+      "integrity": "sha512-8tISTX5ggMGcBwn+3sgE6pLqAOy7nV+TBRzYD0beIC4Cqdg+okxEjkPhXkDZnUklyT7A/AS8eqDP3B3BhRuF7g==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-order": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dropins/storefront-account": "~1.2.0",
     "@dropins/storefront-auth": "~2.1.1",
     "@dropins/storefront-cart": "~1.5.1",
-    "@dropins/storefront-checkout": "~2.1.0-beta4",
+    "@dropins/storefront-checkout": "~2.1.0",
     "@dropins/storefront-order": "~1.4.0",
     "@dropins/storefront-payment-services": "~1.0.2",
     "@dropins/storefront-pdp": "~1.3.5",


### PR DESCRIPTION
## Description
New Checkout drop-in version released v2.1.0

## Test URLs:
- Before: https://suite-release4--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://Checkout-v210--aem-boilerplate-commerce--hlxsites.aem.live/
