### PR TITLE
COMOPT-2042: [Storefront Dropin] Read currentProductPrice from product context and pass to GraphQL

### DIFF
--- a/blocks/product-recommendations/README.md
+++ b/blocks/product-recommendations/README.md
@@ -10,9 +10,9 @@ The Product Recommendations block provides personalized product recommendations 
 
 | Configuration Key | Type | Default | Description | Required | Side Effects |
 |-------------------|------|---------|-------------|----------|--------------|
-| `currentsku` | string | undefined | Explicit current product SKU. On a PDP this is sourced automatically from ACDL `productContext`; use this field on non-PDP pages only. | No | Overrides ACDL-derived SKU |
-| `currentprice` | number | undefined | Explicit current product price (anchor price for filtering). On a PDP price is sourced automatically from ACDL `productContext.pricing` (`specialPrice ?? regularPrice`); use this field on non-PDP pages only. | No | Overrides ACDL-derived price; enables price-based recommendation filtering |
-| `recid` | string | undefined | Recommendation unit ID to render | No | Identifies which recommendation unit to fetch |
+| `recid` | string | — | Recommendation unit ID to render. | **Yes** | Identifies which recommendation unit to fetch |
+| `currentsku` | string | undefined | Current product SKU. Only set this on pages where ACDL `productContext` is not populated. For cross-sell and upsell recommendation types (`viewed-viewed`, `viewed-bought`, `bought-bought`, `more-like-this`, `visual`) this value (from config or ACDL) is required for the unit to return results. | No | Takes precedence over ACDL-derived SKU; if set without `currentprice`, no price is passed to the service |
+| `currentprice` | number | undefined | Current product price as an anchor for dynamic/relative price filter operators. **May only be set together with `currentsku`.** Only needed for SKU-related recommendation types with dynamic or relative price filters when ACDL product context is unavailable. The value should match the effective price shown to the shopper (`specialPrice ?? regularPrice`). | No | Takes precedence over ACDL-derived price; has no effect if `currentsku` is not also set |
 
 <!-- ### URL Parameters
 
@@ -57,5 +57,6 @@ No URL parameters directly affect this block's behavior. -->
 - **Context Errors**: If context data is invalid, falls back to empty arrays for view/purchase history
 - **API Errors**: If recommendation API fails, the ProductList container handles error display
 - **Configuration Errors**: If `readBlockConfig()` fails, uses undefined values for configuration
+- **Missing SKU**: If the recommendation type requires a current SKU but none is available (neither from block config nor from ACDL), an error is logged to the browser console
 - **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
 - **Fallback Behavior**: Always falls back to appropriate default values for missing or invalid configuration

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -171,11 +171,14 @@ export default async function decorate(block) {
         || getConfigValue('adobe-commerce-optimizer') === 'true';
       // Price source must match SKU source: if SKU is pinned via block config,
       // do not pull price from ACDL context (it would belong to a different product).
-      const resolvedPrice = isACO
-        ? (currentprice != null
-          ? Number(currentprice)
-          : (skuFromConfig ? null : context.currentProductPrice))
-        : null;
+      let resolvedPrice = null;
+      if (isACO) {
+        if (currentprice != null) {
+          resolvedPrice = Number(currentprice);
+        } else if (!skuFromConfig) {
+          resolvedPrice = context.currentProductPrice ?? null;
+        }
+      }
       const currentProduct = resolvedSku
         ? { sku: resolvedSku, ...(resolvedPrice != null && { price: resolvedPrice }) }
         : undefined;

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -165,13 +165,17 @@ export default async function decorate(block) {
     );
 
     try {
+      const skuFromConfig = !!currentsku;
       const resolvedSku = currentsku || context.currentSku;
       const isACO = getConfigValue('adobe-commerce-optimizer') === true
         || getConfigValue('adobe-commerce-optimizer') === 'true';
-      const contextPrice = currentprice != null
-        ? Number(currentprice)
-        : context.currentProductPrice;
-      const resolvedPrice = isACO ? contextPrice : null;
+      // Price source must match SKU source: if SKU is pinned via block config,
+      // do not pull price from ACDL context (it would belong to a different product).
+      const resolvedPrice = isACO
+        ? (currentprice != null
+          ? Number(currentprice)
+          : (skuFromConfig ? null : context.currentProductPrice))
+        : null;
       const currentProduct = resolvedSku
         ? { sku: resolvedSku, ...(resolvedPrice != null && { price: resolvedPrice }) }
         : undefined;


### PR DESCRIPTION
Fix price/SKU source mismatch introduced in #1244: when `currentsku` is set via block config, the price was incorrectly falling back to `context.currentProductPrice` from ACDL (which may belong to a different product visited on a previous PDP).

[COMOPT-2042](https://jira.corp.adobe.com/browse/COMOPT-2042)

**Changes:**
- When SKU is sourced from block config (`currentsku`), price is now only taken from block config (`currentprice`) — ACDL `context.currentProductPrice` is not used
- When SKU is sourced from ACDL context, price is sourced from ACDL context as before
- Prevents a static-SKU/contextual-price mismatch on non-PDP pages that have residual ACDL product context

**Related PR:** #1244 (original feature, merged to `integration`)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://PREX-2188-curprod-fix--aem-boilerplate-commerce--hlxsites.aem.live/

Made with [Cursor](https://cursor.com)