### PR TITLE
fix: remove unused routeProduct prop from OrderSummary in commerce-cart

### DIFF
--- a/blocks/commerce-cart/commerce-cart.js
+++ b/blocks/commerce-cart/commerce-cart.js
@@ -253,7 +253,6 @@ export default async function decorate(block) {
 
     // Order Summary
     provider.render(OrderSummary, {
-      routeProduct: createProductLink,
       routeCheckout: checkoutURL ? () => rootLink(checkoutURL) : undefined,
       slots: {
         EstimateShipping: async (ctx) => {


### PR DESCRIPTION
**Summary**
Removed `routeProduct` prop from the `OrderSummary` container render call in the `commerce-cart` block, as it is not part of the `OrderSummaryProps` interface and was being silently ignored.

OrderSummary container on Cart dropin > https://github.com/adobe-commerce/storefront-cart/blob/develop/src/containers/OrderSummary/OrderSummary.tsx 

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://remove-prop--aem-boilerplate-commerce--hlxsites.aem.page/
