### PR TITLE
[Example] Update PDP CTA to display Notify Me when OOS 

### DIFF
--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -56,6 +56,10 @@
   margin-top: var(--spacing-big);
 }
 
+.product-details__configuration--out-of-stock .product-details__quantity {
+  display: none;
+}
+
 .product-details__buttons {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -246,6 +246,7 @@ export default async function decorate(block) {
       // When out of stock, handle "Notify Me" action
       if (isOutOfStock) {
         const values = pdpApi.getProductConfigurationValues();
+        // eslint-disable-next-line no-console
         console.log('TODO: Notify Me Callback', { sku: product?.sku, values });
         return;
       }

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -243,15 +243,10 @@ export default async function decorate(block) {
     children: labels.Global?.AddProductToCart,
     icon: h(Icon, { source: 'Cart' }),
     onClick: async () => {
-      // When user clicks the notify-me button, emit notify-me event
-      // Optional: allow you to use the notify-me event to trigger a notification or email
-      // to the customer when the product is back in stock
+      // When out of stock, handle "Notify Me" action
       if (isOutOfStock) {
         const values = pdpApi.getProductConfigurationValues();
-        events.emit('pdp/notify-me', {
-          sku: values?.sku,
-          parentSku: product?.sku,
-        });
+        console.log('TODO: Notify Me Callback', { sku: product?.sku, values });
         return;
       }
 

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -82,6 +82,11 @@ function updatePrimaryCTA(buttonInstance, { isOutOfStock, isUpdateMode, labels }
   }
 }
 
+function updateStockStateClasses(configurationElement, isOutOfStock) {
+  if (!configurationElement) return;
+  configurationElement.classList.toggle('product-details__configuration--out-of-stock', isOutOfStock);
+}
+
 export default async function decorate(block) {
   const product = events.lastPayload('pdp/data') ?? null;
   const labels = await fetchPlaceholders();
@@ -128,6 +133,7 @@ export default async function decorate(block) {
   const $price = fragment.querySelector('.product-details__price');
   const $galleryMobile = fragment.querySelector('.product-details__right-column .product-details__gallery');
   const $shortDescription = fragment.querySelector('.product-details__short-description');
+  const $configuration = fragment.querySelector('.product-details__configuration');
   const $options = fragment.querySelector('.product-details__options');
   const $quantity = fragment.querySelector('.product-details__quantity');
   const $giftCardOptions = fragment.querySelector('.product-details__gift-card-options');
@@ -343,6 +349,7 @@ export default async function decorate(block) {
   // Track stock status and update CTA accordingly
   events.on('pdp/data', (data) => {
     isOutOfStock = data?.inStock === false;
+    updateStockStateClasses($configuration, isOutOfStock);
     updatePrimaryCTA(addToCart, { isOutOfStock, isUpdateMode, labels });
   }, { eager: true });
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

## Add "Notify Me" CTA for out-of-stock products on PDP
### Summary

When a product or selected variant is out of stock, the primary CTA button on the Product Detail Page now displays **"Notify Me"** instead of **"Add to Cart"**. This applies to both simple products and configurable products with multiple options (e.g., size, color). When the user switches to a different variant, the CTA updates dynamically based on that variant's stock status.

Additionally, the quantity selector is now hidden while the selected product/variant is out of stock, and shown again when it is back in stock.

Review the example integration in `blocks/product-details/product-details.js` and `blocks/product-details/product-details.css`.

### Changes

**File:** `blocks/product-details/product-details.js`

- **Replaced `updateAddToCartButtonText` with `updatePrimaryCTA`** — A new helper function that manages all CTA states in one place. When out of stock, it sets the button text to "Notify Me", removes the cart icon, and ensures the button stays enabled. When in stock, it restores "Add to Cart" or "Update in Cart" with the cart icon based on cart context.

- **Added `isOutOfStock` state variable** — Tracks the stock status of the currently selected product/variant, updated reactively via the `pdp/data` event.

- **Added `pdp/data` event listener** (`{ eager: true }`) — Subscribes to product data changes (initial load + variant switches). Sets `isOutOfStock` based on `data.inStock`, updates CTA via `updatePrimaryCTA`, and toggles stock-state CSS class on the configuration container.

- **Added stock-state class helper** `updateStockStateClasses` — Toggles `.product-details__configuration--out-of-stock` on the configuration container to drive quantity visibility in CSS.


- **Guarded `pdp/valid` listener** — The configuration validity check (`pdp/valid`) now only disables the button when the product is in stock. When out of stock, the "Notify Me" button remains enabled regardless of option selection state.

- **Added out-of-stock guard in `onClick` handler** — When `isOutOfStock` is true, clicking the button logs the integration placeholder callback and returns early, preventing any cart logic from executing:
  - `console.log('TODO: Notify Me Callback', { sku: product?.sku, values });`

- **Updated `cart/data` listener** — Now uses `updatePrimaryCTA` for consistent CTA rendering across all state dimensions (stock status, update mode, labels).

**File:** `blocks/product-details/product-details.css`

- Added out-of-stock quantity visibility rule:
  - `.product-details__configuration--out-of-stock .product-details__quantity { display: none; }`

This hides quantity when out of stock and automatically restores it when in stock.

### Behavior

| Scenario | CTA Text | Button State | Quantity | On Click |
|---|---|---|---|---|
| Simple product, in stock | Add to Cart | Enabled (when valid) | Visible | Adds to cart |
| Simple product, out of stock | Notify Me | Enabled | Hidden | Runs custom notify-me callback |
| Configurable, selected variant in stock | Add to Cart | Enabled (when valid) | Visible | Adds to cart |
| Configurable, selected variant out of stock | Notify Me | Enabled | Hidden | Runs custom notify-me callback |
| Update mode, in stock | Update in Cart | Enabled (when valid) | Visible | Updates cart item |
| Update mode, out of stock | Notify Me | Enabled | Hidden | Runs custom notify-me callback |

### Note:
### Behavior Placeholder label
A new NotifyMe placeholder label should be added to the Global placeholders spreadsheet. The code currently falls back to the hardcoded string "Notify Me" if the label is not configured.

Sample Configurable product: https://oos-example--aem-boilerplate-commerce--hlxsites.aem.live/products/tee-shirt/teeshirt?optionsUIDs=Y29uZmlndXJhYmxlLzUzNi81Mw%3D%3D%2CY29uZmlndXJhYmxlLzI3OS8zOQ%3D%3D


https://github.com/user-attachments/assets/3b490614-d0d3-418f-b47d-3247c0a1042f


Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://oos-example--aem-boilerplate-commerce--hlxsites.aem.live/
https://oos-example--aem-boilerplate-commerce--hlxsites.aem.live/products/tee-shirt/teeshirt
