### PR TITLE
fix: disable add-to-cart for out-of-stock simple products on PLP

### DIFF
--- a/blocks/product-list-page/README.md
+++ b/blocks/product-list-page/README.md
@@ -56,7 +56,7 @@ A visibility filter `{ attribute: 'visibility', in: ['Search', 'Catalog, Search'
 2. **Sort change**: User changes sort via SortBy; dropin calls `search()` with updated sort; block receives `search/result` and updates the URL.
 3. **Filter change**: User toggles facets; dropin calls `search()` with updated filter; block updates result count and URL.
 4. **Pagination**: User changes page; dropin calls `search()` with new page; block scrolls to top and URL is updated.
-5. **Add to cart / wishlist**: Product cards include add-to-cart and wishlist actions; cart and wishlist behavior are handled by their respective dropins.
+5. **Add to cart / wishlist**: Product cards include add-to-cart and wishlist actions; cart and wishlist behavior are handled by their respective dropins. For simple products, the add-to-cart button is disabled when `product.inStock` is falsy. Complex products always link to the PDP where stock is validated by the PDP drop-in.
 
 ### Error Handling
 

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -113,8 +113,11 @@ export default async function decorate(block) {
     UI.render(Button, {
       children: labels.Global?.AddProductToCart,
       icon: Icon({ source: 'Cart' }),
-      onClick: () => cartApi.addProductsToCart([{ sku: product.sku, quantity: 1 }]),
+      onClick: product.inStock
+        ? () => cartApi.addProductsToCart([{ sku: product.sku, quantity: 1 }])
+        : undefined,
       variant: 'primary',
+      disabled: !product.inStock,
     })(button);
     return button;
   };

--- a/blocks/product-recommendations/README.md
+++ b/blocks/product-recommendations/README.md
@@ -17,6 +17,15 @@ The Product Recommendations block provides personalized product recommendations 
 
 No URL parameters directly affect this block's behavior. -->
 
+### GraphQL Extensions
+
+The `@dropins/storefront-recommendations` drop-in does not include `inStock` in its default `PRODUCTS_VIEW_FRAGMENT` or item model. To support disabling add-to-cart for out-of-stock products, two workarounds are applied:
+
+1. **Fragment override** (`build.mjs`): `overrideGQLOperations` extends `PRODUCTS_VIEW_FRAGMENT` with `inStock` so the field is requested from the API.
+2. **Model transformer** (`scripts/initializers/recommendations.js`): A `RecommendationUnitModel` transformer maps `inStock` from the raw GraphQL response onto items, since the drop-in's built-in transform drops unknown fields.
+
+These can be removed once the upstream drop-in includes `inStock` natively.
+
 ### Local Storage
 
 - `{storeViewCode}:productViewHistory` - Stores user's product view history for recommendation context
@@ -47,7 +56,7 @@ No URL parameters directly affect this block's behavior. -->
 1. **Initialization**: Block sets up recommendation context and loads initial recommendations
 2. **Lazy Loading**: On mobile, recommendations load when section becomes visible
 3. **Context Tracking**: Monitors page, product, category, and cart changes to update recommendations
-4. **Product Actions**: Users can add products to cart or navigate to product details
+4. **Product Actions**: Users can add simple products to cart or navigate to product details for complex products. The add-to-cart button is disabled for out-of-stock simple products using the `inStock` property
 5. **Wishlist Integration**: Users can add/remove products from wishlist
 6. **Dynamic Reloading**: Recommendations reload when significant context changes occur
 

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -161,29 +161,32 @@ export default async function decorate(block) {
                 UI.render(Button, {
                   children: labels.Global?.AddProductToCart,
                   icon: Icon({ source: 'Cart' }),
-                  onClick: (event) => {
-                    cartApi.addProductsToCart([
-                      { sku: ctx.item.sku, quantity: 1 },
-                    ]);
-                    // Prevent the click event from bubbling up to the parent span
-                    // to avoid triggering the recs-item-click event
-                    event.stopPropagation();
-                    // Publish ACDL event for add to cart click
-                    const recommendationUnit = recommendationsData?.find(
-                      (unit) => unit.items?.some(
-                        (unitItem) => unitItem.sku === ctx.item.sku,
-                      ),
-                    );
-                    publishRecsItemAddToCartClick({
-                      recommendationUnit,
-                      pagePlacement: 'product-list',
-                      yOffsetTop: addToCart.getBoundingClientRect().top ?? 0,
-                      yOffsetBottom:
-                        addToCart.getBoundingClientRect().bottom ?? 0,
-                      productId: ctx.index,
-                    });
-                  },
+                  onClick: ctx.item.inStock
+                    ? (event) => {
+                      cartApi.addProductsToCart([
+                        { sku: ctx.item.sku, quantity: 1 },
+                      ]);
+                      // Prevent the click event from bubbling up to the parent span
+                      // to avoid triggering the recs-item-click event
+                      event.stopPropagation();
+                      // Publish ACDL event for add to cart click
+                      const recommendationUnit = recommendationsData?.find(
+                        (unit) => unit.items?.some(
+                          (unitItem) => unitItem.sku === ctx.item.sku,
+                        ),
+                      );
+                      publishRecsItemAddToCartClick({
+                        recommendationUnit,
+                        pagePlacement: 'product-list',
+                        yOffsetTop: addToCart.getBoundingClientRect().top ?? 0,
+                        yOffsetBottom:
+                          addToCart.getBoundingClientRect().bottom ?? 0,
+                        productId: ctx.index,
+                      });
+                    }
+                    : undefined,
                   variant: 'primary',
+                  disabled: !ctx.item.inStock,
                 })(addToCart);
               } else {
                 // Select Options Button

--- a/build.mjs
+++ b/build.mjs
@@ -12,6 +12,17 @@ overrideGQLOperations([
     skipFragments: ['DOWNLOADABLE_ORDER_ITEMS_FRAGMENT'],
     operations: [],
   },
+  // This can be removed if/when @dropins/storefront-recommendations includes inStock natively
+  {
+    npm: '@dropins/storefront-recommendations',
+    operations: [
+      `
+      fragment PRODUCTS_VIEW_FRAGMENT on ProductView {
+        inStock
+      }
+      `,
+    ],
+  },
   // {
   //   npm: '@dropins/storefront-checkout',
   //   operations: [],

--- a/scripts/__dropins__/storefront-recommendations/fragments.js
+++ b/scripts/__dropins__/storefront-recommendations/fragments.js
@@ -1,18 +1,34 @@
-/*! Copyright 2025 Adobe
-All Rights Reserved. */
-const e=`
-  fragment PRODUCTS_VIEW_FRAGMENT on ProductView {
-    __typename
-    name
-    sku
-    queryType
-    visibility
-    images {
-      url
+const e = (`fragment PRODUCTS_VIEW_FRAGMENT on ProductView {
+  __typename
+  name
+  sku
+  queryType
+  visibility
+  images {
+    url
+  }
+  urlKey
+  ... on SimpleProductView {
+    price {
+      final {
+        amount {
+          currency
+          value
+        }
+      }
     }
-    urlKey
-    ... on SimpleProductView {
-      price {
+  }
+  ... on ComplexProductView {
+    priceRange {
+      maximum {
+        final {
+          amount {
+            currency
+            value
+          }
+        }
+      }
+      minimum {
         final {
           amount {
             currency
@@ -21,28 +37,9 @@ const e=`
         }
       }
     }
-    ... on ComplexProductView {
-      priceRange {
-        maximum {
-          final {
-            amount {
-              currency
-              value
-            }
-          }
-        }
-        minimum {
-          final {
-            amount {
-              currency
-              value
-            }
-          }
-        }
-      }
-    }
   }
-`,n=`
+  inStock
+}`), n = `
   fragment UNIT_FRAGMENT on RecommendationUnit {
     displayOrder
     pageType
@@ -57,5 +54,8 @@ const e=`
   }
 
   ${e}
-`;export{e as PRODUCTS_VIEW_FRAGMENT,n as UNIT_FRAGMENT};
-//# sourceMappingURL=fragments.js.map
+`;
+export {
+e as PRODUCTS_VIEW_FRAGMENT,
+n as UNIT_FRAGMENT
+};

--- a/scripts/__dropins__/storefront-recommendations/fragments.original.js
+++ b/scripts/__dropins__/storefront-recommendations/fragments.original.js
@@ -1,0 +1,61 @@
+/*! Copyright 2025 Adobe
+All Rights Reserved. */
+const e=`
+  fragment PRODUCTS_VIEW_FRAGMENT on ProductView {
+    __typename
+    name
+    sku
+    queryType
+    visibility
+    images {
+      url
+    }
+    urlKey
+    ... on SimpleProductView {
+      price {
+        final {
+          amount {
+            currency
+            value
+          }
+        }
+      }
+    }
+    ... on ComplexProductView {
+      priceRange {
+        maximum {
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+        }
+        minimum {
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+`,n=`
+  fragment UNIT_FRAGMENT on RecommendationUnit {
+    displayOrder
+    pageType
+    productsView {
+      ...PRODUCTS_VIEW_FRAGMENT
+    }
+    storefrontLabel
+    totalProducts
+    typeId
+    unitId
+    unitName
+  }
+
+  ${e}
+`;export{e as PRODUCTS_VIEW_FRAGMENT,n as UNIT_FRAGMENT};
+//# sourceMappingURL=fragments.js.map

--- a/scripts/initializers/recommendations.js
+++ b/scripts/initializers/recommendations.js
@@ -15,6 +15,20 @@ await initializeDropin(async () => {
     },
   };
 
+  const models = {
+    RecommendationUnitModel: {
+      transformer: (response) => {
+        const results = response?.results ?? [];
+        return results.map((unit) => ({
+          items: (unit.productsView ?? []).map((product) => ({
+            // Removable when @dropins/storefront-recommendations exposes inStock natively
+            inStock: product.inStock ?? false,
+          })),
+        }));
+      },
+    },
+  };
+
   // Initialize recommendations
-  return initializers.mountImmediately(initialize, { langDefinitions });
+  return initializers.mountImmediately(initialize, { langDefinitions, models });
 })();


### PR DESCRIPTION
The PLP and product-recommendations blocks did not check stock status, so the add-to-cart button was always enabled for simple products — even when out of stock. This uses the `inStock` property to disable the button and remove the click handler when the product is out of stock.

### Changes
- **product-list-page**: Disable add-to-cart button and remove `onClick` for out-of-stock simple products
- **product-recommendations**: Same fix, plus:
  - Extended `PRODUCTS_VIEW_FRAGMENT` via `overrideGQLOperations` in `build.mjs` to include `inStock` (not present in the drop-in's default fragment)
  - Added a `RecommendationUnitModel` transformer in the recommendations initializer to map `inStock` from the raw GraphQL response onto items (needed because the drop-in's built-in transform drops unknown fields)

### Not changed
- **product-details (PDP)**: Stock status is already handled internally by the `@dropins/storefront-pdp` drop-in via the `pdp/valid` event
- **commerce-wishlist**: The `@dropins/storefront-wishlist` drop-in already disables the "Move to Cart" button when `product.inStock` is falsy

### Follow-up
- The `build.mjs` override and model transformer for recommendations can be removed once `@dropins/storefront-recommendations` includes `inStock` natively in the fragment and item model

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/apparel
- After: https://plp-stock-check--aem-boilerplate-commerce--hlxsites.aem.live/apparel