### PR TITLE
ACCS-603: upgrade `@dropins/storefront-pdp` to `3.0.3-beta2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@dropins/storefront-checkout": "~3.2.0",
         "@dropins/storefront-order": "3.2.0",
         "@dropins/storefront-payment-services": "~3.1.0",
-        "@dropins/storefront-pdp": "~3.0.2",
+        "@dropins/storefront-pdp": "^3.0.3-beta2",
         "@dropins/storefront-personalization": "~3.1.1",
         "@dropins/storefront-product-discovery": "~3.1.0",
         "@dropins/storefront-recommendations": "~3.0.0",
@@ -2077,9 +2077,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-pdp": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-pdp/-/storefront-pdp-3.0.2.tgz",
-      "integrity": "sha512-wtzRHwqpFgP2a8HwM6eMd0dIV4xOTiZRTclNLxiM7WNmjUO9S0HcNqaKxmFWw5SO4Ooy2WAa+RvWkTWD1X76Wg==",
+      "version": "3.0.3-beta2",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-pdp/-/storefront-pdp-3.0.3-beta2.tgz",
+      "integrity": "sha512-Gv+YgprHLVExvrmdq7mMhQ5QOHyNQt4rIcL2d5rquvgkQ21FdaoLJaPbQTmdt00vvlRf3AXPjYNyyzy6me8ClA==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-personalization": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@dropins/storefront-checkout": "~3.2.0",
     "@dropins/storefront-order": "3.2.0",
     "@dropins/storefront-payment-services": "~3.1.0",
-    "@dropins/storefront-pdp": "~3.0.2",
+    "@dropins/storefront-pdp": "^3.0.3-beta2",
     "@dropins/storefront-personalization": "~3.1.1",
     "@dropins/storefront-product-discovery": "~3.1.0",
     "@dropins/storefront-recommendations": "~3.0.0",


### PR DESCRIPTION
- https://jira.corp.adobe.com/browse/ACCS-603

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://accs-603-pdp-variants--aem-boilerplate-commerce--hlxsites.aem.live/