### PR TITLE
COMOPT-1989 Mapping missing locale

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -28,6 +28,7 @@ async function initAnalytics() {
             websiteId: parseInt(analyticsConfig['website-id'], 10),
             websiteName: analyticsConfig['website-name'],
             viewId: analyticsConfig['view-id'], // applicable for ACO storefronts
+            locale: analyticsConfig.locale,
           },
         },
         {


### PR DESCRIPTION
Storefront-events-collector requires l[ocale](https://github.com/adobe/commerce-events/blob/db2621a0aec6af0f671714406f3abeb4480f609f/packages/storefront-events-collector/src/utils/ccdm.ts#L4) to populate properly events from CCDM/ACO model. 
Locale is defined in the [demo-config-aco.json](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/demo-config-aco.json) but was not mapped in the delayed script.
Previosly this value was mapped form the header aco-scope-locale but was removed a couple of weeks ago it PR [#1155](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1155).
We can revert the change and return to the header, but I think is better to pass through the value defined in the analytics section as the others.

What do you think? @sirugh @keoko 

Note: I've tested both options (this one, and restore the header) in our nebula store and both work.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://comopt-1989-aco-events-not-propagated--aem-boilerplate-commerce--hlxsites.aem.live/