### PR TITLE
feature: automatically subscribe to for price book if configured

### DIFF
--- a/scripts/initializers/auth.js
+++ b/scripts/initializers/auth.js
@@ -1,5 +1,6 @@
 import { initializers } from '@dropins/tools/initializer.js';
 import { initialize, setEndpoint } from '@dropins/storefront-auth/api.js';
+import { getConfigValue } from '@dropins/tools/lib/aem/configs.js';
 import { initializeDropin } from './index.js';
 import { CORE_FETCH_GRAPHQL, fetchPlaceholders } from '../commerce.js';
 
@@ -16,5 +17,5 @@ await initializeDropin(async () => {
   };
 
   // Initialize auth
-  return initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions, adobeCommerceOptimizer: getConfigValue('adobe-commerce-optimizer') });
 })();


### PR DESCRIPTION
Add conditional logic to apply price book header if `adobe-commerce-optimizer: true` in config.
Existing flows remain untouched (ie, if `adobe-commerce-optimizer` is `false` or `undefined`.


To verify:

1. Copy [this config](https://usf-3386--mslabko-test--adobe-commerce.aem.live/config.json) to a config.json locally.
1. Serve and run, load `/apparel` and clear session storage/config and reload.
1. See that requests to CS have price book header and not customer group.
1. Set `adobe-commerce-optimizer: false` in the config.
1. Clear session storage/config and reload.
1. See that requests to CS do NOT have price book header and DO have customer group.

Note: I do not know how this plays with b2b, but this works for b2c!


Test URLS:
- Before:  https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://conditional-aco-header--aem-boilerplate-commerce--hlxsites.aem.live/