### PR TITLE
Example: Bundle / Group Product support in product-details block (POC)

### DIFF
--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -71,6 +71,53 @@
   margin-top: var(--spacing-xsmall);
 }
 
+/* Group product list */
+.product-details__group-product-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-small);
+}
+
+.product-details__group-product-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+.product-details__group-product-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+}
+
+.product-details__group-product-image img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.product-details__group-product-name {
+  margin: 0;
+  font: var(--type-body-1-strong-font);
+}
+
+.product-details__group-product-sku {
+  font: var(--type-details-caption-1-font);
+}
+
+.product-details__group-product-ctas {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+}
+
+.product-details__group-product-ctas button {
+  width: 100%;
+}
+
 @media (min-width: 900px) {
   .product-details__wrapper {
     grid-template-columns: repeat(var(--grid-3-columns), 1fr);

--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -74,10 +74,10 @@
 /* Group product list */
 .product-details__group-product-list {
   list-style: none;
-  margin: 0;
+  margin: var(--spacing-large) 0;
   padding: 0;
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--spacing-small);
 }
 
@@ -119,6 +119,10 @@
 }
 
 @media (min-width: 900px) {
+  .product-details__group-product-list {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
   .product-details__wrapper {
     grid-template-columns: repeat(var(--grid-3-columns), 1fr);
     column-gap: var(--grid-3-gutters);

--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -72,9 +72,21 @@
 }
 
 /* Group product list */
+.product-details__group-product-list-wrapper {
+  display: flex;
+  flex-direction: column;
+  margin: var(--spacing-large) 0;
+  gap: var(--spacing-small);
+}
+
+.product-details__group-product-add-to-cart-btn {
+  display: flex;
+  justify-content: end;
+}
+
 .product-details__group-product-list {
   list-style: none;
-  margin: var(--spacing-large) 0;
+  margin: 0;
   padding: 0;
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -79,7 +79,7 @@ export default async function decorate(block) {
   // bug: the pdp sends an object with event data even if product is not found.
   const product = eventProduct?.sku ? eventProduct : null;
 
-  const isGroupProduct = product.options?.[0].items?.some((item) => !!item.product);
+  const isGroupProduct = product.options?.[0]?.items?.some((item) => !!item.product);
 
   const labels = await fetchPlaceholders();
 
@@ -115,7 +115,7 @@ export default async function decorate(block) {
         <div class="product-details__attributes"></div>
       </div>
       </div>
-      <div class="product-details__group-product-list"></div>
+      <div class="product-details__group-product-list-wrapper"></div>
   `);
 
   const $alert = fragment.querySelector('.product-details__alert');
@@ -131,7 +131,7 @@ export default async function decorate(block) {
   const $wishlistToggleBtn = fragment.querySelector('.product-details__buttons__add-to-wishlist');
   const $description = fragment.querySelector('.product-details__description');
   const $attributes = fragment.querySelector('.product-details__attributes');
-  const $groupProductList = fragment.querySelector('.product-details__group-product-list');
+  const $groupProductList = fragment.querySelector('.product-details__group-product-list-wrapper');
 
   block.replaceChildren(fragment);
 
@@ -205,7 +205,7 @@ export default async function decorate(block) {
     pdpRendered.render(ProductShortDescription, {})($shortDescription),
 
     // Configuration - Swatches
-    isGroupProduct ? null: pdpRendered.render(ProductOptions, {
+    isGroupProduct ? null : pdpRendered.render(ProductOptions, {
       hideSelectedValue: false,
       slots: {
         SwatchImage: (ctx) => {
@@ -236,7 +236,7 @@ export default async function decorate(block) {
   ]);
 
   // Configuration – Button - Add to Cart
-  const addToCart = await UI.render(Button, {
+  const addToCart = isGroupProduct ? null : await UI.render(Button, {
     children: labels.Global?.AddProductToCart,
     icon: h(Icon, { source: 'Cart' }),
     onClick: async () => {
@@ -411,7 +411,7 @@ export default async function decorate(block) {
   // Lifecycle Events
   events.on('pdp/valid', (valid) => {
     // update add to cart button disabled state based on product selection validity
-    addToCart.setProps((prev) => ({ ...prev, disabled: !valid }));
+    addToCart?.setProps((prev) => ({ ...prev, disabled: !valid }));
   }, { eager: true });
 
   // Handle option changes

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -79,7 +79,7 @@ export default async function decorate(block) {
   // bug: the pdp sends an object with event data even if product is not found.
   const product = eventProduct?.sku ? eventProduct : null;
 
-  const isGroupProduct = product.options?.[0]?.items?.some((item) => !!item.product);
+  const isGroupProduct = product?.options?.[0]?.items?.some((item) => !!item?.product);
 
   const labels = await fetchPlaceholders();
 
@@ -406,7 +406,27 @@ export default async function decorate(block) {
       })($groupItemPriceContainer);
     });
 
-    $groupProductList.replaceChildren($groupItemsList);
+    // Add all products to the cart (each with its selected quantity)
+    const $groupAddToCartBtn = document.createElement('div');
+    $groupAddToCartBtn.className = 'product-details__group-product-add-to-cart-btn';
+    UI.render(Button, {
+      children: 'Add All to Cart', // ideally this will be added to placeholders: labels.Global?.AddAllProductsToCart,
+      icon: h(Icon, { source: 'Cart' }),
+      variant: 'primary',
+      onClick: async () => {
+        const cartItems = product.options?.[0]?.items
+          ?.filter((item) => item.product?.sku)
+          ?.map((item) => ({
+            sku: item.product.sku,
+            quantity: groupItemQuantities[item.product.sku] ?? 1,
+          })) ?? [];
+        if (cartItems.length === 0) return;
+        const { addProductsToCart } = await import('@dropins/storefront-cart/api.js');
+        await addProductsToCart(cartItems);
+      },
+    })($groupAddToCartBtn);
+
+    $groupProductList.replaceChildren($groupAddToCartBtn, $groupItemsList);
   }
   // Lifecycle Events
   events.on('pdp/valid', (valid) => {

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -2,6 +2,9 @@ import {
   InLineAlert,
   Icon,
   Button,
+  Incrementer,
+  PriceRange,
+  Image,
   provider as UI,
 } from '@dropins/tools/components.js';
 import { h } from '@dropins/tools/preact.js';
@@ -76,6 +79,8 @@ export default async function decorate(block) {
   // bug: the pdp sends an object with event data even if product is not found.
   const product = eventProduct?.sku ? eventProduct : null;
 
+  const isGroupProduct = product.options?.[0].items?.some((item) => !!item.product);
+
   const labels = await fetchPlaceholders();
 
   // Read itemUid from URL
@@ -109,7 +114,8 @@ export default async function decorate(block) {
         <div class="product-details__description"></div>
         <div class="product-details__attributes"></div>
       </div>
-    </div>
+      </div>
+      <div class="product-details__group-product-list"></div>
   `);
 
   const $alert = fragment.querySelector('.product-details__alert');
@@ -125,6 +131,7 @@ export default async function decorate(block) {
   const $wishlistToggleBtn = fragment.querySelector('.product-details__buttons__add-to-wishlist');
   const $description = fragment.querySelector('.product-details__description');
   const $attributes = fragment.querySelector('.product-details__attributes');
+  const $groupProductList = fragment.querySelector('.product-details__group-product-list');
 
   block.replaceChildren(fragment);
 
@@ -192,13 +199,13 @@ export default async function decorate(block) {
     pdpRendered.render(ProductHeader, {})($header),
 
     // Price
-    pdpRendered.render(ProductPrice, {})($price),
+    isGroupProduct ? null : pdpRendered.render(ProductPrice, {})($price),
 
     // Short Description
     pdpRendered.render(ProductShortDescription, {})($shortDescription),
 
     // Configuration - Swatches
-    pdpRendered.render(ProductOptions, {
+    isGroupProduct ? null: pdpRendered.render(ProductOptions, {
       hideSelectedValue: false,
       slots: {
         SwatchImage: (ctx) => {
@@ -211,10 +218,10 @@ export default async function decorate(block) {
     })($options),
 
     // Configuration  Quantity
-    pdpRendered.render(ProductQuantity, {})($quantity),
+    isGroupProduct ? null : pdpRendered.render(ProductQuantity, {})($quantity),
 
     // Configuration  Gift Card Options
-    pdpRendered.render(ProductGiftCardOptions, {})($giftCardOptions),
+    isGroupProduct ? null : pdpRendered.render(ProductGiftCardOptions, {})($giftCardOptions),
 
     // Description
     pdpRendered.render(ProductDescription, {})($description),
@@ -223,7 +230,7 @@ export default async function decorate(block) {
     pdpRendered.render(ProductAttributes, {})($attributes),
 
     // Wishlist button - WishlistToggle Container
-    wishlistRender.render(WishlistToggle, {
+    isGroupProduct ? null : wishlistRender.render(WishlistToggle, {
       product,
     })($wishlistToggleBtn),
   ]);
@@ -314,6 +321,93 @@ export default async function decorate(block) {
     },
   })($addToCart);
 
+  // Render list of products in group product
+  if (isGroupProduct) {
+    const $groupItemsList = document.createElement('ul');
+    $groupItemsList.className = 'product-details__group-product-list';
+    const groupItemQuantities = {};
+
+    product.options?.[0].items.forEach(({ product: groupProduct }) => {
+      const { sku } = groupProduct;
+      groupItemQuantities[sku] = 1;
+
+      const $groupItemLi = document.createElement('li');
+      $groupItemLi.className = 'product-details__group-product-item';
+
+      const thumbnail = groupProduct?.images?.[0];
+      const imageUrl = thumbnail?.url ?? '';
+      const $groupItemImage = document.createElement('div');
+      $groupItemImage.className = 'product-details__group-product-image';
+      if (imageUrl) {
+        UI.render(Image, {
+          src: imageUrl,
+          alt: thumbnail?.label ?? groupProduct?.name ?? '',
+          width: 200,
+          height: 200,
+          loading: 'lazy',
+        })($groupItemImage);
+      }
+
+      const $groupItemContent = document.createElement('div');
+      $groupItemContent.className = 'product-details__group-product-content';
+
+      const $groupItemName = document.createElement('h2');
+      $groupItemName.className = 'product-details__group-product-name';
+      $groupItemName.textContent = groupProduct.name;
+
+      const $groupItemSku = document.createElement('div');
+      $groupItemSku.className = 'product-details__group-product-sku';
+      $groupItemSku.textContent = groupProduct.sku;
+
+      const $groupItemPriceContainer = document.createElement('div');
+      $groupItemPriceContainer.className = 'product-details__group-product-price';
+
+      const $groupItemQuantityContainer = document.createElement('div');
+      $groupItemQuantityContainer.className = 'product-details__group-product-quantity';
+      UI.render(Incrementer, {
+        onValue: (value) => {
+          groupItemQuantities[sku] = value;
+        },
+      })($groupItemQuantityContainer);
+
+      const $groupItemCtas = document.createElement('div');
+      $groupItemCtas.className = 'product-details__group-product-ctas';
+
+      const $groupItemAddToCartBtn = document.createElement('div');
+      UI.render(Button, {
+        children: labels.Global?.AddProductToCart,
+        icon: h(Icon, { source: 'Cart' }),
+        variant: 'primary',
+        onClick: async () => {
+          const { addProductsToCart } = await import(
+            '@dropins/storefront-cart/api.js'
+          );
+          await addProductsToCart([{
+            sku,
+            quantity: groupItemQuantities[sku] ?? 1,
+          }]);
+        },
+      })($groupItemAddToCartBtn);
+      $groupItemCtas.appendChild($groupItemAddToCartBtn);
+
+      $groupItemContent.append(
+        $groupItemName,
+        $groupItemSku,
+        $groupItemPriceContainer,
+        $groupItemQuantityContainer,
+        $groupItemCtas,
+      );
+      $groupItemLi.append($groupItemImage, $groupItemContent);
+      $groupItemsList.appendChild($groupItemLi);
+
+      UI.render(PriceRange, {
+        amount: groupProduct.price.final.amount.value,
+        currency: groupProduct.price.final.amount.currency,
+      })($groupItemPriceContainer);
+    });
+
+    $groupProductList.replaceChildren($groupItemsList);
+  }
   // Lifecycle Events
   events.on('pdp/valid', (valid) => {
     // update add to cart button disabled state based on product selection validity

--- a/build.mjs
+++ b/build.mjs
@@ -36,7 +36,7 @@ overrideGQLOperations([
       }
       `,
     ],
-  }
+  },
   // {
   //   npm: '@dropins/storefront-checkout',
   //   operations: [],

--- a/build.mjs
+++ b/build.mjs
@@ -12,6 +12,31 @@ overrideGQLOperations([
     skipFragments: ['DOWNLOADABLE_ORDER_ITEMS_FRAGMENT'],
     operations: [],
   },
+  // Extend the PDP data payload: override GraphQL fragment so option values that are products
+  // include images (url, label). When you run the install command, build generates a new query
+  // that includes this data. Used for group products; pdp initializer transformer normalizes
+  // at options[].items[].product.images.
+  // @see https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/extending/
+  // @see https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/initialization/
+  {
+    npm: '@dropins/storefront-pdp',
+    operations: [
+      `
+      fragment PRODUCT_OPTION_FRAGMENT on ProductViewOption {
+        values {
+          ... on ProductViewOptionValueProduct {
+            product {
+              images {
+                url
+                label
+              }
+            }
+          }
+        }
+      }
+      `,
+    ],
+  }
   // {
   //   npm: '@dropins/storefront-checkout',
   //   operations: [],

--- a/scripts/__dropins__/storefront-pdp/fragments.original.js
+++ b/scripts/__dropins__/storefront-pdp/fragments.original.js
@@ -1,55 +1,55 @@
-const e = (`fragment PRODUCT_OPTION_FRAGMENT on ProductViewOption {
-  id
-  title
-  required
-  multi
-  values {
+/*! Copyright 2026 Adobe
+All Rights Reserved. */
+const e=`
+fragment PRODUCT_OPTION_FRAGMENT on ProductViewOption {
     id
     title
-    inStock
-    __typename
-    ... on ProductViewOptionValueProduct {
-      title
-      quantity
-      isDefault
-      __typename
-      product {
-        sku
-        shortDescription
-        metaDescription
-        metaKeyword
-        metaTitle
-        name
-        price {
-          final {
-            amount {
-              value
-              currency
-            }
-          }
-          regular {
-            amount {
-              value
-              currency
-            }
-          }
-          roles
-        }
-        images {
-          url
-          label
-        }
-      }
-    }
-    ... on ProductViewOptionValueSwatch {
+    required
+    multi
+    values {
       id
       title
-      type
-      value
       inStock
+      __typename
+      ... on ProductViewOptionValueProduct {
+        title
+        quantity
+        isDefault
+        __typename
+        product {
+          sku
+          shortDescription
+          metaDescription
+          metaKeyword
+          metaTitle
+          name
+          price {
+            final {
+              amount {
+                value
+                currency
+              }
+            }
+            regular {
+              amount {
+                value
+                currency
+              }
+            }
+            roles
+          }
+        }
+      }
+      ... on ProductViewOptionValueSwatch {
+        id
+        title
+        type
+        value
+        inStock
+      }
     }
   }
-}`), t = `
+`,t=`
   fragment PRICE_RANGE_FRAGMENT on ComplexProductView {
     priceRange {
       maximum {
@@ -84,7 +84,7 @@ const e = (`fragment PRODUCT_OPTION_FRAGMENT on ProductViewOption {
       }
     }
   }
-`, r = `
+`,r=`
 fragment PRODUCT_FRAGMENT on ProductView {
   __typename
   id
@@ -159,9 +159,5 @@ fragment PRODUCT_FRAGMENT on ProductView {
 
 ${e}
 ${t}
-`;
-export {
-t as PRICE_RANGE_FRAGMENT,
-r as PRODUCT_FRAGMENT,
-e as PRODUCT_OPTION_FRAGMENT
-};
+`;export{t as PRICE_RANGE_FRAGMENT,r as PRODUCT_FRAGMENT,e as PRODUCT_OPTION_FRAGMENT};
+//# sourceMappingURL=fragments.js.map

--- a/scripts/__dropins__/storefront-recommendations/fragments.original.js
+++ b/scripts/__dropins__/storefront-recommendations/fragments.original.js
@@ -1,0 +1,61 @@
+/*! Copyright 2025 Adobe
+All Rights Reserved. */
+const e=`
+  fragment PRODUCTS_VIEW_FRAGMENT on ProductView {
+    __typename
+    name
+    sku
+    queryType
+    visibility
+    images {
+      url
+    }
+    urlKey
+    ... on SimpleProductView {
+      price {
+        final {
+          amount {
+            currency
+            value
+          }
+        }
+      }
+    }
+    ... on ComplexProductView {
+      priceRange {
+        maximum {
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+        }
+        minimum {
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+`,n=`
+  fragment UNIT_FRAGMENT on RecommendationUnit {
+    displayOrder
+    pageType
+    productsView {
+      ...PRODUCTS_VIEW_FRAGMENT
+    }
+    storefrontLabel
+    totalProducts
+    typeId
+    unitId
+    unitName
+  }
+
+  ${e}
+`;export{e as PRODUCTS_VIEW_FRAGMENT,n as UNIT_FRAGMENT};
+//# sourceMappingURL=fragments.js.map

--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -102,6 +102,24 @@ await initializeDropin(async () => {
   const models = {
     ProductDetails: {
       initialData: { ...product },
+      // Normalizes product images at options[].items[].product for group products. Transformer
+      // receives GraphQL data and returns an object that gets deep-merged with the payload;
+      // return only this structure (no spread) to avoid exposing unnecessary data. Items without
+      // item.product get product: undefined and are skipped for images.
+      // @see https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/initialization/
+      // @see https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/extending/
+      transformer: (data) => ({
+        options: data.options?.map((option) => ({
+          items: option.items?.map((item) => ({
+            product: item.product ? {
+              images: item.product?.images?.map((image) => ({
+                url: image.url,
+                label: image.label,
+              })) ?? [],
+            } : undefined,
+          })) ?? [],
+        })) ?? [],
+      }),
     },
   };
 


### PR DESCRIPTION
Preview URL: https://example-grouped--aem-boilerplate-commerce--hlxsites.aem.live/products/test-grouped-product/test-grpd-product 

## ⚠️ Warning

**This is not production-ready.** It is a **proof of concept (POC)** to validate and demonstrate how bundle/group product functionality can be added to the product-details block. Use it to understand the approach and data flow; before production you should:

- Harden error handling and loading states
- Add responsive styling for multiple viewports
- Handle out-of-stock and other product attribute labels (e.g. availability, custom attributes)
- Add tests and accessibility checks
- Confirm UX and design with your team

---

## Summary of updates

### 1. **build.mjs** – Extend PDP GraphQL payload

- **What:** Override `PRODUCT_OPTION_FRAGMENT` for `@dropins/storefront-pdp` so option values that are products request `product.images { url, label }`.
- **Why:** The default fragment does not include images for option products; the PDP needs them to show thumbnails for each bundle item.
- **How:** `overrideGQLOperations()` with a new fragment on `ProductViewOption` → `values` → `ProductViewOptionValueProduct` → `product.images`.
- **Docs:** [Extending Drop-In Components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/extending/) (extend data payload via `build.mjs`); [Product Details initialization](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/initialization/).

### 2. **scripts/initializers/pdp.js** – Normalize group product images

- **What:** Add a **transformer** on the `ProductDetails` model that normalizes `options[].items[].product.images` to `{ url, label }` and merges only that structure (no spreading full product/option data).
- **Why:** Ensures images are in a consistent shape and limits what is merged so the initializer deep-merge does not expose or overwrite with unnecessary data.
- **How:** Transformer returns only `{ options: [ { items: [ { product: { images: [...] } } ] } ] }`; items without `item.product` get `product: undefined`. The initializer deep-merges this into the existing product payload.
- **Docs:** [Product Details initialization – Customizing data models](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/initialization/) (transformer, models); [Extending – Add new data to the payload](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/extending/) (transformer merge behavior).

### 3. **blocks/product-details/product-details.js** – Group product UI

- **Detection:** `isGroupProduct = product.options?.[0].items?.some((item) => !!item.product)`.
- **Layout:** When `isGroupProduct` is true:
  - The block uses the placeholder `div.product-details__group-product-list` and replaces its children with a `<ul>` of items.
  - Standard PDP slots (ProductPrice, ProductOptions, ProductQuantity, Add to Cart, WishlistToggle, etc.) are not rendered for the main product; only the group list is shown.
- **Per item (one loop):**
  - **Image:** `Image` from `@dropins/tools/components.js` using first image from `options[0].items[i].product.images` (url, alt, 80×80 or your chosen size, lazy).
  - **Title:** Product name (`h2`).
  - **SKU:** Product SKU.
  - **Price:** `PriceRange` with `amount` and `currency` from `groupProduct.price.final.amount`.
  - **Quantity:** `Incrementer` (min/max as needed); value stored in a `groupItemQuantities[sku]` map and updated via `onValue`.
  - **Add to cart:** `Button` that calls `addProductsToCart([{ sku, quantity: groupItemQuantities[sku] ?? 1 }])` via dynamic import of `@dropins/storefront-cart/api.js`.
- **Naming:** List container `$groupItemsList`; per-item nodes use `$groupItem*` (e.g. `$groupItemImage`, `$groupItemName`, `$groupItemPriceContainer`).

### 4. **blocks/product-details/product-details.css** – Group product styles

- **List:** `.product-details__group-product-list` – no list bullets, flex (e.g. column or row by breakpoint), gap.
- **Item:** `.product-details__group-product-item` – flex column, gap.
- **Content:** `.product-details__group-product-content` – flex column for name, sku, price, quantity, CTAs.
- **Image:** `.product-details__group-product-image img` – size, object-fit, optional border-radius.
- **Name / SKU / CTAs:** Typography and spacing; CTAs (e.g. button full width on small screens) as needed.

---

## Steps to take (high level)

1. **Backend / schema**
   - Confirm your Catalog Service / GraphQL exposes a group/bundle product with option values that are products (e.g. `ProductViewOptionValueProduct`) and that `product.images { url, label }` (and optionally `roles`) are available.
   - If your API uses `items` instead of `values` in the response, the transformer in `pdp.js` is written for `options[].items[]`; align fragment and transformer with the actual field names.

2. **Build**
   - Ensure `build.mjs` runs as part of your install/build (e.g. `npm run build` or drop-in install). This regenerates the PDP GraphQL so the extended fragment is used.
   - See: [Extending – Extend the data payload for the drop-in](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/extending/).

3. **PDP initializer**
   - Keep the Product Details initializer that passes `models.ProductDetails.transformer` and ensure `initialData` (e.g. from `fetchProductData`) is the product that includes options/items.
   - Transformer should return only the minimal structure for images (no spread) so the initializer deep-merge does not overwrite other product fields. See: [Product Details initialization – Model properties](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/initialization/).

4. **product-details block**
   - Use `isGroupProduct` to switch between standard PDP and group-product list.
   - Ensure the block has a stable placeholder for the group list (e.g. `div.product-details__group-product-list`) and that the list is rendered only when `isGroupProduct` is true and `product.options?.[0].items` exists.
   - Keep per-item logic in a single loop: build DOM, render Image/PriceRange/Incrementer/Button, and wire Add to Cart to `addProductsToCart` with the item’s `sku` and the quantity from the Incrementer.

5. **Cart**
   - `addProductsToCart` is used per line item; no change to cart API contract. Ensure storefront-cart is initialized and that the cart drop-in can display multiple line items.


---

## Documentation references

| Topic | URL |
|-------|-----|
| Extending Drop-In Components (payload, build.mjs, transformer) | https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/extending/ |
| Product Details initialization (models, transformer) | https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/initialization/ |

---

## Files touched

**Review these only.** You may also see changes under `scripts/__dropins__/` in the PR.

### Why `scripts/__dropins__/` appears in the PR

The drop-in build tooling (triggered by the `build.mjs` overrides and your install/build) **generates** output under `scripts/__dropins__/`. Those files are merged, transformed, or bundled versions of the npm drop-ins (e.g. storefront-pdp, storefront-cart). So when we change `build.mjs` or dependencies, the build can update files in `__dropins__/` (e.g. fragments, chunks, containers). That’s why they show up in the diff.

### Please ignore generated `__dropins__` files

**Ignore changes under `scripts/__dropins__/` when reviewing.** They are **generated** and will be recreated on your side when you run `npm install` (or your project’s build step that runs the drop-in build). Review and merge only the source changes below; the same build will produce the appropriate `__dropins__` output in your environment.

### Source files to review

- `build.mjs` – GraphQL fragment override for PDP option product images.
- `scripts/initializers/pdp.js` – ProductDetails model transformer for `options[].items[].product.images`.
- `blocks/product-details/product-details.js` – Group product detection, list rendering, Image/PriceRange/Incrementer/Button and Add to Cart.
- `blocks/product-details/product-details.css` – Styles for group product list and items.


Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/test-grouped-product/test-grpd-product
- After: https://example-grouped--aem-boilerplate-commerce--hlxsites.aem.live/products/test-grouped-product/test-grpd-product
