### PR TITLE
USF 1857 AEP analytics config

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -33,8 +33,8 @@ async function initAnalytics() {
         {
           eventForwardingContext: {
             commerce: true,
-            aep: analyticsConfig['aep-ims-org-id'] && analyticsConfig['aep-datastream-id']
-          }
+            aep: analyticsConfig['aep-ims-org-id'] && analyticsConfig['aep-datastream-id'],
+          },
         },
         {
           shopperContext: {
@@ -46,7 +46,7 @@ async function initAnalytics() {
             imsOrgId: analyticsConfig['aep-ims-org-id'],
             datastreamId: analyticsConfig['aep-datastream-id'],
           },
-        }
+        },
       );
 
       // Load events SDK and collector


### PR DESCRIPTION
Need to allow commerce events to automatically forward events to AEP if configuration values are set.  This will streamline AEP event collection for storefront implementors.

Based on config values truthiness of both `aep-ims-org-id` and `aep-datastream-id`, it will set the aep event forwarding context to true.
Will also set the correct values in the aep context.  Setting aep context with falsy values should not be an issue, as event forwarding will be false and context will be unused.


Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://USF-1857-AEP-analytics-config--aem-boilerplate-commerce--hlxsites}.aem.live/
