### PR TITLE
COMOPT-2042: Add PREX Cypress E2E infrastructure and context matrix

### DIFF
--- a/.github/workflows/run-e2e-tests-aco.yaml
+++ b/.github/workflows/run-e2e-tests-aco.yaml
@@ -1,0 +1,28 @@
+name: Cypress E2E B2C ACO Tests
+on: push
+jobs:
+  cypress-aco-run:
+    if: github.repository == 'hlxsites/aem-boilerplate-commerce'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install root dependencies
+        run: npm ci
+      - name: Install adobe aem cli dependencies
+        run: npm install -g @adobe/aem-cli
+      - name: Start server in the background
+        run: aem up --url https://b2b--boilerplate-aco-b2b--adobe-commerce.aem.live &
+      - name: Install Cypress and run tests
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: cypress
+          wait-on: 'http://localhost:3000'
+          command: npm run cypress:aco:run
+        env:
+          AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots-aco
+          path: cypress/screenshots
+          if-no-files-found: ignore

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -62,9 +62,65 @@ All commands use a base config, defined in `cypress.base.config.js` and extend i
 For various reasons, certain tests fail against certain environments. Eventually these will issues will be fixed. But for now, if a test is _expected_ to fail on a specific environment, you can assign a tag to it.
 
 - `{ tags: '@skipSaas' }` skips the test when run with `cypress:saas:run`
-- `{ tags: '@skipPaas' }` skips the test when run with `cypress:run`.
+- `{ tags: '@skipPaas' }` skips the test when run with `cypress:run`
+- `{ tags: '@skipAco' }` skips the test when run with `cypress:aco:run`
 
-| Skipped Tests | Backned Env | Notes |
+## Product Recommendations (PREX) E2E tests
+
+Specs: `verifyRecsDisplay.spec.js` (carousel smoke), `verifyRecsContextMatrix.spec.js` (GraphQL wiring).
+
+### Scope — what boilerplate Cypress does NOT cover
+
+Per-operator filter math (STATIC range, GT/LT current, DYNAMIC, PERCENTAGE) and exhaustive rec unit types are **already covered** by:
+
+- Cell integration tests (`RecServiceFilterTests`, `RecPreviewGQLTests`)
+- Studio Playwright (`e2e-qa-aco`, COMOPT-1868)
+
+Boilerplate Cypress validates **storefront wiring only**: block → dropin → GraphQL request shape. One **static** rec unit + one **dynamic** rec unit per tenant is enough — do not duplicate the IT/Studio operator matrix here.
+
+### productContext — where it comes from (verified in codebase)
+
+| Source | Sets `productContext`? | Used by rec block for anchor? |
+| --- | --- | --- |
+| **PDP** (`scripts/initializers/pdp.js`, `acdl: true`) | ✅ sku + pricing | ✅ primary anchor on PDP |
+| PLP, category, search, cart, checkout | ❌ | ❌ — use block `currentsku` / `currentprice` |
+| Cart (`shoppingCartContext`) | ❌ for anchor | ✅ `cartSkus` only (dedup), not sku/price anchor |
+
+Only the PDP dropin publishes `productContext` to ACDL today. Non-PDP pages with a rec block **must** set `currentsku` (and `currentprice` on ACO for dynamic filters) in Document Authoring.
+
+### `prexPages` — tenant-specific da.live drafts
+
+Defined in `prexPages.config.js`, wired per config via `buildPrexPages('paas'|'saas'|'aco')`.
+
+| Key | Block config | Page type | What it tests |
+| --- | --- | --- | --- |
+| `displayPlp` / `displayPdp` | recid (+ optional currentsku) | PLP / PDP | Carousel smoke |
+| `pdpAcdlOnly` | recid only | PDP | ACDL → currentProduct + price (ACO) |
+| `plpStaticSkuOnly` | recid + currentsku | PLP | Static/MLT anchor, no price in GQL |
+| `plpBlockSkuAndPrice` | recid + currentsku + currentprice | PLP | ACO dynamic from block config |
+| `pdpBlockSkuNoPrice` | recid + currentsku on PDP | PDP | #1272 guard — no ACDL price leak |
+| `plpRecidOnly` | recid only | PLP | Optional — unit types without anchor |
+| `cartRecsBlock` | recid + block anchor fields | Cart | Non-PDP block-config path |
+
+Paths under `/drafts/decepticons/products/{paas|saas|aco}/…` except PaaS `displayPlp` / `plpStaticSkuOnly` which use `/drafts/tests/apparel` today.
+
+### Enabling skipped PREX tests
+
+Remove `@skipSaas`, `@skipAco`, or both once the da.live page exists **and** a rec unit is created in that environment's admin:
+
+| Environment | Config | Proxy URL for local `aem up --url` |
+| --- | --- | --- |
+| PaaS | `cypress.paas.config.js` | `main--boilerplate-paas--adobe-commerce.aem.live` |
+| ACCS | `cypress.saas.config.js` | `main--boilerplate-accs--adobe-commerce.aem.live` |
+| ACO | `cypress.aco.config.js` | `b2b--boilerplate-aco-b2b--adobe-commerce.aem.live` |
+
+```bash
+npm run cypress:run -- --spec "src/tests/b2c/verifyRecs*.spec.js"
+npm run cypress:saas:run -- --spec "src/tests/b2c/verifyRecs*.spec.js"
+npm run cypress:aco:run -- --spec "src/tests/b2c/verifyRecs*.spec.js"
+```
+
+| Skipped Tests | Backend Env | Notes |
 | ------------- | ------------- | -------- |
 | `verifyStoreSwitcher.spec`  | SaaS, PaaS | Story to re-configire multi store <https://jira.corp.adobe.com/browse/USF-2253> |
 | `verifyUserAccount.spec` | SaaS, PaaS | Task <https://jira.corp.adobe.com/browse/USF-2310> |
@@ -72,6 +128,8 @@ For various reasons, certain tests fail against certain environments. Eventually
 | `search-product-click.spec` | SaaS | Epic <https://jira.corp.adobe.com/browse/COMOPT-81> |
 | `search-request-sent.spec` | SaaS | Epic <https://jira.corp.adobe.com/browse/COMOPT-81> |
 | `search-results-view.spec` | SaaS | Epic <https://jira.corp.adobe.com/browse/COMOPT-81> |
+| `verifyRecsDisplay` (PLP/PDP) | ACCS, ACO | Remove `@skipSaas` / `@skipAco` when tenant drafts + recIds exist |
+| `verifyRecsContextMatrix` | ACCS, ACO | Remove skips per scenario when matching da.live page is authored |
 
 ## Metadata/SKUs in Tests
 

--- a/cypress/cypress.aco.config.js
+++ b/cypress/cypress.aco.config.js
@@ -1,0 +1,55 @@
+const { defineConfig } = require('cypress');
+const baseConfig = require('./cypress.base.config');
+const { buildPrexPages } = require('./prexPages.config');
+
+const AEM_ASSETS_PRIVATE_USER = JSON.parse(
+  process.env.AEM_ASSETS_PRIVATE_USER ?? '{}',
+);
+
+module.exports = defineConfig({
+  ...baseConfig,
+  e2e: {
+    ...baseConfig.e2e,
+    supportFile: 'src/support/index.aco.js',
+  },
+  env: {
+    ...baseConfig.env,
+    graphqlEndPoint:
+      'https://integration2-hohc4oi-t35oyq7dhw7ti.us-3.magentosite.cloud/graphql',
+    graphqlCatalogEndPoint:
+      'https://na1.api.commerce.adobe.com/WbqPAxMhK9b37TKrp8htRx/graphql',
+    giftCardA: '02R7NXP5HJI5',
+    productUrlWithOptions:
+      '/products/cypress-configurable-product-latest/cypress456?optionsUIDs=Y29uZmlndXJhYmxlLzkzLzIzMA==',
+    stateShippingId: 'TX,57',
+    stateBillingId: 'NY,43',
+    productImageName: 'ADB150_1.jpg',
+    productImageNameConfigurable: 'adb124.jpg',
+    productWithOptionImageNameConfigurable: 'adb192.jpg',
+
+    prexPages: buildPrexPages('aco'),
+
+    aemAssetsConfig: {
+      commerceConfig: {
+        endpoint: 'https://na1.api.commerce.adobe.com/WbqPAxMhK9b37TKrp8htRx/graphql',
+        coreEndpoint:
+          'https://integration2-hohc4oi-t35oyq7dhw7ti.us-3.magentosite.cloud/graphql',
+      },
+      author: {
+        programId: '',
+        environmentId: '',
+        isStage: false,
+      },
+      credentials: {
+        xPublicApiKey: '',
+        magentoEnvironmentId: '',
+      },
+      user: {
+        ...AEM_ASSETS_PRIVATE_USER,
+        order: '',
+        returnedOrder: '',
+      },
+      prexDraft: '/drafts/decepticons/products/aco/adb125',
+    },
+  },
+});

--- a/cypress/cypress.paas.config.js
+++ b/cypress/cypress.paas.config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
 const baseConfig = require('./cypress.base.config');
+const { buildPrexPages } = require('./prexPages.config');
 
 // A private user used with AEM Assets testing suite.
 const AEM_ASSETS_PRIVATE_USER = JSON.parse(
@@ -19,6 +20,9 @@ module.exports = defineConfig({
     productImageName: '/ADB150.jpg',
     productImageNameConfigurable: '/adb124.jpg',
     productWithOptionImageNameConfigurable: '/adb192.jpg',
+
+    // Tenant-specific da.live draft paths — see prexPages.config.js
+    prexPages: buildPrexPages('paas'),
 
     aemAssetsConfig: {
       commerceConfig: {

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
 const baseConfig = require('./cypress.base.config');
+const { buildPrexPages } = require('./prexPages.config');
 
 // A private user used with AEM Assets testing suite.
 const AEM_ASSETS_PRIVATE_USER = JSON.parse(
@@ -20,6 +21,8 @@ module.exports = defineConfig({
     productImageName: '/adb150.jpg',
     productImageNameConfigurable: '/adb124_1.jpg',
     productWithOptionImageNameConfigurable: '/adb192_1.jpg',
+
+    prexPages: buildPrexPages('saas'),
 
     aemAssetsConfig: {
       commerceConfig: {

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -10,6 +10,8 @@
     "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas",
     "cypress:b2b:saas:open": "cypress open --browser chrome --config-file cypress.b2b.saas.config.js",
     "cypress:b2b:saas:run": "cypress run --config-file cypress.b2b.saas.config.js --env grepTags=@B2BSaas",
+    "cypress:aco:open": "cypress open --browser chrome --config-file cypress.aco.config.js",
+    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco",
     "lint": "eslint src/"
   },
   "author": "Adobe Commerce",

--- a/cypress/prexPages.config.js
+++ b/cypress/prexPages.config.js
@@ -1,0 +1,33 @@
+/**
+ * Tenant-specific da.live draft paths for PREX Cypress tests.
+ *
+ * Shared content authoring is used for most storefront pages. Rec-related tests
+ * use specialized drafts under /drafts/decepticons/products/{paas|saas|aco}/ because
+ * recId (and block config) must match the backend tenant configured in config.json.
+ *
+ * Authoring checklist per path (see cypress/README.md):
+ * - Create rec unit in that environment's admin, copy recId into the block
+ * - pdpAcdlOnly: recid only (PDP dropin populates productContext via acdl)
+ * - plpStaticSkuOnly: recid + currentsku (static / MLT anchor, no currentprice)
+ * - plpBlockSkuAndPrice: recid + currentsku + currentprice (ACO dynamic on non-PDP)
+ * - pdpBlockSkuNoPrice: PDP page + block currentsku, no currentprice (#1272 guard)
+ * - plpRecidOnly: recid only on non-PDP (optional — unit types that need no anchor)
+ * - cartRecsBlock: cart page with rec block + currentsku (+ currentprice on ACO dynamic)
+ */
+function buildPrexPages(envFolder) {
+  const base = `/drafts/decepticons/products/${envFolder}`;
+  const isPaas = envFolder === 'paas';
+
+  return {
+    displayPlp: isPaas ? '/drafts/tests/apparel' : `${base}/recs-plp`,
+    displayPdp: `${base}/adb125`,
+    pdpAcdlOnly: `${base}/adb125`,
+    plpStaticSkuOnly: isPaas ? '/drafts/tests/apparel' : `${base}/recs-static-plp`,
+    plpBlockSkuAndPrice: `${base}/recs-plp-block-price`,
+    pdpBlockSkuNoPrice: `${base}/recs-pdp-block-sku`,
+    plpRecidOnly: `${base}/recs-plp-recid-only`,
+    cartRecsBlock: `${base}/recs-cart`,
+  };
+}
+
+module.exports = { buildPrexPages };

--- a/cypress/run-cypress.sh
+++ b/cypress/run-cypress.sh
@@ -17,7 +17,8 @@ show_menu() {
     echo -e "${GREEN}1)${NC} B2C PaaS Configuration (localhost + cypress:open)"
     echo -e "${GREEN}2)${NC} B2C SaaS Configuration (localhost + cypress:saas:open)"
     echo -e "${GREEN}3)${NC} B2B SaaS Configuration (localhost + cypress:b2b:saas:open)"
-    echo -e "${RED}4)${NC} Exit"
+    echo -e "${GREEN}4)${NC} B2C ACO Configuration (localhost + cypress:aco:open)"
+    echo -e "${RED}5)${NC} Exit"
     echo ""
 }
 
@@ -94,11 +95,30 @@ run_configuration() {
             echo -e "${BLUE}To stop it, run: kill $AEM_PID${NC}"
             ;;
         4)
+            echo -e "${YELLOW}Starting AEM localhost with ACO B2C configuration...${NC}"
+            echo -e "${BLUE}URL: https://b2b--boilerplate-aco-b2b--adobe-commerce.aem.live${NC}"
+
+            cd "$ROOT_DIR" && npx aem up --url https://b2b--boilerplate-aco-b2b--adobe-commerce.aem.live &
+            AEM_PID=$!
+
+            echo -e "${GREEN}AEM localhost server started (PID: $AEM_PID)${NC}"
+            echo -e "${YELLOW}Waiting a moment for server to initialize...${NC}"
+            sleep 3
+
+            cd "$ROOT_DIR/cypress"
+            echo -e "${YELLOW}Opening Cypress with ACO configuration...${NC}"
+            npm run cypress:aco:open
+
+            echo ""
+            echo -e "${BLUE}Note: AEM localhost server (PID: $AEM_PID) is still running in the background.${NC}"
+            echo -e "${BLUE}To stop it, run: kill $AEM_PID${NC}"
+            ;;
+        5)
             echo -e "${YELLOW}Exiting...${NC}"
             exit 0
             ;;
         *)
-            echo -e "${RED}Invalid option. Please select 1, 2, 3, or 4.${NC}"
+            echo -e "${RED}Invalid option. Please select 1, 2, 3, 4, or 5.${NC}"
             return 1
             ;;
     esac
@@ -136,7 +156,7 @@ main() {
 
     while true; do
         show_menu
-        read -p "Enter your choice (1-4): " choice
+        read -p "Enter your choice (1-5): " choice
         
         if run_configuration "$choice"; then
             break

--- a/cypress/src/support/index.aco.js
+++ b/cypress/src/support/index.aco.js
@@ -1,0 +1,15 @@
+/**
+ * ACO-specific Cypress support file.
+ * Extends the base support file for tests running against an ACO-configured storefront.
+ */
+import './index';
+
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes("Cannot read properties of null (reading 'final')")) {
+    return false;
+  }
+  if (err.message.includes("Cannot read properties of null (reading 'dataset')")) {
+    return false;
+  }
+  return true;
+});

--- a/cypress/src/support/index.js
+++ b/cypress/src/support/index.js
@@ -18,3 +18,9 @@ import './b2bLoginHelpers';
 
 import registerCypressGrep from '@cypress/grep'
 registerCypressGrep();
+
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('Tenant not found')) {
+    return false;
+  }
+});

--- a/cypress/src/support/recsGraphql.js
+++ b/cypress/src/support/recsGraphql.js
@@ -1,0 +1,89 @@
+export const RECS_GRAPHQL_ALIAS = 'recsGraphql';
+
+/**
+ * Intercept storefront recommendations GraphQL GET requests.
+ * Negative lookahead excludes fetch-graphql.js module downloads.
+ */
+export function interceptRecsGraphQL() {
+  cy.intercept({ method: 'GET', url: /graphql(?!\.js)/ }).as(RECS_GRAPHQL_ALIAS);
+}
+
+export function waitForRecsGraphQL() {
+  return cy.wait(`@${RECS_GRAPHQL_ALIAS}`);
+}
+
+export function decodeGraphqlUrl(url) {
+  return decodeURIComponent(url);
+}
+
+export function assertUrlIncludesCurrentProduct(url, { sku, requirePrice = false } = {}) {
+  const decoded = decodeGraphqlUrl(url);
+  expect(decoded, 'GraphQL URL includes currentProduct').to.include('currentProduct');
+  if (sku) {
+    expect(decoded, 'GraphQL URL includes anchor SKU').to.include(sku);
+  }
+  if (requirePrice) {
+    assertUrlIncludesCurrentProductPrice(url);
+  }
+}
+
+export function assertUrlIncludesCurrentProductPrice(url) {
+  const decoded = decodeGraphqlUrl(url);
+  expect(decoded, 'GraphQL URL includes currentProduct with price').to.match(/currentProduct[^&]*price/i);
+}
+
+export function assertUrlExcludesCurrentProduct(url) {
+  expect(decodeGraphqlUrl(url), 'GraphQL URL excludes currentProduct').not.to.include('currentProduct');
+}
+
+/**
+ * When block pins currentsku without currentprice on ACO, price must not be sent
+ * even if PDP productContext has pricing (COMOPT-2042 / #1272 guard).
+ */
+export function assertUrlExcludesCurrentProductPrice(url) {
+  const decoded = decodeGraphqlUrl(url);
+  if (!decoded.includes('currentProduct')) {
+    return;
+  }
+  const match = decoded.match(/currentProduct[^&]*/i);
+  expect(match?.[0] ?? '', 'currentProduct payload excludes price').not.to.match(/price/i);
+}
+
+export function getPrexPage(key) {
+  const pages = Cypress.env('prexPages');
+  const path = pages?.[key];
+  if (!path) {
+    throw new Error(`prexPages.${key} is not configured for this Cypress environment`);
+  }
+  return path;
+}
+
+export function visitPrexPage(key) {
+  cy.visit(getPrexPage(key));
+}
+
+export function waitForRecsCarousel(minProducts = 1) {
+  cy.get('.recommendations-product-list__content', { timeout: 60000 })
+    .scrollIntoView()
+    .should('be.visible');
+  cy.get('.recommendations-product-list__content img')
+    .should('have.length.at.least', minProducts);
+}
+
+/**
+ * productContext is populated only on PDP pages (storefront-pdp initializer with acdl: true).
+ * Non-PDP pages rely on block config currentsku / currentprice instead.
+ */
+export function assertProductContextAbsent() {
+  cy.window().then((win) => {
+    const ctx = win.adobeDataLayer?.getState?.('productContext');
+    expect(ctx?.sku, 'productContext.sku absent on non-PDP').to.be.undefined;
+  });
+}
+
+export function assertProductContextPresent() {
+  cy.window().then((win) => {
+    const ctx = win.adobeDataLayer?.getState?.('productContext');
+    expect(ctx?.sku, 'productContext.sku is set on PDP').to.be.a('string').and.not.be.empty;
+  });
+}

--- a/cypress/src/tests/b2c/events/recs.spec.js
+++ b/cypress/src/tests/b2c/events/recs.spec.js
@@ -15,7 +15,7 @@ import { expectsEventWithContext } from "../../../assertions";
 const RECS_URL = "/products/play-create-repeat-crewneck/adb388";
 it(
   "api-request-sent, api-response-received, unit-impression-render",
-  { tags: ["@skipSaas", "@skipPaas"] },
+  { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   () => {
     cy.visit(RECS_URL);
     cy.waitForResource("commerce-events-collector.js").then(() => {
@@ -50,7 +50,7 @@ it(
   },
 );
 // Skipping until events are updated with ticket https://jira.corp.adobe.com/browse/COMOPT-421
-it("recs-unit-view", { tags: ["@skipSaas", "@skipPaas"] }, () => {
+it("recs-unit-view", { tags: ["@skipSaas", "@skipPaas", "@skipAco"] }, () => {
   cy.viewport(1440, 600);
   cy.visit(RECS_URL);
   cy.waitForResource("commerce-events-collector.js").then(() => {
@@ -90,7 +90,7 @@ it("recs-unit-view", { tags: ["@skipSaas", "@skipPaas"] }, () => {
   });
 });
 // Skipping until events are updated with ticket https://jira.corp.adobe.com/browse/COMOPT-421
-it("recs-item-click", { tags: ["@skipSaas", "@skipPaas"] }, () => {
+it("recs-item-click", { tags: ["@skipSaas", "@skipPaas", "@skipAco"] }, () => {
   cy.visit(RECS_URL);
   cy.waitForResource("commerce-events-collector.js").then(() => {
     cy.window().then((win) => {
@@ -130,7 +130,7 @@ it("recs-item-click", { tags: ["@skipSaas", "@skipPaas"] }, () => {
   });
 });
 // Skipping until events are updated with ticket https://jira.corp.adobe.com/browse/COMOPT-421
-it("reqs-item-add-to-cart", { tags: ["@skipSaas", "@skipPaas"] }, () => {
+it("reqs-item-add-to-cart", { tags: ["@skipSaas", "@skipPaas", "@skipAco"] }, () => {
   cy.visit(RECS_URL);
   cy.waitForResource("commerce-events-collector.js").then(() => {
     cy.window().then((win) => {

--- a/cypress/src/tests/b2c/verifyRecsContextMatrix.spec.js
+++ b/cypress/src/tests/b2c/verifyRecsContextMatrix.spec.js
@@ -1,0 +1,152 @@
+import {
+  assertProductContextAbsent,
+  assertProductContextPresent,
+  assertUrlExcludesCurrentProduct,
+  assertUrlExcludesCurrentProductPrice,
+  assertUrlIncludesCurrentProduct,
+  interceptRecsGraphQL,
+  visitPrexPage,
+  waitForRecsCarousel,
+  waitForRecsGraphQL,
+} from '../../support/recsGraphql';
+
+/**
+ * GraphQL contract tests for the product-recommendations block → dropin → backend wiring.
+ *
+ * Filter operator math (STATIC range, GT_CURRENT, DYNAMIC, PERCENTAGE) and rec unit types
+ * are covered by Cell integration tests and Studio Playwright — not duplicated here.
+ * This file proves the storefront passes (or omits) currentProduct correctly per environment.
+ *
+ * productContext anchor: only PDP sets it today (scripts/initializers/pdp.js → acdl: true).
+ * Cart/search/category use shoppingCartContext / pageContext — not productContext.
+ */
+
+describe('PREX context matrix — ACO dynamic price passthrough', () => {
+  beforeEach(() => {
+    interceptRecsGraphQL();
+  });
+
+  it('PDP with recid only: ACDL productContext drives currentProduct with price', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('pdpAcdlOnly');
+    assertProductContextPresent();
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlIncludesCurrentProduct(request.url, { requirePrice: true });
+    });
+  });
+
+  it('PLP with currentsku + currentprice in block config: currentProduct with price', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('plpBlockSkuAndPrice');
+    assertProductContextAbsent();
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlIncludesCurrentProduct(request.url, { requirePrice: true });
+    });
+  });
+
+  it('PDP with block currentsku only: must not send ACDL price (#1272 guard)', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('pdpBlockSkuNoPrice');
+    assertProductContextPresent();
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProductPrice(request.url);
+    });
+  });
+});
+
+describe('PREX context matrix — static / MLT anchor (no price in GraphQL)', () => {
+  beforeEach(() => {
+    interceptRecsGraphQL();
+  });
+
+  it('PLP with currentsku only: no currentProduct price (PaaS)', {
+    tags: ['@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('plpStaticSkuOnly');
+    assertProductContextAbsent();
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProduct(request.url);
+    });
+  });
+
+  it('PLP with currentsku only: no currentProduct price (ACCS)', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('plpStaticSkuOnly');
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProduct(request.url);
+    });
+  });
+
+  it('PLP with currentsku only: no currentProduct price (ACO static unit)', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('plpStaticSkuOnly');
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProduct(request.url);
+    });
+  });
+});
+
+describe('PREX context matrix — non-ACO must omit currentProduct price', () => {
+  beforeEach(() => {
+    interceptRecsGraphQL();
+  });
+
+  it('PDP with recid only: no currentProduct in GraphQL (PaaS)', {
+    tags: ['@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('pdpAcdlOnly');
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProduct(request.url);
+    });
+  });
+
+  it('PDP with recid only: no currentProduct in GraphQL (ACCS)', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('pdpAcdlOnly');
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProduct(request.url);
+    });
+  });
+});
+
+describe('PREX context matrix — non-PDP pages use block config, not ACDL productContext', () => {
+  beforeEach(() => {
+    interceptRecsGraphQL();
+  });
+
+  it('cart page rec block: anchor from block config, not productContext (ACO)', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('cartRecsBlock');
+    assertProductContextAbsent();
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlIncludesCurrentProduct(request.url, { requirePrice: true });
+    });
+  });
+
+  it('cart page rec block: no currentProduct price on PaaS', {
+    tags: ['@skipPaas', '@skipSaas', '@skipAco'],
+  }, () => {
+    visitPrexPage('cartRecsBlock');
+    assertProductContextAbsent();
+    waitForRecsCarousel();
+    waitForRecsGraphQL().then(({ request }) => {
+      assertUrlExcludesCurrentProduct(request.url);
+    });
+  });
+});

--- a/cypress/src/tests/b2c/verifyRecsDisplay.spec.js
+++ b/cypress/src/tests/b2c/verifyRecsDisplay.spec.js
@@ -1,25 +1,47 @@
-import {
-    assertImageListDisplay
-} from "../../assertions";
+import { assertImageListDisplay } from '../../assertions';
+import { getPrexPage, visitPrexPage } from '../../support/recsGraphql';
 
-describe("Verify Product Recommendation dropin display", { tags: "@skipSaas" }, () => {
-    it("Verify recs dropin loads on PLP", () => {
-        //Navaigate to draft page 
-        cy.visit("/drafts/tests/apparel");
+describe('Verify Product Recommendation dropin display', () => {
+  it('loads rec carousel on tenant-specific PLP draft', { tags: ['@skipSaas', '@skipAco'] }, () => {
+    visitPrexPage('displayPlp');
 
-        cy.get('.recommendations-product-list__content').scrollIntoView();
-        assertImageListDisplay('.recommendations-product-list__content', 3);
-        cy.get('.recommendations-carousel__content').scrollTo('right');
-        cy.get('[aria-label="Product 4 of 5"]').should('be.visible');
-        cy.get('[aria-label="Product 5 of 5"]').should('be.visible');
-        cy.get('[aria-label="Product 4 of 5"]').click();
+    cy.get('.recommendations-product-list__content').scrollIntoView();
+    assertImageListDisplay('.recommendations-product-list__content', 3);
+    cy.get('.recommendations-carousel__content').scrollTo('right');
+    cy.get('[aria-label="Product 4 of 5"]').should('be.visible');
+    cy.get('[aria-label="Product 5 of 5"]').should('be.visible');
+    cy.get('[aria-label="Product 4 of 5"]').click();
 
-        // Verify navigation to product page
-        cy.url().should("include", "/products/");
+    cy.url().should('include', '/products/');
+    cy.get('.product-details').should('be.visible');
+  });
 
-        // Verify product page elements are loaded
-        cy.get(".product-details")
-            .should("be.visible");
-    });
+  it('loads rec carousel on tenant-specific PDP draft', { tags: ['@skipSaas', '@skipAco'] }, () => {
+    visitPrexPage('displayPdp');
+
+    cy.get('.recommendations-product-list__content').scrollIntoView();
+    assertImageListDisplay('.recommendations-product-list__content', 3);
+  });
 });
 
+describe('Verify Product Recommendation dropin display — ACCS PLP', () => {
+  it('loads rec carousel on ACCS PLP draft', { tags: ['@skipPaas', '@skipAco'] }, () => {
+    cy.visit(getPrexPage('displayPlp'));
+    cy.get('.recommendations-product-list__content', { timeout: 60000 })
+      .scrollIntoView()
+      .should('be.visible');
+    assertImageListDisplay('.recommendations-product-list__content', 1);
+  });
+});
+
+describe('Verify Product Recommendation dropin display — ACO', () => {
+  it('loads rec carousel on ACO PLP draft', { tags: ['@skipPaas', '@skipSaas', '@skipAco'] }, () => {
+    visitPrexPage('displayPlp');
+    assertImageListDisplay('.recommendations-product-list__content', 1);
+  });
+
+  it('loads rec carousel on ACO PDP draft', { tags: ['@skipPaas', '@skipSaas', '@skipAco'] }, () => {
+    visitPrexPage('displayPdp');
+    assertImageListDisplay('.recommendations-product-list__content', 1);
+  });
+});


### PR DESCRIPTION
Add PREX Cypress E2E infrastructure for COMOPT-2042 storefront wiring validation across PaaS, ACCS, and ACO configs. Specs prove block → dropin → GraphQL request shape only; filter operator coverage remains in Cell IT and Studio Playwright.

[COMOPT-2042](https://jira.corp.adobe.com/browse/COMOPT-2042)

**Changes:**
- Add `verifyRecsContextMatrix.spec.js` — GraphQL wiring (`currentProduct` passthrough, static PLP anchor, #1272 guard, cart block-config path)
- Refactor `verifyRecsDisplay.spec.js` to use tenant-specific `prexPages` from `prexPages.config.js`
- Add `cypress.aco.config.js`, `recsGraphql.js`, `index.aco.js`, and `run-e2e-tests-aco.yaml` (B2C ACO CI)
- Wire `prexPages` into PaaS/ACCS/ACO configs; add `@skipAco` grep support and PREX docs in `cypress/README.md`

**Related PR:** #1271 (dropin `currentProduct` wiring on `b2b-integration`)

ACCS/ACO PREX scenarios are tagged `@skipSaas` / `@skipAco` until matching da.live drafts and tenant-scoped recIds exist.

Test URLs:
- Before: https://b2b-integration--aem-boilerplate-commerce--hlxsites.aem.live/drafts/tests/apparel
- After: https://COMOPT-2042-recs-e2e--aem-boilerplate-commerce--hlxsites.aem.live/drafts/tests/apparel