### PR TITLE
fix: remove X-Adobe-Company header for unauthenticated requests

### DIFF
--- a/scripts/initializers/index.js
+++ b/scripts/initializers/index.js
@@ -20,6 +20,7 @@ const setAuthHeaders = (state) => {
   } else {
     sessionStorage.removeItem('DROPIN__COMPANYSWITCHER__COMPANY__CONTEXT');
     sessionStorage.removeItem('DROPIN__COMPANYSWITCHER__GROUP__CONTEXT');
+    CORE_FETCH_GRAPHQL.removeFetchGraphQlHeader('X-Adobe-Company');
     CORE_FETCH_GRAPHQL.removeFetchGraphQlHeader('Authorization');
     CS_FETCH_GRAPHQL.removeFetchGraphQlHeader('Authorization');
   }
@@ -143,7 +144,7 @@ export default async function initializeDropins() {
      * the correct payload.
      */
     const companyContext = sessionStorage.getItem('DROPIN__COMPANYSWITCHER__COMPANY__CONTEXT');
-    if (companyContext) {
+    if (token && companyContext) {
       CORE_FETCH_GRAPHQL.setFetchGraphQlHeader('X-Adobe-Company', companyContext);
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the `X-Adobe-Company` header was being sent on guest GraphQL requests (login, password reset, register) even when no user was authenticated.

Resolves [CCSAAS-4997](https://jira.corp.adobe.com/browse/CCSAAS-4997)

## Root cause

The boilerplate makes an architectural optimization to reduce guest page load: the `storefront-company-switcher` drop-in is only initialized when the user is authenticated. This is intentional — there is no meaningful company context for guests.

However, this means the drop-in's own `authenticated: false` handler (which calls `removeCompanyHeaders()`) never fires for guest sessions. Combined with the `SYNC_KEYS` mechanism that restores `sessionStorage` from `localStorage` on page load, this creates a window where:

1. `setAuthHeaders(false)` clears `sessionStorage` but leaves `X-Adobe-Company` live on the GraphQL client
2. `SYNC_KEYS` restores the company context from `localStorage` into `sessionStorage`
3. The boilerplate attaches `X-Adobe-Company` unconditionally from the restored `sessionStorage` value
4. The `authenticated` event fires and clears `localStorage` — too late, the header is already set

On logout, a page redirect can complete before the drop-in gets a chance to reset the header, making this effectively a race condition.

## Changes

`scripts/initializers/index.js`

- `setAuthHeaders(false)` now calls `removeFetchGraphQlHeader('X-Adobe-Company')` alongside the existing `Authorization` header teardown, so logout fully clears company context from the GraphQL client.
- The startup header attach is gated on `token && companyContext` instead of `companyContext` alone, so a guest with a `localStorage`-restored session value never gets `X-Adobe-Company` attached.

## Test URLs

- Before: https://b2b-integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://company-header-fix--aem-boilerplate-commerce--hlxsites.aem.live/

### Verification (smoking-gun checklist)

Open an incognito window and confirm no unauthenticated GraphQL request carries `X-Adobe-Company`:

| Signal | Where | Expected |
|---|---|---|
| No auth cookie | Application → Cookies | `auth_dropin_user_token` absent |
| No bearer header | Network → Request Headers | `Authorization` absent |
| No company header | Network → Request Headers | `X-Adobe-Company` **absent** |