### PR TITLE
404 when Product is not available for a company on company switch

### DIFF
--- a/404.html
+++ b/404.html
@@ -81,6 +81,17 @@
     import { sampleRUM } from '/scripts/aem.js';
     sampleRUM('404', { source: document.referrer });
   </script>
+  <script nonce="aem" type="module">
+    import { events } from '@dropins/tools/event-bus.js';
+    import { getConfigValue } from '@dropins/tools/lib/aem/configs.js';
+
+    if (events.lastPayload('authenticated') && getConfigValue('commerce-companies-enabled') === true) {
+      // Error page cannot handle company context changes correctly, so we reload the page.
+      events.on('companyContext/changed', () => {
+        window.location.reload();
+      });
+    }
+  </script>
   <link rel="stylesheet" href="/styles/styles.css">
   <style>
     main.error {

--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -114,7 +114,10 @@ await initializeDropin(async () => {
     // Reload PDP when company context changes
     const loadedProduct = await getProductData(false);
     if (!loadedProduct?.sku) {
-      loadErrorPage();
+      // Calling loadErrorPage() here produces a 404 page without header.
+      // This does not allow the user to go back or switch companies again.
+      // Instead, we reload the page to show the error page with the header and controls.
+      window.location.reload();
       return;
     }
     events.emit('pdp/data', loadedProduct);


### PR DESCRIPTION
## Fixed issue
* [USF-3542](https://jira.corp.adobe.com/browse/USF-3542): B2B - User displayed with broken Product details page instead of 404 page, when Product is not available for a company on company switch

### Test URLs
- Before: https://b2b-suite-release1--boilerplate-b2b-accs--adobe-commerce.aem.page/
- After: https://usf-3542--boilerplate-b2b-accs--adobe-commerce.aem.page/
