### PR TITLE
chore: remove sidekick config

### DIFF
--- a/default-site.json
+++ b/default-site.json
@@ -63,31 +63,6 @@
   "robots": {
     "txt": "User-agent: *\nAllow: /\nDisallow: /drafts/\nDisallow: /enrichment/\nDisallow: /tools/\nDisallow: /plugins/experimentation/\n\nSitemap: https://{DOMAIN}/sitemap-index.xml"
   },
-  "sidekick": {
-    "project": "Boilerplate",
-    "plugins": [
-      {
-        "id": "cif",
-        "title": "Commerce",
-        "environments": [
-          "edit"
-        ],
-        "url": "https://main--{SITE}--{ORG}.aem.live/tools/picker/dist/index.html",
-        "isPalette": true,
-        "paletteRect": "top: 54px; left: 5px; bottom: 5px; width: 300px; height: calc(100% - 59px); border-radius: var(--hlx-sk-button-border-radius); overflow: hidden; resize: horizontal;"
-      },
-      {
-        "id": "personalisation",
-        "title": "Personalisation",
-        "environments": [
-          "edit"
-        ],
-        "url": "https://main--{SITE}--{ORG}.aem.live/tools/segments/dist/index.html",
-        "isPalette": true,
-        "paletteRect": "top: 54px; left: 5px; bottom: 5px; width: 300px; height: calc(100% - 59px); border-radius: var(--hlx-sk-button-border-radius); overflow: hidden; resize: horizontal;"
-      }
-    ]
-  },
   "access": {
     "admin": {
       "role": {

--- a/demo-sidekick.json
+++ b/demo-sidekick.json
@@ -1,5 +1,0 @@
-{
-  "project": "My Project",
-  "editUrlLabel": "Document Authoring",
-  "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}{{pathname}}"
-}


### PR DESCRIPTION
Defining `tools/sidekick/config.json` or your own site config is no longer necessary as sidekick config now automated by HLX.

Thus, we can remove these references.

Related thread; https://magento.slack.com/archives/C05QU7MMRNF/p1769611050877079

Test Urls:

- https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- https://remove-sidekick-cfg--aem-boilerplate-commerce--hlxsites.aem.live/