### PR TITLE
ACCS-579: Numeric range facet include/exclude slider sample (PoC)

### DIFF
--- a/blocks/product-list-page/numeric-range-slider.js
+++ b/blocks/product-list-page/numeric-range-slider.js
@@ -1,0 +1,207 @@
+const DEBOUNCE_MS = 300;
+
+function clamp(value, lo, hi) {
+  return Math.max(lo, Math.min(hi, value));
+}
+
+export function createNumericRangeSlider({
+  label, min: initMin, max: initMax, leftMax, rightMin, unit = '', onChange,
+}) {
+  let min = initMin;
+  let max = initMax;
+  let lMax = Math.min(leftMax ?? max, max);
+  let rMin = Math.max(rightMin ?? min, min);
+  let curMin = min;
+  let curMax = max;
+  let enabled = false;
+  let debounceTimer = null;
+
+  const toPercent = (v) => ((v - min) / (max - min)) * 100;
+  const fromPercent = (pct) => {
+    const raw = min + ((max - min) * clamp(pct, 0, 100)) / 100;
+    return Math.round(raw);
+  };
+
+  const fireChange = (newMin, newMax) => {
+    enabled = true;
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => onChange?.(newMin, newMax), DEBOUNCE_MS);
+  };
+
+  const el = document.createElement('div');
+  el.className = 'numeric-range-slider';
+  el.innerHTML = `
+    <div class="numeric-range-slider__header">
+      <span class="numeric-range-slider__label">${label}</span>
+    </div>
+    <div class="numeric-range-slider__body">
+      <div class="numeric-range-slider__track-wrapper">
+        <div class="numeric-range-slider__track">
+          <div class="numeric-range-slider__fill numeric-range-slider__fill--left"></div>
+          <div class="numeric-range-slider__fill numeric-range-slider__fill--locked"></div>
+          <div class="numeric-range-slider__fill numeric-range-slider__fill--right"></div>
+        </div>
+        <div class="numeric-range-slider__handle numeric-range-slider__handle--min"
+             role="slider" tabindex="0"
+             aria-label="${label} minimum"
+             aria-valuemin="${min}" aria-valuemax="${max}" aria-valuenow="${curMin}"></div>
+        <div class="numeric-range-slider__handle numeric-range-slider__handle--max"
+             role="slider" tabindex="0"
+             aria-label="${label} maximum"
+             aria-valuemin="${min}" aria-valuemax="${max}" aria-valuenow="${curMax}"></div>
+      </div>
+      <div class="numeric-range-slider__footer">
+        <span class="numeric-range-slider__value numeric-range-slider__value--min">${curMin}${unit}</span>
+        <span class="numeric-range-slider__value numeric-range-slider__value--max">${curMax}${unit}</span>
+      </div>
+    </div>
+  `;
+
+  const trackWrapper = el.querySelector('.numeric-range-slider__track-wrapper');
+  const track = el.querySelector('.numeric-range-slider__track');
+  const fillLeft = el.querySelector('.numeric-range-slider__fill--left');
+  const fillLocked = el.querySelector('.numeric-range-slider__fill--locked');
+  const fillRight = el.querySelector('.numeric-range-slider__fill--right');
+  const handleMin = el.querySelector('.numeric-range-slider__handle--min');
+  const handleMax = el.querySelector('.numeric-range-slider__handle--max');
+  const valueMin = el.querySelector('.numeric-range-slider__value--min');
+  const valueMax = el.querySelector('.numeric-range-slider__value--max');
+
+  function render() {
+    const minPct = toPercent(curMin);
+    const maxPct = toPercent(curMax);
+    const lMaxPct = toPercent(lMax);
+    const rMinPct = toPercent(rMin);
+
+    // Clamp fills so they never extend past the handles
+    const fillLPct = Math.min(lMaxPct, maxPct);
+    const fillRPct = Math.max(rMinPct, minPct);
+
+    fillLeft.style.left = `${minPct}%`;
+    fillLeft.style.right = `${100 - fillLPct}%`;
+
+    // Locked zone between leftMax and rightMin (hidden when ranges overlap)
+    if (lMax < rMin) {
+      fillLocked.style.left = `${fillLPct}%`;
+      fillLocked.style.right = `${100 - fillRPct}%`;
+      fillLocked.style.display = '';
+    } else {
+      fillLocked.style.display = 'none';
+    }
+
+    fillRight.style.left = `${fillRPct}%`;
+    fillRight.style.right = `${100 - maxPct}%`;
+
+    handleMin.style.left = `${minPct}%`;
+    handleMax.style.left = `${maxPct}%`;
+    handleMin.setAttribute('aria-valuenow', curMin);
+    handleMax.setAttribute('aria-valuenow', curMax);
+    valueMin.textContent = `${curMin}${unit}`;
+    valueMax.textContent = `${curMax}${unit}`;
+  }
+
+  function getPctFromEvent(clientX) {
+    const rect = trackWrapper.getBoundingClientRect();
+    return ((clientX - rect.left) / rect.width) * 100;
+  }
+
+  function handlePointerDown(handle, e) {
+    e.preventDefault();
+    const target = e.currentTarget;
+    target.setPointerCapture(e.pointerId);
+
+    const onMove = (ev) => {
+      const val = fromPercent(getPctFromEvent(ev.clientX));
+      if (handle === 'min') {
+        curMin = clamp(val, min, curMax);
+      } else {
+        curMax = clamp(val, curMin, max);
+      }
+      render();
+      fireChange(curMin, curMax);
+    };
+
+    const onUp = () => {
+      target.removeEventListener('pointermove', onMove);
+      target.removeEventListener('pointerup', onUp);
+      target.removeEventListener('pointercancel', onUp);
+      fireChange(curMin, curMax);
+    };
+
+    target.addEventListener('pointermove', onMove);
+    target.addEventListener('pointerup', onUp);
+    target.addEventListener('pointercancel', onUp);
+  }
+
+  handleMin.addEventListener('pointerdown', (e) => handlePointerDown('min', e));
+  handleMax.addEventListener('pointerdown', (e) => handlePointerDown('max', e));
+
+  function handleKeyDown(handle, e) {
+    const step = e.shiftKey ? 10 : 1;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+      if (handle === 'min') curMin = clamp(curMin + step, min, curMax);
+      else curMax = clamp(curMax + step, curMin, max);
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+      if (handle === 'min') curMin = clamp(curMin - step, min, curMax);
+      else curMax = clamp(curMax - step, curMin, max);
+      e.preventDefault();
+    } else {
+      return;
+    }
+    render();
+    fireChange(curMin, curMax);
+  }
+
+  handleMin.addEventListener('keydown', (e) => handleKeyDown('min', e));
+  handleMax.addEventListener('keydown', (e) => handleKeyDown('max', e));
+
+  track.addEventListener('click', (e) => {
+    const val = fromPercent(getPctFromEvent(e.clientX));
+    if (Math.abs(val - curMin) <= Math.abs(val - curMax)) {
+      curMin = clamp(val, min, curMax);
+    } else {
+      curMax = clamp(val, curMin, max);
+    }
+    render();
+    fireChange(curMin, curMax);
+  });
+
+  render();
+
+  el.updateBounds = (newMin, newMax, newLeftMax, newRightMin) => {
+    min = newMin;
+    max = newMax;
+    lMax = Math.min(newLeftMax ?? max, max);
+    rMin = Math.max(newRightMin ?? min, min);
+    curMin = clamp(curMin, min, max);
+    curMax = clamp(curMax, min, max);
+    if (curMin > curMax) curMin = curMax;
+    handleMin.setAttribute('aria-valuemin', min);
+    handleMin.setAttribute('aria-valuemax', max);
+    handleMax.setAttribute('aria-valuemin', min);
+    handleMax.setAttribute('aria-valuemax', max);
+    render();
+    return { min: curMin, max: curMax };
+  };
+
+  el.setValues = (newMin, newMax) => {
+    curMin = clamp(newMin, min, max);
+    curMax = clamp(newMax, min, max);
+    if (curMin > curMax) curMin = curMax;
+    render();
+    return { min: curMin, max: curMax };
+  };
+
+  el.reset = () => {
+    enabled = false;
+    curMin = min;
+    curMax = max;
+    render();
+  };
+
+  el.setEnabled = (on) => { enabled = on; };
+  el.isEnabled = () => enabled;
+
+  return el;
+}

--- a/blocks/product-list-page/product-list-page.css
+++ b/blocks/product-list-page/product-list-page.css
@@ -83,18 +83,101 @@
 
 /* Empty State */
 
-.block.product-list-page.product-list-page--empty .search__wrapper {
-    grid-template-areas:
-        "product-list";
-    grid-template-columns: 1fr;
-}
-
-.block.product-list-page.product-list-page--empty .search__result-info,
-.block.product-list-page.product-list-page--empty .search__view-facets,
-.block.product-list-page.product-list-page--empty .search__facets,
-.block.product-list-page.product-list-page--empty .search__product-sort,
 .block.product-list-page.product-list-page--empty .search__pagination {
     display: none;
+}
+
+/* Slider pills — icon after text to match dropin selected filters */
+.search__slider-pill .dropin-button {
+    flex-direction: row-reverse;
+}
+
+/* Numeric Range Slider */
+
+.numeric-range-slider {
+    padding-block: var(--spacing-small);
+    border-bottom: 1px solid var(--color-neutral-400);
+}
+
+.numeric-range-slider__label {
+    display: block;
+    margin-block-end: var(--spacing-xsmall);
+}
+
+.numeric-range-slider__body {
+    margin-block-start: var(--spacing-xxsmall);
+}
+
+.numeric-range-slider__track-wrapper {
+    position: relative;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    margin-inline: 8px;
+}
+
+.numeric-range-slider__track {
+    position: relative;
+    width: 100%;
+    height: 4px;
+    background: var(--color-neutral-400);
+    border-radius: var(--shape-border-radius-2);
+    cursor: pointer;
+}
+
+.numeric-range-slider__fill {
+    position: absolute;
+    height: 100%;
+    border-radius: var(--shape-border-radius-2);
+}
+
+.numeric-range-slider__fill--left,
+.numeric-range-slider__fill--right {
+    background: var(--color-neutral-800, #222);
+}
+
+.numeric-range-slider__fill--locked {
+    background: repeating-linear-gradient(
+        -45deg,
+        var(--color-neutral-800, #222),
+        var(--color-neutral-800, #222) 2px,
+        var(--color-neutral-400, #bbb) 2px,
+        var(--color-neutral-400, #bbb) 5px
+    );
+    opacity: 0.5;
+}
+
+.numeric-range-slider__handle {
+    position: absolute;
+    top: 50%;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--color-neutral-800, #222);
+    border: 2px solid var(--color-neutral-50, #fff);
+    transform: translate(-50%, -50%);
+    cursor: grab;
+    touch-action: none;
+    z-index: 1;
+}
+
+.numeric-range-slider__handle:focus-visible {
+    outline: 2px solid var(--color-action-focus, #1473e6);
+    outline-offset: 2px;
+}
+
+.numeric-range-slider__handle:active {
+    cursor: grabbing;
+}
+
+.numeric-range-slider__footer {
+    display: flex;
+    justify-content: space-between;
+    margin-block-start: var(--spacing-xxsmall);
+}
+
+.numeric-range-slider__value {
+    font: var(--type-body-2-default-font);
 }
 
 /* Media Queries */

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -18,10 +18,65 @@ import { events } from '@dropins/tools/event-bus.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 import { fetchPlaceholders, getProductLink } from '../../scripts/commerce.js';
 import { getSearchStateFromUrl, applySearchStateToUrl } from './search-url.js';
+// Numeric Range Slider
+import { createNumericRangeSlider } from './numeric-range-slider.js';
 
 // Initializers
 import '../../scripts/initializers/search.js';
 import '../../scripts/initializers/wishlist.js';
+
+// filterMode 'exclude': product range must CONTAIN slider range
+// filterMode 'include': product range must FIT WITHIN slider range
+const NUMERIC_RANGE_FACETS = [
+  {
+    minAttribute: 'temperature_min',
+    maxAttribute: 'temperature_max',
+    label: 'Temperature (Exclude)',
+    unit: '°C',
+    filterMode: 'exclude',
+  },
+  {
+    minAttribute: 'turbidity_min',
+    maxAttribute: 'turbidity_max',
+    label: 'Turbidity (Include)',
+    unit: ' NTU',
+    filterMode: 'include',
+  },
+];
+
+const NUMERIC_RANGE_ALL_ATTRS = new Set(
+  NUMERIC_RANGE_FACETS.flatMap((c) => [c.minAttribute, c.maxAttribute]),
+);
+const NUMERIC_RANGE_BY_MIN = Object.fromEntries(
+  NUMERIC_RANGE_FACETS.map((c) => [c.minAttribute, c]),
+);
+const NUMERIC_RANGE_BY_MAX = Object.fromEntries(
+  NUMERIC_RANGE_FACETS.map((c) => [c.maxAttribute, c]),
+);
+
+function getStatsBounds(facet) {
+  const stats = facet.buckets.find((b) => b.__typename === 'StatsBucket');
+  if (stats && stats.min != null && stats.max != null) {
+    return { min: stats.min, max: stats.max };
+  }
+  return null;
+}
+
+// Live Search `to` is exclusive (<), so add epsilon to include boundary values
+const RANGE_EPSILON = 0.01;
+
+function getNumericRangeFilters(config, sliderMin, sliderMax) {
+  if (config.filterMode === 'exclude') {
+    return [
+      { attribute: config.minAttribute, range: { to: sliderMin + RANGE_EPSILON } },
+      { attribute: config.maxAttribute, range: { from: sliderMax } },
+    ];
+  }
+  return [
+    { attribute: config.minAttribute, range: { from: sliderMin } },
+    { attribute: config.maxAttribute, range: { to: sliderMax + RANGE_EPSILON } },
+  ];
+}
 
 export default async function decorate(block) {
   const labels = await fetchPlaceholders();
@@ -58,14 +113,122 @@ export default async function decorate(block) {
 
   const searchState = getSearchStateFromUrl(new URL(window.location.href));
 
-  // Default visibility filter for all of our requests
   const visibilityFilter = { attribute: 'visibility', in: ['Search', 'Catalog, Search'] };
-  const userFilters = searchState.filter.filter((f) => f.attribute !== 'visibility');
+  const userFilters = searchState.filter.filter(
+    (f) => f.attribute !== 'visibility' && !NUMERIC_RANGE_ALL_ATTRS.has(f.attribute),
+  );
 
-  // Normalize URL (e.g. pipe-separated filter values)
   const normalizedUrl = new URL(window.location.href);
   applySearchStateToUrl(normalizedUrl, searchState);
   window.history.replaceState({}, '', normalizedUrl.toString());
+
+  const sliderSelections = {};
+  const sliderElements = {};
+  const collectedBounds = {};
+  let lastSearchRequest = null;
+
+  const urlSliders = searchState.slider;
+  NUMERIC_RANGE_FACETS.forEach((cfg) => {
+    const urlState = urlSliders.get(cfg.label.toLowerCase());
+    if (urlState) {
+      sliderSelections[cfg.minAttribute] = { min: urlState.min, max: urlState.max };
+    }
+  });
+
+  function reissueSearch() {
+    if (!lastSearchRequest) return;
+
+    const baseFilters = (lastSearchRequest.filter || []).filter(
+      (f) => !NUMERIC_RANGE_ALL_ATTRS.has(f.attribute),
+    );
+
+    const rangeFilters = [];
+    NUMERIC_RANGE_FACETS.forEach((c) => {
+      const slider = sliderElements[c.minAttribute];
+      const sel = sliderSelections[c.minAttribute];
+      if (slider?.isEnabled() && sel) {
+        rangeFilters.push(...getNumericRangeFilters(c, sel.min, sel.max));
+      }
+    });
+
+    search({
+      ...lastSearchRequest,
+      filter: [...baseFilters, ...rangeFilters],
+      currentPage: 1,
+    }).catch((e) => {
+      console.error('Error searching with numeric range filters', e);
+    });
+  }
+
+  function onSliderChange(cfg, newMin, newMax) {
+    sliderSelections[cfg.minAttribute] = { min: newMin, max: newMax };
+    updateSliderPills();
+    reissueSearch();
+  }
+
+  function onSliderReset(cfg) {
+    delete sliderSelections[cfg.minAttribute];
+    sliderElements[cfg.minAttribute]?.reset();
+    updateSliderPills();
+    reissueSearch();
+  }
+
+  // --- Slider pills in Selected Facets ---
+  const sliderPillsContainer = document.createElement('div');
+  sliderPillsContainer.className = 'search__slider-pills';
+  let dropinHasSelections = false;
+
+  function resetAllSliders() {
+    NUMERIC_RANGE_FACETS.forEach((cfg) => {
+      if (sliderElements[cfg.minAttribute]?.isEnabled()) {
+        onSliderReset(cfg);
+      }
+    });
+  }
+
+  function updateSliderPills() {
+    sliderPillsContainer.innerHTML = '';
+    let hasActiveSliders = false;
+    NUMERIC_RANGE_FACETS.forEach((cfg) => {
+      const slider = sliderElements[cfg.minAttribute];
+      const sel = sliderSelections[cfg.minAttribute];
+      if (slider?.isEnabled() && sel) {
+        hasActiveSliders = true;
+        const pill = document.createElement('div');
+        pill.className = 'search__slider-pill';
+        UI.render(Button, {
+          variant: 'secondary',
+          children: `${sel.min}${cfg.unit} ~ ${sel.max}${cfg.unit}`,
+          icon: Icon({ source: 'Close', size: '16' }),
+          onClick: () => onSliderReset(cfg),
+        })(pill);
+        sliderPillsContainer.appendChild(pill);
+      }
+    });
+
+    if (hasActiveSliders && !dropinHasSelections) {
+      const clearAll = document.createElement('div');
+      clearAll.className = 'search__slider-pill';
+      UI.render(Button, {
+        variant: 'secondary',
+        children: 'Clear All',
+        onClick: () => resetAllSliders(),
+      })(clearAll);
+      sliderPillsContainer.appendChild(clearAll);
+    }
+  }
+
+  function getSliderUrlMap() {
+    const map = new Map();
+    NUMERIC_RANGE_FACETS.forEach((cfg) => {
+      const slider = sliderElements[cfg.minAttribute];
+      const sel = sliderSelections[cfg.minAttribute];
+      if (slider?.isEnabled() && sel) {
+        map.set(cfg.label.toLowerCase(), { min: sel.min, max: sel.max });
+      }
+    });
+    return map;
+  }
 
   // Request search based on the page type on block load
   if (config.urlpath) {
@@ -74,7 +237,9 @@ export default async function decorate(block) {
       phrase: '', // search all products in the category
       currentPage: searchState.currentPage,
       pageSize,
-      sort: searchState?.sort?.length ? searchState.sort : [{ attribute: 'position', direction: 'DESC' }],
+      sort: searchState?.sort?.length
+        ? searchState.sort
+        : [{ attribute: 'position', direction: 'DESC' }],
       filter: [
         { attribute: 'categoryPath', eq: config.urlpath }, // Add category filter
         // Always add visibility filter to the request
@@ -141,8 +306,107 @@ export default async function decorate(block) {
       },
     })($viewFacets),
 
-    // Facets
-    provider.render(Facets, {})($facets),
+    // Facets — use Facet slot to override numeric range facets with slider
+    provider.render(Facets, {
+      slots: {
+        SelectedFacets: (ctx) => {
+          ctx.appendChild(sliderPillsContainer);
+          let hadSelections = false;
+          ctx.onRender((next) => {
+            const hasSelections = next.data && next.data.length > 0;
+            dropinHasSelections = hasSelections;
+            // When dropin's selected facets go from some to none, reset sliders too
+            if (hadSelections && !hasSelections) {
+              resetAllSliders();
+            }
+            hadSelections = hasSelections;
+            updateSliderPills();
+          });
+        },
+        Facet: (ctx) => {
+          const facet = ctx.data;
+          const stats = getStatsBounds(facet);
+
+          const maxCfg = NUMERIC_RANGE_BY_MAX[facet.attribute];
+          if (maxCfg) {
+            if (stats) {
+              if (!collectedBounds[maxCfg.minAttribute]) collectedBounds[maxCfg.minAttribute] = {};
+              collectedBounds[maxCfg.minAttribute].max = stats.max;
+              collectedBounds[maxCfg.minAttribute].rightMin = stats.min;
+              const slider = sliderElements[maxCfg.minAttribute];
+              const bounds = collectedBounds[maxCfg.minAttribute];
+              if (slider && bounds.min != null) {
+                const b = bounds;
+                const clamped = slider.updateBounds(b.min, stats.max, b.leftMax, stats.min);
+                if (slider.isEnabled() && sliderSelections[maxCfg.minAttribute]) {
+                  const prev = sliderSelections[maxCfg.minAttribute];
+                  sliderSelections[maxCfg.minAttribute] = clamped;
+                  if (prev.min !== clamped.min || prev.max !== clamped.max) {
+                    reissueSearch();
+                  }
+                }
+              }
+            }
+            ctx.replaceWith(document.createElement('div'));
+            return;
+          }
+
+          const minCfg = NUMERIC_RANGE_BY_MIN[facet.attribute];
+          if (minCfg) {
+            // Keep existing slider visible even when stats are empty (0 results)
+            if (!stats) {
+              const existing = sliderElements[minCfg.minAttribute];
+              if (existing) ctx.replaceWith(existing);
+              return;
+            }
+
+            if (!collectedBounds[minCfg.minAttribute]) collectedBounds[minCfg.minAttribute] = {};
+            collectedBounds[minCfg.minAttribute].min = stats.min;
+            collectedBounds[minCfg.minAttribute].leftMax = stats.max;
+
+            const sliderMax = collectedBounds[minCfg.minAttribute].max ?? stats.max;
+            const { rightMin } = collectedBounds[minCfg.minAttribute];
+
+            const existing = sliderElements[minCfg.minAttribute];
+            if (existing) {
+              const clamped = existing.updateBounds(stats.min, sliderMax, stats.max, rightMin);
+              if (existing.isEnabled() && sliderSelections[minCfg.minAttribute]) {
+                const prev = sliderSelections[minCfg.minAttribute];
+                sliderSelections[minCfg.minAttribute] = clamped;
+                if (prev.min !== clamped.min || prev.max !== clamped.max) {
+                  reissueSearch();
+                }
+              }
+              ctx.replaceWith(existing);
+              return;
+            }
+
+            const slider = createNumericRangeSlider({
+              label: minCfg.label,
+              min: stats.min,
+              max: sliderMax,
+              leftMax: stats.max,
+              rightMin,
+              unit: minCfg.unit,
+              onChange: (newMin, newMax) => onSliderChange(minCfg, newMin, newMax),
+            });
+
+            sliderElements[minCfg.minAttribute] = slider;
+
+            const urlSel = sliderSelections[minCfg.minAttribute];
+            if (urlSel) {
+              slider.setEnabled(true);
+              sliderSelections[minCfg.minAttribute] = slider.setValues(urlSel.min, urlSel.max);
+              updateSliderPills();
+              reissueSearch();
+            }
+
+            ctx.replaceWith(slider);
+          }
+        },
+      },
+    })($facets),
+
     // Product List
     provider.render(SearchResults, {
       routeProduct: (product) => getProductLink(product.urlKey, product.sku),
@@ -183,30 +447,44 @@ export default async function decorate(block) {
     })($productList),
   ]);
 
-  // Listen for search results (event is fired before the block is rendered; eager: true)
   events.on('search/result', (payload) => {
     const totalCount = payload.result?.totalCount || 0;
 
     block.classList.toggle('product-list-page--empty', totalCount === 0);
 
-    // Results Info
     $resultInfo.innerHTML = payload.request?.phrase
       ? `${totalCount} results found for <strong>"${payload.request.phrase}"</strong>.`
       : `${totalCount} results found.`;
 
-    // Update the view facets button with the number of filters
     if (payload.request.filter.length > 0) {
       $viewFacets.querySelector('button').setAttribute('data-count', payload.request.filter.length);
     } else {
       $viewFacets.querySelector('button').removeAttribute('data-count');
     }
+
+    lastSearchRequest = payload.request;
+    updateSliderPills();
+
+    // Re-apply slider filters stripped by the Facets dropin
+    const requestAttrs = new Set((payload.request.filter || []).map((f) => f.attribute));
+    const slidersNeedReapply = NUMERIC_RANGE_FACETS.some((c) => {
+      const slider = sliderElements[c.minAttribute];
+      return slider?.isEnabled() && sliderSelections[c.minAttribute]
+        && !requestAttrs.has(c.minAttribute);
+    });
+    if (slidersNeedReapply) {
+      reissueSearch();
+    }
   }, { eager: true });
 
-  // Listen for search results (event is fired after the block is rendered; eager: false)
-  // URL is owned by this project; update it when search state changes.
   events.on('search/result', (payload) => {
     const url = new URL(window.location.href);
-    applySearchStateToUrl(url, payload.request);
+    const urlFilters = (payload.request.filter || []).filter(
+      (f) => !NUMERIC_RANGE_ALL_ATTRS.has(f.attribute),
+    );
+    applySearchStateToUrl(url, {
+      ...payload.request, filter: urlFilters, slider: getSliderUrlMap(),
+    });
     window.history.pushState({}, '', url.toString());
   }, { eager: false });
 }

--- a/blocks/product-list-page/search-url.js
+++ b/blocks/product-list-page/search-url.js
@@ -1,14 +1,3 @@
-/**
- * Search URL state (query params) for product list / search.
- * All URL reading and writing for search is owned by this project;
- * the storefront-product-discovery dropin does not touch the URL.
- */
-
-/**
- * Parses the sort query param into the search API format.
- * @param {string} [sortParam] - Comma-separated sort spec, e.g. "price_ASC,name_DESC"
- * @returns {{ attribute: string, direction: string }[]} Array of sort clauses
- */
 function parseSort(sortParam) {
   if (!sortParam) return [];
   return sortParam.split(',').map((item) => {
@@ -17,18 +6,11 @@ function parseSort(sortParam) {
   });
 }
 
-/**
- * Parses the filter query param into the search API format.
- * Supports: single value (attr:val), multiple values (attr:a,b,c), ranges (attr:0-100).
- * @param {string} [filterParam] - Pipe-separated filters, e.g. "color:blue|price:0-100"
- * @returns {Array<{ attribute: string, in?: string[], range?: { from: number, to: number } }>}
- */
 function parseFilter(filterParam) {
   if (!filterParam) return [];
 
   const decodedParam = decodeURIComponent(filterParam);
   const rawFilters = decodedParam.split('|');
-  /** @type {Array<{ attribute: string, in?: string[], range?: { from: number, to: number } }>} */
   const results = [];
 
   rawFilters.forEach((segment) => {
@@ -38,15 +20,17 @@ function parseFilter(filterParam) {
     const value = segment.slice(colonIdx + 1).trim();
     if (!attribute || !value) return;
 
-    if (value.includes('-')) {
-      const [from, to] = value.split('-');
-      const fromNum = Number(from);
-      const toNum = Number(to);
-      if (Number.isFinite(fromNum) && Number.isFinite(toNum)) {
-        results.push({
-          attribute,
-          range: { from: fromNum, to: toNum },
-        });
+    if (value.includes('~')) {
+      const [fromStr, toStr] = value.split('~');
+      const fromNum = fromStr ? Number(fromStr) : undefined;
+      const toNum = toStr ? Number(toStr) : undefined;
+      const hasFrom = fromNum !== undefined && Number.isFinite(fromNum);
+      const hasTo = toNum !== undefined && Number.isFinite(toNum);
+      if (hasFrom || hasTo) {
+        const range = {};
+        if (hasFrom) range.from = fromNum;
+        if (hasTo) range.to = toNum;
+        results.push({ attribute, range });
         return;
       }
     }
@@ -67,20 +51,10 @@ function parseFilter(filterParam) {
   return results;
 }
 
-/**
- * Serializes a sort array into the URL query string format.
- * @param {{ attribute: string, direction: string }[]} sort - Sort clauses from search API
- * @returns {string} Comma-separated sort spec, e.g. "price_ASC,name_DESC"
- */
 function serializeSort(sort) {
   return sort.map((item) => `${item.attribute}_${item.direction}`).join(',');
 }
 
-/**
- * Serializes a filter array into the URL query string format.
- * @param {Array<{ attribute: string, in?: string[], range?: { from: number, to: number } }>} filter
- * @returns {string} Pipe-separated filter spec, or empty string if no filters
- */
 function serializeFilter(filter) {
   if (!filter || filter.length === 0) return '';
 
@@ -89,42 +63,57 @@ function serializeFilter(filter) {
       return inValues.map((v) => `${attribute}:${v}`).join('|');
     }
     if (range) {
-      return `${attribute}:${range.from}-${range.to}`;
+      const from = range.from != null ? range.from : '';
+      const to = range.to != null ? range.to : '';
+      return `${attribute}:${from}~${to}`;
     }
     return null;
   }).filter(Boolean).join('|');
 }
 
-/**
- * Reads all search state from the current URL query params.
- * Return shape matches the request object used by applySearchStateToUrl and the search API.
- * @param {URL} url - URL to read from (e.g. new URL(window.location.href))
- * @returns {{ phrase: string, currentPage: number, sort: Array, filter: Array }}
- *   phrase: search query (q param); currentPage: page number (default 1);
- *   sort, filter: parsed for the search API
- */
+// Format: "temperature:0~80|turbidity:25~75"
+function parseSlider(sliderParam) {
+  const map = new Map();
+  if (!sliderParam) return map;
+  sliderParam.split('|').forEach((segment) => {
+    const colonIdx = segment.indexOf(':');
+    if (colonIdx === -1) return;
+    const label = segment.slice(0, colonIdx).trim();
+    const value = segment.slice(colonIdx + 1).trim();
+    if (!label || !value.includes('~')) return;
+    const [minStr, maxStr] = value.split('~');
+    const min = Number(minStr);
+    const max = Number(maxStr);
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      map.set(label, { min, max });
+    }
+  });
+  return map;
+}
+
+function serializeSlider(sliderMap) {
+  if (!sliderMap || sliderMap.size === 0) return '';
+  return [...sliderMap.entries()]
+    .map(([label, { min, max }]) => `${label}:${min}~${max}`)
+    .join('|');
+}
+
 export function getSearchStateFromUrl(url) {
   const q = url.searchParams.get('q') ?? '';
   const page = url.searchParams.get('page');
   const sort = url.searchParams.get('sort');
   const filter = url.searchParams.get('filter');
+  const slider = url.searchParams.get('slider');
 
   return {
     phrase: q,
     currentPage: page ? Number(page) : 1,
     sort: parseSort(sort),
     filter: parseFilter(filter),
+    slider: parseSlider(slider),
   };
 }
 
-/**
- * Writes search state from a request object onto the URL's query params.
- * Call after search/result to keep the URL in sync (e.g. in the search/result event handler).
- * Mutates the URL in place; then use url.toString() or history.pushState to apply.
- * @param {URL} url - URL to update (e.g. new URL(window.location.href))
- * @param {{ phrase?: string, currentPage?: number, sort?: Array, filter?: Array }} request
- *   Search request from the discovery API; only set params are written to the URL.
- */
 export function applySearchStateToUrl(url, request) {
   if (request?.phrase) {
     url.searchParams.set('q', request.phrase);
@@ -136,8 +125,15 @@ export function applySearchStateToUrl(url, request) {
     url.searchParams.set('sort', serializeSort(request.sort));
   }
   if (request?.filter != null) {
-    // Don't add visibility filter to the URL, since we always add it in product-list-page.js
     const urlFilters = request.filter.filter((f) => f.attribute !== 'visibility');
     url.searchParams.set('filter', serializeFilter(urlFilters));
+  }
+  if (request?.slider != null) {
+    const s = serializeSlider(request.slider);
+    if (s) {
+      url.searchParams.set('slider', s);
+    } else {
+      url.searchParams.delete('slider');
+    }
   }
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,28 @@
+{
+  "public": {
+    "default": {
+      "commerce-core-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
+      "commerce-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
+      "headers": {
+        "all": {
+          "Store": "default"
+        },
+        "cs": {
+          "Magento-Store-View-Code": "default",
+          "Magento-Website-Code": "base",
+          "Magento-Store-Code": "main_website_store",
+          "Magento-Customer-Group": "b6589fc6ab0dc82cf12099d1c2d40ab994e8410c"
+        }
+      },
+      "analytics": {
+        "environment-id": "QUxJ3FeSXX7nmPAGdqUBMX",
+        "environment": "Testing",
+        "base-currency-code": "USD",
+        "store-view-currency-code": "USD",
+        "store-code": "default",
+        "store-name": "Default Store View",
+        "store-view-code": "default"
+      }
+    }
+  }
+}

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "public": {
     "default": {
-      "commerce-core-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
-      "commerce-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/JNjfhWJ3MJvZhj3bwsamRP/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/JNjfhWJ3MJvZhj3bwsamRP/graphql",
       "headers": {
         "all": {
           "Store": "default"
@@ -15,7 +15,7 @@
         }
       },
       "analytics": {
-        "environment-id": "QUxJ3FeSXX7nmPAGdqUBMX",
+        "environment-id": "JNjfhWJ3MJvZhj3bwsamRP",
         "environment": "Testing",
         "base-currency-code": "USD",
         "store-view-currency-code": "USD",


### PR DESCRIPTION
Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://accs-579-numeric-attributes--aem-boilerplate-commerce--hlxsites.aem.page/

Some considerations for the slider implementation:

1. We need an epsilon value for the "to" boundary for Live Search API:
```
  // Live Search range `to` uses exclusive upper bound (lt, not lte).
  // Add a tiny epsilon so that the exact boundary value is included.
  const eps = Number.EPSILON;

  if (config.filterMode === 'exclude') {
    return [
      { attribute: config.minAttribute, range: { to: sliderMin + eps } },
      { attribute: config.maxAttribute, range: { from: sliderMax } },
    ];
  }
  return [
    { attribute: config.minAttribute, range: { from: sliderMin } },
    { attribute: config.maxAttribute, range: { to: sliderMax + eps } },
  ];
```
2. You'll receive min/max and `RangeBucket` for numeric attributes.
```
"productSearch": {
    "facets": [
        {
            "title": "Temperature (Max)",
            "attribute": "temperature_max",
            "buckets": [
                {
                    "title": "75.0-100.0",
                    "__typename": "RangeBucket", // user sets ranges in Admin manually
                    "from": 75.0,
                    "to": 100.0,
                    "count": 1
                },
                {
                    "title": "",
                    "__typename": "StatsBucket", // min/max
                    "min": -300.0,
                    "max": -10.0
                } ...
```