### PR TITLE
USF-3715: Allow categories with hyphens

### DIFF
--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -257,8 +257,11 @@ function getFilterFromParams(filterParam) {
           attribute,
           in: value.split(commaRegex),
         });
-      } else if (value.includes('-')) {
-        // Handle range values (like price)
+      } 
+
+      const rangeRegex = /^\d+(\.\d+)?-\d+(\.\d+)?$/;
+
+      if (rangeRegex.test(value)) {
         const [from, to] = value.split('-');
         results.push({
           attribute,
@@ -268,7 +271,7 @@ function getFilterFromParams(filterParam) {
           },
         });
       } else {
-        // Handle single values (like categories with one value)
+        // Supports hyphens in category/url keys
         results.push({
           attribute,
           in: [value],

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -62,12 +62,17 @@ export default async function decorate(block) {
   if (config.urlpath) {
     // If it's a category page...
     const urlFilters = getFilterFromParams(filter);
-    // Detect if categories already exist in URL
-    const hasCategoryFilter = urlFilters.some((f) => f.attribute === 'categories');
-    // Only inject base category if user hasn't selected any yet
-    const categoryFilter = hasCategoryFilter
+
+    // Normalize urlpath (defensive — removes accidental slashes)
+    const baseCategory = config.urlpath?.replace(/^\/|\/$/g, '');
+
+    // Check whether URL already defines categories
+    const urlCategoryFilter = urlFilters.find((f) => f.attribute === 'categories');
+
+    // If no categories in URL → enforce base category
+    const categoryFilter = urlCategoryFilter
       ? []
-      : [{ attribute: 'categories', in: [config.urlpath] }];
+      : [{ attribute: 'categories', in: [baseCategory] }];
 
     await search({
       phrase: '',
@@ -76,7 +81,7 @@ export default async function decorate(block) {
       sort: sort ? getSortFromParams(sort) : [{ attribute: 'position', direction: 'DESC' }],
       filter: [
         ...categoryFilter,
-        { attribute: 'visibility', in: ['Search', 'Catalog, Search'] },
+        { attribute: 'visibility', in: ['Search', 'Catalog', 'Catalog, Search'] },
         ...urlFilters,
       ],
     }).catch(() => {

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -252,8 +252,11 @@ function getFilterFromParams(filterParam) {
           attribute,
           in: value.split(commaRegex),
         });
-      } else if (value.includes('-')) {
-        // Handle range values (like price)
+      } 
+
+      const rangeRegex = /^\d+(\.\d+)?-\d+(\.\d+)?$/;
+
+      if (rangeRegex.test(value)) {
         const [from, to] = value.split('-');
         results.push({
           attribute,
@@ -263,7 +266,7 @@ function getFilterFromParams(filterParam) {
           },
         });
       } else {
-        // Handle single values (like categories with one value)
+        // Supports hyphens in category/url keys
         results.push({
           attribute,
           in: [value],

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -95,7 +95,7 @@ export default async function decorate(block) {
       pageSize: 8,
       sort: getSortFromParams(sort),
       filter: [
-        { attribute: 'visibility', in: ['Search', 'Catalog, Search'] },
+        { attribute: 'visibility', in: ['Search', 'Catalog', 'Catalog, Search'] },
         ...getFilterFromParams(filter),
       ],
     }).catch(() => {

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -257,7 +257,7 @@ function getFilterFromParams(filterParam) {
           attribute,
           in: value.split(commaRegex),
         });
-      } 
+      }
 
       const rangeRegex = /^\d+(\.\d+)?-\d+(\.\d+)?$/;
 

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -277,6 +277,15 @@ function getFilterFromParams(filterParam) {
 
     // Detect multi-select (comma separated)
     if (value.includes(',')) {
+      const values = [...new Set(value.split(','))];
+      results.push({
+        attribute,
+        in: values,
+      });
+      return;
+    }
+
+    if (value.includes(',')) {
       const values = value
         .split(',')
         .map((v) => v.trim())

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -252,7 +252,7 @@ function getFilterFromParams(filterParam) {
           attribute,
           in: value.split(commaRegex),
         });
-      } 
+      }
 
       const rangeRegex = /^\d+(\.\d+)?-\d+(\.\d+)?$/;
 

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -67,7 +67,7 @@ export default async function decorate(block) {
       pageSize: 8,
       sort: sort ? getSortFromParams(sort) : [{ attribute: 'position', direction: 'DESC' }],
       filter: [
-        { attribute: 'categoryPath', eq: config.urlpath }, // Add category filter
+        { attribute: 'categories', in: [config.urlpath] }, // Add category filter
         { attribute: 'visibility', in: ['Search', 'Catalog, Search'] },
         ...getFilterFromParams(filter),
       ],

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -254,6 +254,7 @@ function getFilterFromParams(filterParam) {
         });
       }
 
+      // Detect real numeric ranges only (e.g. 10-50, 19.99-29.99)
       const rangeRegex = /^\d+(\.\d+)?-\d+(\.\d+)?$/;
 
       if (rangeRegex.test(value)) {
@@ -266,7 +267,7 @@ function getFilterFromParams(filterParam) {
           },
         });
       } else {
-        // Supports hyphens in category/url keys
+        // Supports hyphens in category/url keys, treat as a real string value instead of a range
         results.push({
           attribute,
           in: [value],

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -61,15 +61,23 @@ export default async function decorate(block) {
   // Request search based on the page type on block load
   if (config.urlpath) {
     // If it's a category page...
+    const urlFilters = getFilterFromParams(filter);
+    // Detect if categories already exist in URL
+    const hasCategoryFilter = urlFilters.some((f) => f.attribute === 'categories');
+    // Only inject base category if user hasn't selected any yet
+    const categoryFilter = hasCategoryFilter
+      ? []
+      : [{ attribute: 'categories', in: [config.urlpath] }];
+
     await search({
-      phrase: '', // search all products in the category
+      phrase: '',
       currentPage: page ? Number(page) : 1,
       pageSize: 8,
       sort: sort ? getSortFromParams(sort) : [{ attribute: 'position', direction: 'DESC' }],
       filter: [
-        { attribute: 'categories', in: [config.urlpath] }, // Add category filter
+        ...categoryFilter,
         { attribute: 'visibility', in: ['Search', 'Catalog, Search'] },
-        ...getFilterFromParams(filter),
+        ...urlFilters,
       ],
     }).catch(() => {
       console.error('Error searching for products');


### PR DESCRIPTION
USF-3715: Allow categories with hyphens

Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
After: https://usf-3715-latest--aem-boilerplate-commerce--hlxsites.aem.page/search?q=tee&page=1&sort=&filter=categories%3Acollections%2Femployee-networks

