### PR TITLE
COMOPT-1989 Mapping locale if set in analytics (for ACO)

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -28,6 +28,8 @@ async function initAnalytics() {
             websiteId: parseInt(analyticsConfig['website-id'], 10),
             websiteName: analyticsConfig['website-name'],
             viewId: analyticsConfig['view-id'], // applicable for ACO storefronts
+            // setting locale if defined, applicable for ACO storefronts
+            ...(analyticsConfig.locale && { locale: analyticsConfig.locale }),
           },
         },
         {


### PR DESCRIPTION
Storefront-events-collector requires l[ocale](https://github.com/adobe/commerce-events/blob/db2621a0aec6af0f671714406f3abeb4480f609f/packages/storefront-events-collector/src/utils/ccdm.ts#L4) to populate properly events from CCDM/ACO model.
Locale is defined in the [demo-config-aco.json](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/demo-config-aco.json) but was not mapped in the delayed script, without this, events are not correctly processed by the snowplow pipeline

Test URLs:

Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
After: https://analytics-locale-int--aem-boilerplate-commerce--hlxsites.aem.live/