### PR TITLE
[Do Not Merge] Example implementation for sign in error override 

### DIFF
--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -254,6 +254,7 @@ export const renderLoginForm = async (container) => renderContainer(
         signInFormConfig: {
           renderSignUpLink: true,
           initialEmailValue,
+          apiErrorMessageOverride: 'Custom error: Unable to sign in. Please contact support.',
           // No onSuccessCallback needed - the 'authenticated' event will be fired automatically
         },
         signUpFormConfig: {

--- a/blocks/commerce-login/commerce-login.js
+++ b/blocks/commerce-login/commerce-login.js
@@ -17,6 +17,7 @@ export default async function decorate(block) {
     await authRenderer.render(SignIn, {
       routeForgotPassword: () => rootLink(CUSTOMER_FORGOTPASSWORD_PATH),
       routeRedirectOnSignIn: () => rootLink(CUSTOMER_ACCOUNT_PATH),
+      apiErrorMessageOverride: 'Custom error: Unable to sign in. Please contact support.',
     })(block);
   }
 }

--- a/blocks/header/renderAuthCombine.js
+++ b/blocks/header/renderAuthCombine.js
@@ -16,6 +16,7 @@ import {
 const signInFormConfig = {
   renderSignUpLink: true,
   routeForgotPassword: () => rootLink(CUSTOMER_FORGOTPASSWORD_PATH),
+  apiErrorMessageOverride: 'Custom error: Unable to sign in. Please contact support.',
   slots: {
     SuccessNotification: (ctx) => {
       const userName = ctx?.isSuccessful?.userName || '';

--- a/blocks/header/renderAuthDropdown.js
+++ b/blocks/header/renderAuthDropdown.js
@@ -30,6 +30,7 @@ function renderSignIn(element) {
     },
     formSize: 'small',
     routeForgotPassword: () => rootLink(CUSTOMER_FORGOTPASSWORD_PATH),
+    apiErrorMessageOverride: 'Custom error: Unable to sign in. Please contact support.',
   })(element);
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Example implementation for https://jira.corp.adobe.com/browse/ACCS-237

## Implementation steps

1. Update the package.json to use the `"@dropins/storefront-auth": "~3.2.0"` package and run npm install
2. Review the example integration in `blocks/commerce-login/commerce-login.js`, `blocks/header/renderAuthCombine.js`, `blocks/header/renderAuthDropdown.js` , or `blocks/commerce-checkout/containers.js` depending on which sign-in form you would like to override the error message returned from API. 

In this example, we use the `apiErrorMessageOverride` prop.

## Where to add `apiErrorMessageOverride`

| Location | File | How |
|---|---|---|
| **Login page** | `blocks/commerce-login/commerce-login.js` | Add `apiErrorMessageOverride` to the `SignIn` render props |
| **Header login dropdown** | `blocks/header/renderAuthDropdown.js` | Add `apiErrorMessageOverride` to the `SignIn` render props |
| **Header combined auth modal** | `blocks/header/renderAuthCombine.js` | Add `apiErrorMessageOverride` inside the `signInFormConfig` object |




Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://test-override--aem-boilerplate-commerce--hlxsites.aem.live/


<img width="1494" height="641" alt="Screenshot 2026-04-07 at 2 51 42 PM" src="https://github.com/user-attachments/assets/11df814a-449c-462f-90af-b5ab2c583335" />

