### PR TITLE
PAY-6337: Patch infinite load on failed 'confirm-payment-source'

### DIFF
--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -354,6 +354,7 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
 
             PaymentServices.render(CreditCard, {
               getCartId: () => ctx.cartId,
+              onError: () => { /* Patch: define 'onError' callback for submit() to reject on error. */ },
               creditCardFormRef,
             })($creditCard);
 


### PR DESCRIPTION
The Payment Services drop-in does not properly handle the case when no `onError` callback is provided to the `CreditCard` container, resulting in an infinite loader on failed Credit Card checkouts.

A proper fix can and will be implemented in the Payment Services drop-in. Until the proper fix becomes available in the Payment Services drop-in, the infinite loader issue can be mitigated by defining an empty `onError` callback when rendering the `CreditCard`, which is what this pull request implements.

Patch for https://jira.corp.adobe.com/browse/PAY-6337

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://pay-6337-patch--aem-boilerplate-commerce--hlxsites.aem.live/

Before (https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/)
<img width="1403" height="1068" alt="image" src="https://github.com/user-attachments/assets/918e9181-0bcd-430c-ac60-3203a86fc36d" />

After (https://pay-6337-patch--aem-boilerplate-commerce--hlxsites.aem.live/checkout)
<img width="1219" height="708" alt="image" src="https://github.com/user-attachments/assets/616bf7fd-5ecd-44fc-879d-ea5c9e0fa1ff" />
