### PR TITLE
poc: Using indexes to dynamically create a nav

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -4,7 +4,9 @@ import { events } from '@dropins/tools/event-bus.js';
 import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
-import { fetchPlaceholders, getProductLink, rootLink } from '../../scripts/commerce.js';
+import {
+  fetchIndex, fetchPlaceholders, getProductLink, rootLink,
+} from '../../scripts/commerce.js';
 
 import renderAuthCombine from './renderAuthCombine.js';
 import { renderAuthDropdown } from './renderAuthDropdown.js';
@@ -158,25 +160,85 @@ function setupSubmenu(navSection) {
 }
 
 /**
+ * Builds a tree structure from flat nav entries based on path hierarchy.
+ * @param {Array} entries Flat array of nav entries
+ * @returns {Array} Tree-structured entries with children arrays
+ */
+function buildNavTree(entries) {
+  const sorted = [...entries].sort((a, b) => a.path.localeCompare(b.path));
+  const byPath = new Map(sorted.map((e) => [e.path, { ...e, children: [] }]));
+  const roots = [];
+
+  byPath.forEach((entry) => {
+    const parentPath = entry.path.substring(0, entry.path.lastIndexOf('/'));
+    const parent = byPath.get(parentPath);
+    if (parent) {
+      parent.children.push(entry);
+    } else {
+      roots.push(entry);
+    }
+  });
+
+  return roots;
+}
+
+/**
+ * Recursively builds a UL/LI nav list from tree-structured entries.
+ * Parent entries with children render as text labels with nested lists.
+ * Leaf entries render as links.
+ * @param {Array} entries Tree-structured nav entries
+ * @returns {HTMLUListElement} Navigation list element
+ */
+function buildNavList(entries) {
+  const ul = document.createElement('ul');
+
+  entries.forEach((entry) => {
+    const li = document.createElement('li');
+    const label = entry.navTitle || entry.title;
+
+    if (entry.children.length > 0) {
+      li.append(label);
+      li.appendChild(buildNavList(entry.children));
+    } else {
+      const a = document.createElement('a');
+      a.href = rootLink(entry.path);
+      a.textContent = label;
+      li.appendChild(a);
+    }
+
+    ul.appendChild(li);
+  });
+
+  return ul;
+}
+
+/**
  * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
-  // load nav as fragment
+  // load nav fragment and fetch nav index in parallel
   const navMeta = getMetadata('nav');
   const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
-  const fragment = await loadFragment(navPath);
+  const [fragment, navIndex] = await Promise.all([
+    loadFragment(navPath),
+    fetchIndex('nav').catch(() => ({ data: [] })),
+  ]);
+  const navEntries = navIndex.data.filter((entry) => entry.category && entry.title);
 
   // decorate nav DOM
   block.textContent = '';
   const nav = document.createElement('nav');
   nav.id = 'nav';
-  while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
+  if (fragment) {
+    while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
+  }
 
+  // Ensure all three nav sections exist (brand, sections, tools)
   const classes = ['brand', 'sections', 'tools'];
   classes.forEach((c, i) => {
-    const section = nav.children[i];
-    if (section) section.classList.add(`nav-${c}`);
+    if (!nav.children[i]) nav.appendChild(document.createElement('div'));
+    nav.children[i].classList.add(`nav-${c}`);
   });
 
   const navBrand = nav.querySelector('.nav-brand');
@@ -187,6 +249,21 @@ export default async function decorate(block) {
   }
 
   const navSections = nav.querySelector('.nav-sections');
+
+  // Replace nav sections with index-based navigation if available
+  if (navEntries.length > 0 && navSections) {
+    let wrapper = navSections.querySelector('.default-content-wrapper');
+    if (!wrapper) {
+      wrapper = document.createElement('div');
+      wrapper.classList.add('default-content-wrapper');
+      navSections.innerHTML = '';
+      navSections.appendChild(wrapper);
+    }
+    wrapper.innerHTML = '';
+    const tree = buildNavTree(navEntries);
+    wrapper.appendChild(buildNavList(tree));
+  }
+
   if (navSections) {
     navSections
       .querySelectorAll(':scope .default-content-wrapper > ul > li')

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -196,14 +196,13 @@ function buildNavList(entries) {
     const li = document.createElement('li');
     const label = entry.navTitle || entry.title;
 
+    const a = document.createElement('a');
+    a.href = rootLink(entry.path);
+    a.textContent = label;
+    li.appendChild(a);
+
     if (entry.children.length > 0) {
-      li.append(label);
       li.appendChild(buildNavList(entry.children));
-    } else {
-      const a = document.createElement('a');
-      a.href = rootLink(entry.path);
-      a.textContent = label;
-      li.appendChild(a);
     }
 
     ul.appendChild(li);

--- a/default-query.yaml
+++ b/default-query.yaml
@@ -52,3 +52,23 @@ indices:
         select: head > meta[name="enrichment-positions"]
         values: |
           match(attribute(el, 'content'), '([^,]+)')
+  nav:
+    target: /nav.json
+    exclude:
+      - 'drafts/**'
+      - 'enrichment/**'
+      - 'fragments/**'
+      - 'products/**'
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      navTitle:
+        select: head > meta[name="nav-title"]
+        value: |
+          attribute(el, 'content')
+      category:
+        select: div.product-list-page
+        value: |
+          attribute(el, 'class')


### PR DESCRIPTION
## Summary

Proof of concept for replacing the authored nav fragment with a dynamically generated navigation powered by an EDS query index.

Instead of maintaining category links manually in a `nav` document, the navigation is built automatically from pages that use the `product-list-page` block. Publish a category page → it appears in the nav. Notably, this is a "content based" solution and does not "care" about Commerce. For a "commerce based" solution, we could potentially use queries such as `navigationTree` to create the view at runtime.

## How it works

1. A 'nav' index is created, which indexes all pages, specifically looking for those containing "product-list-page" blocks.
2. That index indexes all pages and flags those containing a `product-list-page` block via the `category` property.
3. The header block fetches `/nav.json` and filters for entries with a PLP block.
4. Page paths determine hierarchy — e.g. `/apparel/shirts` nests under `/apparel`.
5. The nav fragment is still loaded for brand/logo and tools (cart, search, auth); only the nav sections are replaced with index-generated content.
6. Falls back to the authored nav if the index is empty or unavailable.

Authors can set a `nav-title` metadata property to override the display label.

## Try it out

1. Clone this branch
3. `npx aem up --url https://main--nav-poc--sirugh.aem.live`
4. Open http://localhost:3000 — nav is built from the index

<img width="568" height="205" alt="image" src="https://github.com/user-attachments/assets/35d3a376-b0af-4836-bdbe-30959a438069" />


## Open questions

- Should the nav index exclude specific paths (e.g. `/search`) that use PLP without being categories?
- Ordering strategy — currently alphabetical by path. Should we support explicit ordering?
- Performance implications - nav now renders after an index request.
- SEO implications -- still, nav is not encoded into server output (comes from hydrated view after index request).
- Does it actually make sense to make category nav "content based" instead of "commerce"? Since we use index based on published pages, we don't have to worry about a link not existing. If we use commerce navigationTree slugs, then there is possibility of non-existent pages.