### PR TITLE
poc: adds quick edit

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -135,6 +135,39 @@ export function decorateMain(main) {
   decorateButtons(main);
 }
 
+let quickEditLoadPromise = null;
+
+/**
+ * Dynamically loads the Quick Edit plugin (da.live).
+ * @param {...*} args forwarded to quick-edit init (Sidekick payload or URL deep-link).
+ */
+async function loadQuickEdit(...args) {
+  if (quickEditLoadPromise) return quickEditLoadPromise;
+
+  quickEditLoadPromise = (async () => {
+    // eslint-disable-next-line import/no-cycle
+    const { default: initQuickEdit } = await import('../tools/quick-edit/quick-edit.js');
+    initQuickEdit(...args);
+  })();
+
+  return quickEditLoadPromise;
+}
+
+function registerQuickEditSidekick() {
+  const addSidekickListeners = (sk) => {
+    sk.addEventListener('custom:quick-edit', loadQuickEdit);
+  };
+
+  const sk = document.querySelector('aem-sidekick');
+  if (sk) {
+    addSidekickListeners(sk);
+  } else {
+    document.addEventListener('sidekick-ready', () => {
+      addSidekickListeners(document.querySelector('aem-sidekick'));
+    }, { once: true });
+  }
+}
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
@@ -192,24 +225,7 @@ async function loadLazy(doc) {
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
 
-  const loadQuickEdit = async (...args) => {
-    // eslint-disable-next-line import/no-cycle
-    const { default: initQuickEdit } = await import('../tools/quick-edit/quick-edit.js');
-    initQuickEdit(...args);
-  };
-
-  const addSidekickListeners = (sk) => {
-    sk.addEventListener('custom:quick-edit', loadQuickEdit);
-  };
-
-  const sk = document.querySelector('aem-sidekick');
-  if (sk) {
-    addSidekickListeners(sk);
-  } else {
-    document.addEventListener('sidekick-ready', () => {
-      addSidekickListeners(document.querySelector('aem-sidekick'));
-    }, { once: true });
-  }
+  registerQuickEditSidekick();
 }
 
 /**
@@ -240,3 +256,8 @@ loadPage();
   // eslint-disable-next-line import/no-unresolved
   import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
 }());
+
+setTimeout(() => {
+  const hasQE = new URL(window.location.href).searchParams.has('quick-edit');
+  if (hasQE) loadQuickEdit();
+}, 500);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -155,7 +155,10 @@ async function loadEager(doc) {
       loadErrorPage(418);
     }
     document.body.classList.add('appear');
-    await loadSection(main.querySelector('.section'), waitForFirstImage);
+    await loadSection(main.querySelector('.section'), (section) => {
+      if (document.body.classList.contains('quick-edit')) return Promise.resolve();
+      return waitForFirstImage(section);
+    });
   }
 
   try {
@@ -188,6 +191,25 @@ async function loadLazy(doc) {
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
+
+  const loadQuickEdit = async (...args) => {
+    // eslint-disable-next-line import/no-cycle
+    const { default: initQuickEdit } = await import('../tools/quick-edit/quick-edit.js');
+    initQuickEdit(...args);
+  };
+
+  const addSidekickListeners = (sk) => {
+    sk.addEventListener('custom:quick-edit', loadQuickEdit);
+  };
+
+  const sk = document.querySelector('aem-sidekick');
+  if (sk) {
+    addSidekickListeners(sk);
+  } else {
+    document.addEventListener('sidekick-ready', () => {
+      addSidekickListeners(document.querySelector('aem-sidekick'));
+    }, { once: true });
+  }
 }
 
 /**
@@ -199,7 +221,7 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
-async function loadPage() {
+export async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -257,7 +257,7 @@ loadPage();
   import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
 }());
 
-setTimeout(() => {
+(() => {
   const hasQE = new URL(window.location.href).searchParams.has('quick-edit');
-  if (hasQE) loadQuickEdit();
-}, 500);
+  if (hasQE) import('../tools/quick-edit/quick-edit.js').then((mod) => mod.default());
+})();

--- a/tools/quick-edit/quick-edit.js
+++ b/tools/quick-edit/quick-edit.js
@@ -1,0 +1,27 @@
+// eslint-disable-next-line import/no-cycle
+import { loadPage } from '../../scripts/scripts.js';
+
+const importMap = {
+  imports: {
+    'da-lit': 'https://da.live/deps/lit/dist/index.js',
+    'da-y-wrapper': 'https://da.live/deps/da-y-wrapper/dist/index.js',
+  },
+};
+
+function addImportmap() {
+  const importmapEl = document.createElement('script');
+  importmapEl.type = 'importmap';
+  importmapEl.textContent = JSON.stringify(importMap);
+  document.head.appendChild(importmapEl);
+}
+
+async function loadModule(origin, payload) {
+  document.body.classList.add('quick-edit');
+  const { default: loadQuickEdit } = await import(`${origin}/nx/public/plugins/quick-edit/quick-edit.js`);
+  loadQuickEdit(payload, loadPage);
+}
+
+export default function init(payload) {
+  addImportmap();
+  loadModule('https://da.live', payload);
+}

--- a/tools/quick-edit/quick-edit.js
+++ b/tools/quick-edit/quick-edit.js
@@ -15,13 +15,38 @@ function addImportmap() {
   document.head.appendChild(importmapEl);
 }
 
-async function loadModule(origin, payload) {
-  document.body.classList.add('quick-edit');
+async function loadMoudle(origin, payload) {
   const { default: loadQuickEdit } = await import(`${origin}/nx/public/plugins/quick-edit/quick-edit.js`);
   loadQuickEdit(payload, loadPage);
 }
 
+function generateSidekickPayload() {
+  let { hostname } = window.location;
+  if (hostname === 'localhost') {
+    hostname = document.querySelector('meta[property="hlx:proxyUrl"]').content;
+  }
+  const parts = hostname.split('.')[0].split('--');
+  const [, repo, owner] = parts;
+
+  return {
+    detail: {
+      config: {
+        mountpoint: `https://content.da.live/${owner}/${repo}/`,
+      },
+      location: {
+        pathname: window.location.pathname,
+      },
+    },
+  };
+}
+
 export default function init(payload) {
+  const { search } = window.location;
+  const ref = new URLSearchParams(search).get('quick-edit');
+  let origin;
+  if (ref === 'on' || !ref) origin = 'https://da.live';
+  if (ref === 'local') origin = 'http://localhost:6456';
+  if (!origin) origin = `https://${ref}--da-nx--adobe.aem.live`;
   addImportmap();
-  loadModule('https://da.live', payload);
+  loadMoudle(origin, payload || generateSidekickPayload());
 }


### PR DESCRIPTION
Adds [Quick Edit scripts](https://docs.da.live/about/early-access/quick-edit#quick-edit) needed to enable ootb "experience workspace" functionality.

This PR should have no impact on anything in the site, just allows us to use Quick Edit / Exp Workspace.

You can test it by going here: https://exw-int--aem-boilerplate-commerce--hlxsites.aem.page/drafts/rugh/demo-doc and using Sidekick + Quick Edit button. Then click some element on page and modify.

<img width="1908" height="890" alt="image" src="https://github.com/user-attachments/assets/9773fbb3-ae86-4e69-858e-b900a68bca2c" />

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://exw-int--aem-boilerplate-commerce--hlxsites.aem.live/
