### PR TITLE
Fix permissions handling in commerce account navigation by ensuring a…

### DIFF
--- a/blocks/commerce-account-nav/commerce-account-nav.js
+++ b/blocks/commerce-account-nav/commerce-account-nav.js
@@ -22,7 +22,7 @@ export default async function decorate(block) {
   };
 
   /** Get permissions */
-  const permissions = events.lastPayload('auth/permissions');
+  const permissions = events.lastPayload('auth/permissions') || {};
 
   /** Create items */
   $items.forEach(($item) => {


### PR DESCRIPTION
… default empty object is used when no permissions are returned.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
