### PR TITLE
docs: clarify suite releases vs dropin updates for forked implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,31 +19,58 @@ Use the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/
 
 Alternatively, you can follow our [Guide](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/) for a more detailed walkthrough.
 
-## Updating Drop-in dependencies
+## Staying Up to Date
 
-You may need to update one of the drop-in components, or `@adobe/magento-storefront-event-collector` or `@adobe/magento-storefront-events-sdk` to a new version. Before applying any update, check the release notes for breaking changes and ensure the `postinstall` script runs so that the dependencies in your `scripts/__dropins__` directory are updated to the latest build.
+Once you fork or clone this repo, the code is yours — you are not subscribed to updates.
+
+### What a suite release is (and is not)
+
+A suite release — for example "B2C v8.0.0" — is a tagged snapshot of this boilerplate at a point in time when a specific combination of drop-in package versions and boilerplate code was tested together and verified to work. That tag is useful as a **starting point** for developers who are setting up a new project.
+
+If you have already forked or cloned this repo, a new suite release is not an upgrade you need to apply. There is no mechanism that pushes boilerplate code changes into your fork, and nothing will break in your project because a new release tag was created upstream. Treat suite releases the same way you would treat a new major version of a project template: relevant only if you are starting fresh.
+
+### Updating your drop-in packages
+
+The only thing you need to actively track after forking is your **npm dependencies** — specifically the `@dropins/*` and `@adobe/*` packages (including `@adobe/magento-storefront-event-collector` and `@adobe/magento-storefront-events-sdk`) listed in your `package.json`. Before applying any update, check the release notes for breaking changes and ensure the `postinstall` script runs so that the dependencies in your `scripts/__dropins__` directory are updated to the latest build.
 
 - Drop-in components: <https://experienceleague.adobe.com/developer/commerce/storefront/release-notes/>
 
-### Automated weekly updates
+These packages follow semantic versioning. Minor and patch releases are non-breaking by contract, so routine updates should be safe to apply.
 
-A GitHub Actions workflow runs every Monday and opens a pull request whenever newer stable versions of `@adobe/*` or `@dropins/*` packages are available. The PR includes updated `package.json`, `package-lock.json`, and regenerated dropin assets under `scripts/__dropins__/`. Pre-release packages are held without changes and surfaced in the workflow output.
+To see which packages have newer versions available:
 
-You can also trigger the workflow manually from the **Actions** tab in GitHub.
+```bash
+npm outdated
+```
 
-### Manual updates
-
-To update a specific package:
+To install a specific version:
 
 ```bash
 npm install @dropins/storefront-cart@2.0.0  # updates the package in node_modules/
 npm run postinstall                         # copies scripts from node_modules into scripts/__dropins__/
 ```
 
-This is a custom script which copies files out of `node_modules` and into a local directory which EDS can serve. You must manually run `postinstall` due to a design choice in `npm` which does not execute `postinstall` after you install a _specific_ package.
+To update a drop-in to its latest stable release:
+
+```bash
+npm install @dropins/storefront-cart@latest
+npm run postinstall
+```
+
+Always run `postinstall` after any drop-in update — it copies the built assets from `node_modules` into `scripts/__dropins__`, which is what Edge Delivery Services serves. Note that `npm` does not run `postinstall` automatically when you install a specific package, so this step must always be done manually.
+
+### Automated dependency PRs
+
+This repo includes a GitHub Actions workflow that runs every Monday and opens a pull request when newer stable versions of `@adobe/*` or `@dropins/*` packages are available. The PR includes updated `package.json`, `package-lock.json`, and regenerated dropin assets under `scripts/__dropins__/`. Pre-release packages are held without changes and surfaced in the workflow output. This works similarly to Dependabot or Renovate; once you fork the repo, the workflow runs in your fork so you can review and merge updates at your own pace.
+
+You can also trigger the workflow manually from the **Actions** tab in GitHub.
+
+### Pulling boilerplate code changes into your fork (optional)
+
+If you want to incorporate code changes made to this upstream boilerplate after you forked — for example, a new block or a bug fix in `scripts/` — you can do so by adding this repo as a git remote and merging selectively. This is entirely optional. Upstream changes may conflict with modifications you have made to your fork, so expect to resolve conflicts manually. There is no guarantee of a clean merge, and nothing in your project depends on staying in sync with the upstream boilerplate code.
 
 ## Changelog
 
-Major changes are described and documented as part of pull requests and tracked via the `changelog` tag. To keep your project up to date, please follow this list:
+Major changes to this boilerplate are described and documented as part of pull requests and tracked via the `changelog` tag. This log documents changes to the canonical starting point — not upgrades that forked implementations must apply. Review it if you are considering pulling specific upstream changes into your fork:
 
 <https://github.com/hlxsites/aem-boilerplate-commerce/issues?q=label%3Achangelog+is%3Aclosed>

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Always run `postinstall` after any drop-in update — it copies the built assets
 
 ### Automated dependency PRs
 
-This repo includes a GitHub Actions workflow that runs every Monday and opens a pull request when newer stable versions of `@adobe/*` or `@dropins/*` packages are available. The PR includes updated `package.json`, `package-lock.json`, and regenerated dropin assets under `scripts/__dropins__/`. Pre-release packages are held without changes and surfaced in the workflow output. This works similarly to Dependabot or Renovate; once you fork the repo, the workflow runs in your fork so you can review and merge updates at your own pace.
+This repo includes a GitHub Actions workflow that runs every Monday and opens a pull request when newer stable versions of `@adobe/*` or `@dropins/*` packages are available within the ranges declared in your `package.json` ([semver](https://semver.org/)). The PR includes updated `package.json`, `package-lock.json`, and regenerated dropin assets under `scripts/__dropins__/`. Pre-release packages are held without changes and surfaced in the workflow output. This works similarly to Dependabot or Renovate; once you fork the repo, the workflow runs in your fork so you can review and merge updates at your own pace.
 
 You can also trigger the workflow manually from the **Actions** tab in GitHub.
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,13 @@ Once you fork or clone this repo, the code is yours — you are not subscribed t
 
 ### What a suite release is (and is not)
 
-A suite release — for example "B2C v8.0.0" — is a tagged snapshot of this boilerplate at a point in time when a specific combination of drop-in package versions and boilerplate code was tested together and verified to work. That tag is useful as a **starting point** for developers who are setting up a new project.
+A suite release — for example "[b2c-march-2026](https://github.com/hlxsites/aem-boilerplate-commerce/tree/b2c-march-2026)" — is a tagged snapshot of this boilerplate at a point in time when a specific combination of drop-in package versions and boilerplate code was tested together and verified to work. That tag is useful as a **starting point** for developers who are setting up a new project. You can find the release notes for each suite release in the [releases](https://experienceleague.adobe.com/developer/commerce/storefront/releases/) page.
 
 If you have already forked or cloned this repo, a new suite release is not an upgrade you need to apply. There is no mechanism that pushes boilerplate code changes into your fork, and nothing will break in your project because a new release tag was created upstream. Treat suite releases the same way you would treat a new major version of a project template: relevant only if you are starting fresh.
 
-### Updating your drop-in packages
+### Updating your drop-in dependencies
 
-The only thing you need to actively track after forking is your **npm dependencies** — specifically the `@dropins/*` and `@adobe/*` packages (including `@adobe/magento-storefront-event-collector` and `@adobe/magento-storefront-events-sdk`) listed in your `package.json`. Before applying any update, check the release notes for breaking changes and ensure the `postinstall` script runs so that the dependencies in your `scripts/__dropins__` directory are updated to the latest build.
-
-- Drop-in components: <https://experienceleague.adobe.com/developer/commerce/storefront/release-notes/>
+The only things you need to actively track after forking are your **npm dependencies** — specifically the `@dropins/*` and `@adobe/*` packages (including `@adobe/magento-storefront-event-collector` and `@adobe/magento-storefront-events-sdk`) listed in your `package.json`. Before applying any update, check the release notes for breaking changes and ensure the `postinstall` script runs so that the dependencies in your `scripts/__dropins__` directory are updated to the latest build.
 
 These packages follow semantic versioning. Minor and patch releases are non-breaking by contract, so routine updates should be safe to apply.
 


### PR DESCRIPTION
After merge, apply this change to https://github.com/adobe-rnd/aem-boilerplate-xcom.

URL for testing:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://clarify-releases-docs--aem-boilerplate-commerce--hlxsites.aem.live/
