### PR TITLE
Company Switcher version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dropins/storefront-cart": "~3.0.0-beta1",
         "@dropins/storefront-checkout": "^2.2.0-beta2",
         "@dropins/storefront-company-management": "^1.0.0-beta16",
-        "@dropins/storefront-company-switcher": "^1.0.4",
+        "@dropins/storefront-company-switcher": "^1.0.5",
         "@dropins/storefront-order": "~1.5.0-beta1",
         "@dropins/storefront-payment-services": "~2.0.0",
         "@dropins/storefront-pdp": "~1.3.5",
@@ -2009,9 +2009,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-company-switcher": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-company-switcher/-/storefront-company-switcher-1.0.4.tgz",
-      "integrity": "sha512-fn5p85MjU6v9ZRt4tewgjNrJOiHHESgTM/yGQpFran1WGJ7ITNvMU9P5WIgkBW6/yelo+2zbeYRI91eNlV8BNw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-company-switcher/-/storefront-company-switcher-1.0.5.tgz",
+      "integrity": "sha512-2387pcmM56fXPLQ36WNWEoTtui00esFw1bORCOqAMvIR4tLlX1T5BA/L2jBYf7yn3CyKF3PEOISPzloSkAT8/A==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-order": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "~3.0.0-beta1",
     "@dropins/storefront-checkout": "^2.2.0-beta2",
     "@dropins/storefront-company-management": "^1.0.0-beta16",
-    "@dropins/storefront-company-switcher": "^1.0.4",
+    "@dropins/storefront-company-switcher": "^1.0.5",
     "@dropins/storefront-order": "~1.5.0-beta1",
     "@dropins/storefront-payment-services": "~2.0.0",
     "@dropins/storefront-pdp": "~1.3.5",


### PR DESCRIPTION
Install newer version of Company Switcher with updated dependencies per [Slack thread](https://magento.slack.com/archives/C03J16UAEHZ/p1763451828267849?thread_ts=1763405663.324079&cid=C03J16UAEHZ)

Test URLs:

- Before: https://b2b-integration--boilerplate-b2b-accs-qa--adobe-commerce.aem.page/
- After: https://company-switcher-version-bump--boilerplate-b2b-accs-qa--adobe-commerce.aem.page/
