### PR TITLE
PAY-6579 - Hide APMs payment method on Checkout in ACCS

### DIFF
--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -368,6 +368,9 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
         [PaymentMethodCode.SMART_BUTTONS]: {
           enabled: false,
         },
+        [PaymentMethodCode.APM]: {
+          enabled: false,
+        },
         [PaymentMethodCode.APPLE_PAY]: {
           render: (ctx) => {
             const $applePay = document.createElement('div');
@@ -407,9 +410,6 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
           enabled: false,
         },
         [PaymentMethodCode.VAULT]: {
-          enabled: false,
-        },
-        [PaymentMethodCode.FASTLANE]: {
           enabled: false,
         },
       },

--- a/scripts/__dropins__/storefront-payment-services/data/models/method.d.ts
+++ b/scripts/__dropins__/storefront-payment-services/data/models/method.d.ts
@@ -4,6 +4,7 @@ export declare enum PaymentMethodCode {
     FASTLANE = "payment_services_paypal_fastlane",
     GOOGLE_PAY = "payment_services_paypal_google_pay",
     SMART_BUTTONS = "payment_services_paypal_smart_buttons",
-    VAULT = "payment_services_paypal_vault"
+    VAULT = "payment_services_paypal_vault",
+    APM = "payment_services_paypal_apm"
 }
 //# sourceMappingURL=method.d.ts.map


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/PAY-6579

We added "APM" in the backend for our Luma integration. However, the payment method is not functional in EDS and should be hidden.

Test URLs:

Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
After: https://pay-6579--aem-boilerplate-commerce--hlxsites.aem.live/
