### PR TITLE
poc: Using Commerce GraphQL navigation query to dynamically create a nav

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -2,9 +2,12 @@
 import { events } from '@dropins/tools/event-bus.js';
 
 import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
+import { getConfigValue } from '@dropins/tools/lib/aem/configs.js';
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
-import { fetchPlaceholders, getProductLink, rootLink } from '../../scripts/commerce.js';
+import {
+  CS_FETCH_GRAPHQL, fetchIndex, fetchPlaceholders, getProductLink, rootLink,
+} from '../../scripts/commerce.js';
 
 import renderAuthCombine from './renderAuthCombine.js';
 import { renderAuthDropdown } from './renderAuthDropdown.js';
@@ -157,26 +160,123 @@ function setupSubmenu(navSection) {
   }
 }
 
+const ACO_NAVIGATION_QUERY = `query Navigation($family: String!) {
+  navigation(family: $family) {
+    slug
+    name
+    children {
+      slug
+      name
+      children {
+        slug
+        name
+        children {
+          slug
+          name
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * Fetches the navigation tree from Commerce GraphQL.
+ * ACO sites use the navigation query; non-ACO sites are not yet supported.
+ * @returns {Promise<Array>} Navigation tree nodes
+ */
+async function fetchNavigationTree() {
+  const isACO = getConfigValue('adobe-commerce-optimizer');
+  if (!isACO) {
+    // TODO: implement non-ACO navigation query
+    return [];
+  }
+
+  const family = getConfigValue('navigation-family') || 'top_menu';
+
+  const { data } = await CS_FETCH_GRAPHQL.fetchGraphQl(ACO_NAVIGATION_QUERY, {
+    variables: { family },
+  });
+
+  return data?.navigation || [];
+}
+
+/**
+ * Maps a navigation tree into entries with full paths built from slugs.
+ * @param {Array} nodes Navigation tree nodes
+ * @param {string} parentPath Parent path prefix
+ * @returns {Array} Tree with path property added to each node
+ */
+function mapNavTree(nodes, parentPath = '') {
+  return (nodes || []).map((node) => ({
+    name: node.name,
+    path: `${parentPath}/${node.slug}`,
+    children: node.children?.length
+      ? mapNavTree(node.children, `${parentPath}/${node.slug}`)
+      : [],
+  }));
+}
+
+/**
+ * Recursively builds a UL/LI nav list from a navigation tree.
+ * All entries render as links. Parents also get nested child lists.
+ * Unpublished pages (not in publishedPaths) are styled red.
+ * @param {Array} entries Navigation tree entries with path and name
+ * @param {Set<string>} publishedPaths Set of published page paths
+ * @returns {HTMLUListElement} Navigation list element
+ */
+function buildNavList(entries, publishedPaths) {
+  const ul = document.createElement('ul');
+
+  entries.forEach((entry) => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = rootLink(entry.path);
+    a.textContent = entry.name;
+    if (!publishedPaths.has(entry.path)) {
+      a.style.color = 'red';
+    }
+    li.appendChild(a);
+
+    if (entry.children.length > 0) {
+      li.appendChild(buildNavList(entry.children, publishedPaths));
+    }
+
+    ul.appendChild(li);
+  });
+
+  return ul;
+}
+
 /**
  * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
-  // load nav as fragment
+  // load nav fragment, navigation tree, and sitemap in parallel
   const navMeta = getMetadata('nav');
   const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
-  const fragment = await loadFragment(navPath);
+  const [fragment, navNodes, sitemap] = await Promise.all([
+    loadFragment(navPath),
+    fetchNavigationTree().catch(() => []),
+    fetchIndex('sitemap').catch(() => ({ data: [] })),
+  ]);
+
+  const publishedPaths = new Set(sitemap.data.map((entry) => entry.path));
+  const navTree = mapNavTree(navNodes);
 
   // decorate nav DOM
   block.textContent = '';
   const nav = document.createElement('nav');
   nav.id = 'nav';
-  while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
+  if (fragment) {
+    while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
+  }
 
+  // Ensure all three nav sections exist (brand, sections, tools)
   const classes = ['brand', 'sections', 'tools'];
   classes.forEach((c, i) => {
-    const section = nav.children[i];
-    if (section) section.classList.add(`nav-${c}`);
+    if (!nav.children[i]) nav.appendChild(document.createElement('div'));
+    nav.children[i].classList.add(`nav-${c}`);
   });
 
   const navBrand = nav.querySelector('.nav-brand');
@@ -187,6 +287,20 @@ export default async function decorate(block) {
   }
 
   const navSections = nav.querySelector('.nav-sections');
+
+  // Replace nav sections with navigation tree if available
+  if (navTree.length > 0 && navSections) {
+    let wrapper = navSections.querySelector('.default-content-wrapper');
+    if (!wrapper) {
+      wrapper = document.createElement('div');
+      wrapper.classList.add('default-content-wrapper');
+      navSections.innerHTML = '';
+      navSections.appendChild(wrapper);
+    }
+    wrapper.innerHTML = '';
+    wrapper.appendChild(buildNavList(navTree, publishedPaths));
+  }
+
   if (navSections) {
     navSections
       .querySelectorAll(':scope .default-content-wrapper > ul > li')

--- a/config.json
+++ b/config.json
@@ -1,0 +1,25 @@
+{
+  "public": {
+    "default": {
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/6RjzS6pBcbWRTEruKw4MhC/graphql",
+      "headers": {
+        "cs": {
+          "ac-view-id": "a97939e4-7168-44fe-85f0-28946369f699",
+          "ac-price-book-id": "global",
+          "ac-scope-locale": "mps_default"
+        }
+      },
+      "adobe-commerce-optimizer": true,
+      "analytics": {
+        "environment-id": "8idEEDDiVwjCEJAyB5kjfi",
+        "environment": "Testing",
+        "store-url": "https://main--boilerplate-aco--adobe-commerce.aem.live/",
+        "base-currency-code": "USD",
+        "store-view-currency-code": "USD",
+        "storefront-template": "Other",
+        "view-id": "0d3eebf7-b5fb-4904-9ccf-f35fcc61862b",
+        "locale": "en-US"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Alternative to #1197. Instead of sourcing navigation from an EDS index, this POC fetches the category tree from the Commerce GraphQL `navigation` query and renders it as the site nav.

The navigation tree from Commerce is cross-referenced with `sitemap.json` — items without a published page are rendered in red to visually flag missing content.

<img width="1728" height="1045" alt="image" src="https://github.com/user-attachments/assets/78528157-ff57-4bfd-81d7-567d91192bf4" />

## How it works

1. The header fetches the navigation tree via `CS_FETCH_GRAPHQL` using the `navigation(family:)` query (defaults to `top_menu`).
2. The full tree is rendered as nested nav items.
3. `sitemap.json` is fetched in parallel. Links to pages that don't exist in the sitemap are styled red; published pages render normally.
4. The nav fragment is still loaded for brand/logo and tools (cart, search, auth); only the nav sections are replaced.
5. Falls back to the authored nav if the query returns no results.

## Caveats

- **ACO only** — the `navigation` query is only available on Adobe Commerce Optimizer endpoints. Non-ACO sites fall back to the authored nav (placeholder for future query).
- **Red links** — red-colored links indicate categories from the catalog that don't have a corresponding published page in the CMS. This is a visual debugging aid, not a production pattern.
- **Performance** — large catalogs (this test catalog has ~15,000 lines of navigation data) cause noticeable rendering delay as the full tree is iterated and built into DOM. Production use would need pagination, lazy rendering, or depth limiting.

## Try it out

1. Clone this branch
2. `npx aem up --url https://main--nav-poc-graphql--sirugh.aem.live`
3. Open http://localhost:3000 — nav is built from the Commerce navigation query

## Open questions

- What query should non-ACO sites use?
- Ordering strategy — currently uses the order returned by the Commerce API. Should we support explicit ordering?
- Should we limit tree depth to improve performance for large catalogs?
- How should unpublished categories be handled in production? (hide, disable, or link anyway?)