### PR TITLE
USF-3549

### DIFF
--- a/blocks/commerce-wishlist/commerce-wishlist.js
+++ b/blocks/commerce-wishlist/commerce-wishlist.js
@@ -50,7 +50,11 @@ const showAuthModal = (event) => {
         window.location.reload();
       },
     },
-    signUpFormConfig: {},
+    signUpFormConfig: {
+      onSuccessCallback: () => {
+        window.location.reload();
+      },
+    },
     resetPasswordFormConfig: {},
   })(signInForm);
 };


### PR DESCRIPTION
This PR is to fix this case:
1. Go wishlist as a guest user
2. Click to login, in the login modal click to sign up a new customer
3. Fill the form with the customer data
4. Click in create account

The account is created but the form stayed on the page and seems you are not logged in, you need to manually reload the page. See the screenshot attached.

**The issue:** When you click "Sign Up" from the modal, it renders a separate sign-up form which has its own callback. The onSuccessCallback in signInFormConfig doesn't fire for sign-up!

Fix #[USF-3549](https://jira.corp.adobe.com/browse/USF-3549)

Test URLs:
- Before: https://suite-release5--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://usf-3549--aem-boilerplate-commerce--hlxsites.aem.page/
