### PR TITLE
[Amigos] USF-3603: Re-enable USF-3555 E2E test after backend status field promotion to PROD/Sandbox

### DIFF
--- a/cypress/src/tests/b2b/COMPANY_TESTS_COVERAGE.md
+++ b/cypress/src/tests/b2b/COMPANY_TESTS_COVERAGE.md
@@ -745,7 +745,7 @@ These tests were attempted but removed due to API limitations. They require manu
 
 ---
 
-**Last Updated:** December 12, 2025  
+**Last Updated:** January 5, 2026  
 **Status:** ✅ All 20 tests fully passing (1 skipped for faster runs)  
 **Total Tests:** 20 tests (was 53 isolated tests)  
 **Runtime:** ~18 minutes (was ~35-40 minutes)  
@@ -753,4 +753,6 @@ These tests were attempted but removed due to API limitations. They require manu
 **New Coverage:** Backend profile sync (TC-14), Company status filtering (USF-3555), Shopping Cart context (TC-42), Order lifecycle with Payment on Account (TC-47 CASE_1/4/5)  
 **Code Quality:** 10 custom commands, structured environment variables, 2 unused files removed  
 **New REST APIs:** `updateCompanyProfile()` (fixed), `cancelOrder()`, `createInvoice()`, `createCreditMemo()` with proper error handling  
-**QA Tracking Status:** ⚠️ **Zephyr integration pending** - Test plan link added, Zephyr ticket IDs not yet mapped
+**QA Tracking Status:** ⚠️ **Zephyr integration pending** - Test plan link added, Zephyr ticket IDs not yet mapped  
+**Recent Changes:**  
+- **USF-3603 (Jan 5, 2026):** Re-enabled Company Switcher tests after backend `status` field promotion to PROD/Sandbox

--- a/cypress/src/tests/b2b/verifyCompanySwitcher.spec.js
+++ b/cypress/src/tests/b2b/verifyCompanySwitcher.spec.js
@@ -108,13 +108,8 @@ describe('Company Switcher (Optimized Journey)', { tags: ['@B2BSaas'] }, () => {
    * Tests: Context switching across company management pages with different roles
    * Setup: ONCE at journey start
    * Time: ~2 minutes (vs 6 tests x 52s = 5+ minutes if separate)
-   * 
-   * SKIPPED: Waiting for backend 'status' field deployment to PROD/Sandbox environments.
-   * The GraphQL query includes 'status' field which is not yet available in PROD/Sandbox,
-   * causing all companies to be filtered out and the picker not to render.
-   * TODO: Remove .skip once backend is promoted (USF-3603)
    */
-  it.skip('JOURNEY: Company context persists across company management pages with role-based permissions', { defaultCommandTimeout: 30000 }, () => {
+  it('JOURNEY: Company context persists across company management pages with role-based permissions', { defaultCommandTimeout: 30000 }, () => {
     cy.logToTerminal('========= 🚀 JOURNEY: Complete Company Context Switching =========');
 
     // ========== SETUP: Create 2 companies + shared user (ONCE) ==========
@@ -528,13 +523,8 @@ describe('Company Switcher (Optimized Journey)', { tags: ['@B2BSaas'] }, () => {
    * Setup: 1 user with 4 companies (APPROVED, PENDING, REJECTED, BLOCKED)
    * Expected: Only APPROVED and BLOCKED companies appear in dropdown
    * Time: ~1-2 minutes
-   * 
-   * SKIPPED: Waiting for backend 'status' field deployment to PROD/Sandbox environments.
-   * The GraphQL query includes 'status' field which is not yet available in PROD/Sandbox,
-   * causing the query to fail. This test will be re-enabled after backend promotion.
-   * TODO: Remove .skip once backend is promoted (USF-3603)
    */
-  it.skip('JOURNEY: Company switcher filters out inactive companies (USF-3555)', { defaultCommandTimeout: 30000 }, () => {
+  it('JOURNEY: Company switcher filters out inactive companies (USF-3555)', { defaultCommandTimeout: 30000 }, () => {
     cy.logToTerminal('========= 🚀 JOURNEY: Company Status Filtering (USF-3555) =========');
 
     // ========== SETUP: Create 4 companies with different statuses ==========


### PR DESCRIPTION
## USF-3603: Re-enable Company Switcher E2E Tests

### Summary
Re-enabled two skipped company switcher E2E tests after backend `status` field promotion to PROD/Sandbox.

### Changes
- ✅ Removed `.skip` from both company switcher journey tests in `verifyCompanySwitcher.spec.js`:
  - "JOURNEY: Company context persists across company management pages with role-based permissions"
  - "JOURNEY: Company switcher filters out inactive companies (USF-3555)"
- ✅ Removed TODO comments referencing USF-3603
- ✅ Updated `COMPANY_TESTS_COVERAGE.md` with timestamp and recent changes

### Context
Tests were previously skipped because the GraphQL `company.status` field was not available in PROD/Sandbox environments. Backend deployment (USF-3547) is now complete, allowing these tests to run.

### Testing
Run locally against PROD/Sandbox to verify both tests pass, then confirm in CI/CD.

### Dependencies
- ✅ Backend Team: USF-3547 deployed to PROD/Sandbox
- ⏳ CI/CD validation pending

Test URLs:
- Before: https://b2b-suite-release1--boilerplate-b2b-accs--adobe-commerce.aem.page/
- After: https://usf-3603--boilerplate-b2b-accs--adobe-commerce.aem.page/
