### PR TITLE
Ability to change the layout of a PDP (modifying product-details block)

### DIFF
--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -38,6 +38,21 @@ import { IMAGES_SIZES } from '../../scripts/initializers/pdp.js';
 import '../../scripts/initializers/cart.js';
 import '../../scripts/initializers/wishlist.js';
 
+// AEM
+import { readBlockConfig } from '../../scripts/aem.js';
+
+// Layout templates
+import { TEMPLATES } from './templates/index.js';
+
+function loadTemplateStyles(href) {
+  if (!href) return;
+  if (document.head.querySelector(`link[rel="stylesheet"][href="${href}"]`)) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  document.head.appendChild(link);
+}
+
 /**
  * Checks if the page has prerendered product JSON-LD data
  * @returns {boolean} True if product JSON-LD exists and contains @type=Product
@@ -82,6 +97,9 @@ function formatNumericAttributeValue(value) {
 }
 
 export default async function decorate(block) {
+  const config = readBlockConfig(block);
+  const template = config.template?.toString().trim().toLowerCase() || null;
+
   const eventProduct = events.lastPayload('pdp/data') ?? null;
   // bug: the pdp sends an object with event data even if product is not found.
   const product = eventProduct?.sku ? eventProduct : null;
@@ -126,6 +144,9 @@ export default async function decorate(block) {
   `);
 
   const $alert = fragment.querySelector('.product-details__alert');
+  const $wrapper = fragment.querySelector('.product-details__wrapper');
+  const $leftColumn = fragment.querySelector('.product-details__left-column');
+  const $rightColumn = fragment.querySelector('.product-details__right-column');
   const $gallery = fragment.querySelector('.product-details__gallery');
   const $header = fragment.querySelector('.product-details__header');
   const $price = fragment.querySelector('.product-details__price');
@@ -140,6 +161,33 @@ export default async function decorate(block) {
   const $attributes = fragment.querySelector('.product-details__attributes');
 
   block.replaceChildren(fragment);
+
+  if (template && TEMPLATES[template]) {
+    const { apply, styles } = TEMPLATES[template];
+    loadTemplateStyles(styles);
+    await apply({
+      block,
+      template,
+      wrapper: $wrapper,
+      leftColumn: $leftColumn,
+      rightColumn: $rightColumn,
+      elements: {
+        alert: $alert,
+        gallery: $gallery,
+        galleryMobile: $galleryMobile,
+        header: $header,
+        price: $price,
+        shortDescription: $shortDescription,
+        giftCardOptions: $giftCardOptions,
+        options: $options,
+        quantity: $quantity,
+        addToCart: $addToCart,
+        wishlistToggle: $wishlistToggleBtn,
+        description: $description,
+        attributes: $attributes,
+      },
+    });
+  }
 
   const gallerySlots = {
     CarouselThumbnail: (ctx) => {

--- a/blocks/product-details/templates/editorial/editorial-template.css
+++ b/blocks/product-details/templates/editorial/editorial-template.css
@@ -1,0 +1,14 @@
+.pdp-editorial-header-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.pdp-editorial-header-row .product-details__header {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.pdp-editorial-header-row .product-details__buttons__add-to-wishlist {
+  flex: 0 0 auto;
+}

--- a/blocks/product-details/templates/editorial/editorial-template.js
+++ b/blocks/product-details/templates/editorial/editorial-template.js
@@ -1,0 +1,11 @@
+export default async function editorial(context) {
+  const { elements } = context;
+
+  elements.header.after(elements.attributes);
+  elements.header.after(elements.description);
+
+  const headerRow = document.createElement('div');
+  headerRow.className = 'pdp-editorial-header-row';
+  elements.header.before(headerRow);
+  headerRow.append(elements.wishlistToggle, elements.header);
+}

--- a/blocks/product-details/templates/index.js
+++ b/blocks/product-details/templates/index.js
@@ -1,0 +1,15 @@
+import mirrored from './mirrored/mirrored-template.js';
+import editorial from './editorial/editorial-template.js';
+
+const basePath = new URL('.', import.meta.url).pathname;
+
+export const TEMPLATES = {
+  mirrored: {
+    apply: mirrored,
+    styles: `${basePath}mirrored/mirrored-template.css`,
+  },
+  editorial: {
+    apply: editorial,
+    styles: `${basePath}editorial/editorial-template.css`,
+  },
+};

--- a/blocks/product-details/templates/mirrored/mirrored-template.css
+++ b/blocks/product-details/templates/mirrored/mirrored-template.css
@@ -1,0 +1,14 @@
+.pdp-mirrored .product-details__left-column {
+    grid-column: 8 / span 5;
+    grid-row: 1;
+}
+
+.pdp-mirrored .product-details__right-column {
+    grid-column: 1 / span 6;
+    grid-row: 1;
+}
+
+.pdp-mirrored .product-details__configuration {
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/blocks/product-details/templates/mirrored/mirrored-template.js
+++ b/blocks/product-details/templates/mirrored/mirrored-template.js
@@ -1,0 +1,5 @@
+export default async function mirrored(context) {
+  const { wrapper } = context;
+
+  wrapper.classList.add('pdp-mirrored');
+}


### PR DESCRIPTION
## What
Adds layout customization to the `product-details` block via a small in-block template registry. The block reads a `template` config and dispatches to a layout function defined alongside the block.

Ticket: https://jira.corp.adobe.com/browse/USF-4109
Wiki: https://wiki.corp.adobe.com/x/2hs_6Q

Related to https://github.com/hlxsites/aem-boilerplate-commerce/pull/1290.

## How
- New `template` config property on the block selects which layout to apply.
- After the static fragment is mounted (and before drop-ins render), the block looks up `TEMPLATES[template]` and calls `apply(context)` with references to the wrapper, columns and key DOM nodes (gallery, header, options, wishlist toggle, etc.) — the same context shape as the extension hook.
- Each template lives in `blocks/product-details/templates/<name>/` as a plain `async (context) => void` function plus a sibling CSS file. The block lazily injects a deduped `<link rel="stylesheet">` for only the active template.

## Included example templates
- **mirrored** — swaps the buy-box and gallery columns on desktop.
- **editorial** — reorders description/attributes and places the wishlist toggle next to the header.

<img width="624" height="377" alt="image" src="https://github.com/user-attachments/assets/4e41f29a-b18d-4061-9c1a-ed6d45d26dfa" />

<img width="624" height="427" alt="image" src="https://github.com/user-attachments/assets/e2402f06-1e48-494c-a0cc-40432822bb21" />

## Notes
- If `template` is missing or unknown, no custom layout is applied and the block renders with its default markup — identical fallback behavior to the extension solution.
- Adding a new template = drop a `<name>/<name>-template.{js,css}` pair under `templates/` and register it in `templates/index.js`.

## How to test
1. Open a PDP and confirm the default layout still renders unchanged.
2. Set `template: mirrored` in the block config → buy-box on the left, gallery on the right (desktop).
3. Set `template: editorial` → description and attributes appear under the header, and the wishlist toggle sits next to the title.

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://usf-4109b--aem-boilerplate-commerce--hlxsites.aem.page/
