### PR TITLE
Fix redirect after creating an account on the checkout success page

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -310,6 +310,17 @@ export default async function decorate(block) {
 
   function handleAuthenticated(authenticated) {
     if (!authenticated) return;
+
+    // When a customer creates an account on the checkout success page and then
+    // signs in, they will be redirected to the order details page with the order
+    // number as orderRef, allowing the order details to be displayed
+    const orderData = events.lastPayload('order/placed');
+    if (orderData) {
+      const encodedOrderNumber = encodeURIComponent(orderData.number);
+      const url = rootLink(`/order-details?orderRef=${encodedOrderNumber}`);
+      window.history.pushState({}, '', url);
+    }
+
     window.location.reload();
   }
 


### PR DESCRIPTION
After https://github.com/hlxsites/aem-boilerplate-commerce/pull/972, when a customer creates an account on the checkout success page, the page will reload and redirect them to the orders page.

With this fix, we will redirect the user to the order details page by setting `orderRef` query param to the order number before redirecting.

Test URLs:
- Before: https://suite-release5--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://checkout-create-account--aem-boilerplate-commerce--hlxsites.aem.page/
