### PR TITLE
USF-2992: Add company management container docs

### DIFF
--- a/blocks/commerce-company-profile/README.md
+++ b/blocks/commerce-company-profile/README.md
@@ -23,22 +23,10 @@ The Commerce Company Profile block provides company profile management functiona
 ## Integration
 
 ### Block Configuration
-The block can be configured with the following options via `readBlockConfig()`:
 
-- **className** (string, optional): CSS class for additional styling customization of the CompanyProfile component
-- **withHeader** (boolean, optional, default: true): Controls whether the container header is visible or not
-- **slots** (object, optional): Slot configuration for customizing company data display
-  - **CompanyData** (SlotProps, optional): Slot for customizing how company data is rendered
+The block does not use `readBlockConfig()`. The CompanyProfile container is rendered without configuration options as it relies on backend permissions to determine what data to display and allow editing.
 
-Example configuration:
-```javascript
-const config = readBlockConfig(block);
-// config = {
-//   className: 'custom-company-profile',
-//   withHeader: false,
-//   slots: { CompanyData: customSlot }
-// }
-```
+**Note:** The CompanyProfile container supports `className` and `slots` props, but these must be passed programmatically if needed and are not read from block configuration in the standard implementation.
 
 <!-- ### URL Parameters
 

--- a/blocks/commerce-company-users/README.md
+++ b/blocks/commerce-company-users/README.md
@@ -23,22 +23,10 @@ The Commerce Company Users block provides company user management functionality 
 ## Integration
 
 ### Block Configuration
-The block can be configured with the following options via `readBlockConfig()`:
 
-- **className** (string, optional): CSS class for additional styling customization of the CompanyUsers component
-- **withHeader** (boolean, optional, default: true): Controls whether the container header is visible or not
-- **slots** (object, optional): Slot configuration for customizing company data display
-  - **CompanyData** (SlotProps, optional): Slot for customizing how company data is rendered
+The block does not use `readBlockConfig()`. The CompanyUsers container is rendered without configuration options as it manages its own pagination, filtering, and user management interface internally.
 
-Example configuration:
-```javascript
-const config = readBlockConfig(block);
-// config = {
-//   className: 'custom-company-profile',
-//   withHeader: false,
-//   slots: { CompanyData: customSlot }
-// }
-```
+**Note:** The CompanyUsers container has no configurable props - it only accepts standard HTML attributes and manages all functionality internally based on backend permissions.
 
 <!-- ### URL Parameters
 


### PR DESCRIPTION
## Fix Incorrect Container Props in Block Documentation

Removes incorrect `withHeader` prop documentation from CompanyProfile and CompanyUsers block READMEs.

**What:** Fixed 2 block README files with wrong prop documentation  
**Why:** Documented props that don't exist in actual container implementations  
**Impact:** Documentation accuracy only

**Files:**
- `blocks/commerce-company-profile/README.md` - Removed `withHeader` prop
- `blocks/commerce-company-users/README.md` - Removed all config props (container has none)

**Related:** Coordinates with adobe-com/microsite-commerce-storefront#654

Test URLs:
- Before: https://b2b-suite-release1--boilerplate-b2b-accs--adobe-commerce.aem.page/
- After: https://usf-2992--boilerplate-b2b-accs--adobe-commerce.aem.page/
