### PR TITLE
USF-3986: remove empty company-switcher placeholders from initializer

### DIFF
--- a/scripts/initializers/company-switcher.js
+++ b/scripts/initializers/company-switcher.js
@@ -1,24 +1,14 @@
 import { initializers } from '@dropins/tools/initializer.js';
 import { initialize, setEndpoint } from '@dropins/storefront-company-switcher/api.js';
 import { initializeDropin } from './index.js';
-import { CORE_FETCH_GRAPHQL, CS_FETCH_GRAPHQL, fetchPlaceholders } from '../commerce.js';
+import { CORE_FETCH_GRAPHQL, CS_FETCH_GRAPHQL } from '../commerce.js';
 
 await initializeDropin(async () => {
   // Set Fetch GraphQL (Core)
   setEndpoint(CORE_FETCH_GRAPHQL);
 
-  // Fetch placeholders
-  const labels = await fetchPlaceholders('placeholders/company-switcher.json').catch(() => ({}));
-
-  const langDefinitions = {
-    default: {
-      ...labels,
-    },
-  };
-
   // Initialize company switcher
   return initializers.mountImmediately(initialize, {
-    langDefinitions,
     fetchGraphQlModules: [CORE_FETCH_GRAPHQL, CS_FETCH_GRAPHQL],
     groupGraphQlModules: [CS_FETCH_GRAPHQL],
   });


### PR DESCRIPTION
Fix #USF-3986

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://usf-3986--aem-boilerplate-commerce--hlxsites.aem.live/
