### PR TITLE
COMOPT-2042: [Storefront Dropin] Read currentProductPrice from product context and pass to GraphQL

### DIFF
--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -165,13 +165,17 @@ export default async function decorate(block) {
     );
 
     try {
+      const skuFromConfig = !!currentsku;
       const resolvedSku = currentsku || context.currentSku;
       const isACO = getConfigValue('adobe-commerce-optimizer') === true
         || getConfigValue('adobe-commerce-optimizer') === 'true';
-      const contextPrice = currentprice != null
-        ? Number(currentprice)
-        : context.currentProductPrice;
-      const resolvedPrice = isACO ? contextPrice : null;
+      // Price source must match SKU source: if SKU is pinned via block config,
+      // do not pull price from ACDL context (it would belong to a different product).
+      const resolvedPrice = isACO
+        ? (currentprice != null
+          ? Number(currentprice)
+          : (skuFromConfig ? null : context.currentProductPrice))
+        : null;
       const currentProduct = resolvedSku
         ? { sku: resolvedSku, ...(resolvedPrice != null && { price: resolvedPrice }) }
         : undefined;


### PR DESCRIPTION
Fix price/SKU source mismatch introduced in #1244: when `currentsku` is set via block config, the price was incorrectly falling back to `context.currentProductPrice` from ACDL (which may belong to a different product visited on a previous PDP).

[COMOPT-2042](https://jira.corp.adobe.com/browse/COMOPT-2042)

**Changes:**
- When SKU is sourced from block config (`currentsku`), price is now only taken from block config (`currentprice`) — ACDL `context.currentProductPrice` is not used
- When SKU is sourced from ACDL context, price is sourced from ACDL context as before
- Prevents a static-SKU/contextual-price mismatch on non-PDP pages that have residual ACDL product context

**Related PR:** #1244 (original feature, merged to `integration`)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://PREX-2188-curprod-fix--aem-boilerplate-commerce--hlxsites.aem.live/