### PR TITLE
breaking: uses query param for sku instead of folder mapped path

### DIFF
--- a/blocks/commerce-cart/commerce-cart.js
+++ b/blocks/commerce-cart/commerce-cart.js
@@ -168,7 +168,7 @@ export default async function decorate(block) {
   }
 
   // Render Containers
-  const createProductLink = (product) => getProductLink(product.url.urlKey, product.topLevelSku);
+  const createProductLink = (product) => getProductLink(product.topLevelSku);
   await Promise.all([
     // Cart List
     provider.render(CartSummaryList, {

--- a/blocks/commerce-mini-cart/commerce-mini-cart.js
+++ b/blocks/commerce-mini-cart/commerce-mini-cart.js
@@ -160,7 +160,7 @@ export default async function decorate(block) {
   block.innerHTML = '';
 
   // Render MiniCart
-  const createProductLink = (product) => getProductLink(product.url.urlKey, product.topLevelSku);
+  const createProductLink = (product) => getProductLink(product.topLevelSku);
   await provider.render(MiniCart, {
     routeEmptyCartCTA: startShoppingURL ? () => rootLink(startShoppingURL) : undefined,
     routeCart: cartURL ? () => rootLink(cartURL) : undefined,

--- a/blocks/commerce-order-product-list/commerce-order-product-list.js
+++ b/blocks/commerce-order-product-list/commerce-order-product-list.js
@@ -13,11 +13,11 @@ export default async function decorate(block) {
     if (!productData) {
       return rootLink('#');
     }
-    const { product, productUrlKey } = productData;
-    if (!product || !productUrlKey || !product.sku) {
+    const { product } = productData;
+    if (!product || !product.sku) {
       return rootLink('#');
     }
-    return getProductLink(productUrlKey, product.sku);
+    return getProductLink(product.sku);
   };
   await orderRenderer.render(OrderProductList, {
     slots: {

--- a/blocks/commerce-order-returns/commerce-order-returns.js
+++ b/blocks/commerce-order-returns/commerce-order-returns.js
@@ -49,6 +49,6 @@ export default async function decorate(block) {
 
       return rootLink(`${returnDetailsPath}?orderRef=${encodedOrderRef}&returnRef=${returnNumber}`);
     },
-    routeProductDetails: (productData) => (productData?.product ? getProductLink(productData.product.urlKey, productData.product.sku) : rootLink('#')),
+    routeProductDetails: (productData) => (productData?.product ? getProductLink(productData.product.sku) : rootLink('#')),
   })(block);
 }

--- a/blocks/commerce-orders-list/commerce-orders-list.js
+++ b/blocks/commerce-orders-list/commerce-orders-list.js
@@ -25,9 +25,9 @@ export default async function decorate(block) {
     }
 
     // Product exists in catalog, validate it has the required fields
-    const { urlKey, topLevelSku } = productData;
-    if (urlKey && topLevelSku) {
-      return getProductLink(urlKey, topLevelSku);
+    const { topLevelSku } = productData;
+    if (topLevelSku) {
+      return getProductLink(topLevelSku);
     }
     return rootLink('#');
   };

--- a/blocks/commerce-returns-list/commerce-returns-list.js
+++ b/blocks/commerce-returns-list/commerce-returns-list.js
@@ -49,7 +49,7 @@ export default async function decorate(block) {
       routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
       routeOrderDetails: ({ orderNumber }) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
       routeReturnsList: () => rootLink(CUSTOMER_RETURNS_PATH),
-      routeProductDetails: (productData) => (productData?.product ? getProductLink(productData.product.urlKey, productData.product.sku) : rootLink('#')),
+      routeProductDetails: (productData) => (productData?.product ? getProductLink(productData.product.sku) : rootLink('#')),
     })(block);
   }
 }

--- a/blocks/commerce-shipping-status/commerce-shipping-status.js
+++ b/blocks/commerce-shipping-status/commerce-shipping-status.js
@@ -30,10 +30,10 @@ export default async function decorate(block) {
     },
     routeProductDetails: (data) => {
       if (data?.orderItem) {
-        return getProductLink(data?.orderItem?.productUrlKey, data?.orderItem?.product?.sku);
+        return getProductLink(data?.orderItem?.product?.sku);
       }
       if (data?.product) {
-        return getProductLink(data?.product?.urlKey, data?.product?.sku);
+        return getProductLink(data?.product?.sku);
       }
       return '#';
     },

--- a/blocks/commerce-wishlist/commerce-wishlist.js
+++ b/blocks/commerce-wishlist/commerce-wishlist.js
@@ -76,7 +76,7 @@ export default async function decorate(block) {
   await wishlistRenderer.render(Wishlist, {
     routeEmptyWishlistCTA: startShoppingURL ? () => rootLink(startShoppingURL) : undefined,
     moveProdToCart: cartApi.addProductsToCart,
-    routeProdDetailPage: (product) => getProductLink(product.urlKey, product.sku),
+    routeProdDetailPage: (product) => getProductLink(product.sku),
     onLoginClick: showAuthModal,
     getProductData: pdpApi.getProductData,
     getRefinedProduct: pdpApi.getRefinedProduct,

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -386,7 +386,7 @@ export default async function decorate(block) {
         render.render(SearchResults, {
           skeletonCount: pageSize,
           scope: 'popover',
-          routeProduct: ({ urlKey, sku }) => getProductLink(urlKey, sku),
+          routeProduct: ({ sku }) => getProductLink(sku),
           onSearchResult: (results) => {
             searchResult.style.display = results.length > 0 ? 'block' : 'none';
           },
@@ -394,7 +394,7 @@ export default async function decorate(block) {
             ProductImage: (ctx) => {
               const { product, defaultImageProps } = ctx;
               const anchorWrapper = document.createElement('a');
-              anchorWrapper.href = getProductLink(product.urlKey, product.sku);
+              anchorWrapper.href = getProductLink(product.sku);
 
               tryRenderAemAssetsImage(ctx, {
                 alias: product.sku,

--- a/blocks/header/renderAuthCombine.js
+++ b/blocks/header/renderAuthCombine.js
@@ -271,7 +271,7 @@ const renderAuthCombine = (navSections, toggleMenu) => {
             'afterend',
             `<ul class="popupMenuUrlList">
               <li><a href="${rootLink(CUSTOMER_ACCOUNT_PATH)}">My Account</a></li>
-              <li><a href="${getProductLink('hollister-backyard-sweatshirt', 'MH05')}">Product page</a></li>
+              <li><a href="${getProductLink('MH05')}">Product page</a></li>
               <li><button class="logoutButton">Logout</button></li>
             </ul>`,
           );

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -424,7 +424,6 @@ async function setJsonLdProduct(product) {
     inStock,
     description,
     sku,
-    urlKey,
     price,
     priceRange,
     images,
@@ -473,9 +472,9 @@ async function setJsonLdProduct(product) {
       '@type': 'Brand',
       name: brand?.value,
     },
-    url: new URL(getProductLink(urlKey, sku), window.location),
+    url: new URL(getProductLink(sku), window.location),
     sku,
-    '@id': new URL(getProductLink(urlKey, sku), window.location),
+    '@id': new URL(getProductLink(sku), window.location),
   };
 
   if (variants.length > 1) {

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -107,7 +107,7 @@ export default async function decorate(block) {
       UI.render(Button, {
         children: labels.Global?.AddProductToCart,
         icon: Icon({ source: 'Cart' }),
-        href: getProductLink(product.urlKey, product.sku),
+        href: getProductLink(product.sku),
         variant: 'primary',
       })(button);
       return button;
@@ -149,12 +149,12 @@ export default async function decorate(block) {
     provider.render(Facets, {})($facets),
     // Product List
     provider.render(SearchResults, {
-      routeProduct: (product) => getProductLink(product.urlKey, product.sku),
+      routeProduct: (product) => getProductLink(product.sku),
       slots: {
         ProductImage: (ctx) => {
           const { product, defaultImageProps } = ctx;
           const anchorWrapper = document.createElement('a');
-          anchorWrapper.href = getProductLink(product.urlKey, product.sku);
+          anchorWrapper.href = getProductLink(product.sku);
 
           tryRenderAemAssetsImage(ctx, {
             alias: product.sku,

--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -172,7 +172,7 @@ export default async function decorate(block) {
       container.innerHTML = '';
     }
 
-    const createProductLink = (item) => getProductLink(item.urlKey, item.sku);
+    const createProductLink = (item) => getProductLink(item.sku);
 
     // Get product view history
     context.userViewHistory = getProductViewHistory();

--- a/cypress/cypress.aco.config.js
+++ b/cypress/cypress.aco.config.js
@@ -23,7 +23,7 @@ module.exports = defineConfig({
     catalogEnvironmentId: 'f38a0de0-764b-41fa-bd2c-5bc2f3c7b39a',
     giftCardA: '02R7NXP5HJI5',
     productUrlWithOptions:
-      '/products/cypress-configurable-product-latest/cypress456?optionsUIDs=Y29uZmlndXJhYmxlLzkzLzIzMA==',
+      '/products/default?sku=CYPRESS456&optionsUIDs=Y29uZmlndXJhYmxlLzkzLzIzMA==',
     stateShippingId: 'TX,57',
     stateBillingId: 'NY,43',
     productImageName: 'ADB150_1.jpg',

--- a/cypress/cypress.paas.config.js
+++ b/cypress/cypress.paas.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
     COMMERCE_ADMIN_PASSWORD: process.env.CYPRESS_COMMERCE_ADMIN_PASSWORD,
     giftCardA: "00GO12SK6WF3",
     productUrlWithOptions:
-      "/products/default?sku=cypress456&optionsUIDs=Y29uZmlndXJhYmxlLzI3OS8zOQ%3D%3D",
+      "/products/default?sku=CYPRESS456&optionsUIDs=Y29uZmlndXJhYmxlLzI3OS8zOQ%3D%3D",
     stateShippingId: "TX,171",
     stateBillingId: "NY,129",
     productImageName: "/ADB150.jpg",

--- a/cypress/cypress.paas.config.js
+++ b/cypress/cypress.paas.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
     COMMERCE_ADMIN_PASSWORD: process.env.CYPRESS_COMMERCE_ADMIN_PASSWORD,
     giftCardA: "00GO12SK6WF3",
     productUrlWithOptions:
-      "/products/cypress-configurable-product-latest/cypress456?optionsUIDs=Y29uZmlndXJhYmxlLzI3OS8zOQ%3D%3D",
+      "/products/default?sku=cypress456&optionsUIDs=Y29uZmlndXJhYmxlLzI3OS8zOQ%3D%3D",
     stateShippingId: "TX,171",
     stateBillingId: "NY,129",
     productImageName: "/ADB150.jpg",

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -21,7 +21,7 @@ module.exports = defineConfig({
     giftCardA:
       process.env.IS_PROD_RELEASE === "true" ? "01J2UN97NBO0" : "00419VQ5C341",
     productUrlWithOptions:
-      "/products/cypress-configurable-product-latest/cypress456?optionsUIDs=Y29uZmlndXJhYmxlLzkzLzEz",
+      "/products/default?sku=cypress456&optionsUIDs=Y29uZmlndXJhYmxlLzkzLzEz",
     stateShippingId: "TX,57",
     stateBillingId: "NY,43",
     productImageName: "/adb150.jpg",

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -21,7 +21,7 @@ module.exports = defineConfig({
     giftCardA:
       process.env.IS_PROD_RELEASE === "true" ? "01J2UN97NBO0" : "00419VQ5C341",
     productUrlWithOptions:
-      "/products/default?sku=cypress456&optionsUIDs=Y29uZmlndXJhYmxlLzkzLzEz",
+      "/products/default?sku=CYPRESS456&optionsUIDs=Y29uZmlndXJhYmxlLzkzLzEz",
     stateShippingId: "TX,57",
     stateBillingId: "NY,43",
     productImageName: "/adb150.jpg",

--- a/cypress/src/assertions/index.js
+++ b/cypress/src/assertions/index.js
@@ -412,6 +412,15 @@ export const assertOrderCommentItem = (text) => {
     .and('contain.text', text);
 };
 
+export const assertProductLinksUseSkuQueryParam = (selector = fields.productListGrid) => {
+  cy.get(selector)
+    .find("a[href]")
+    .should("have.length.greaterThan", 0)
+    .each(($a) => {
+      expect($a.attr("href")).to.match(/^\/products\/default\?sku=[^&]+/);
+    });
+};
+
 export const assertSearchResults = () => {
   // Check if search results are displayed
   cy.get(fields.productListGrid)

--- a/cypress/src/fixtures/index.js
+++ b/cypress/src/fixtures/index.js
@@ -51,7 +51,7 @@ export const products = {
     urlPathWithOptions: Cypress.env('productUrlWithOptions'),
   },
   virtual: {
-    urlPath: "/products/default?sku=virtual123",
+    urlPath: "/products/default?sku=VIRTUAL123",
     sku: 'VIRTUAL123',
   },
   simple: {

--- a/cypress/src/fixtures/index.js
+++ b/cypress/src/fixtures/index.js
@@ -47,19 +47,19 @@ export const checkMoneyOrder = {
 
 export const products = {
   configurable: {
-    urlPath: "/products/cypress-configurable-product-latest/cypress456",
+    urlPath: "/products/default?sku=cypress456",
     urlPathWithOptions: Cypress.env('productUrlWithOptions'),
   },
   virtual: {
-    urlPath: "/products/virtual-product/virtual123",
+    urlPath: "/products/default?sku=virtual123",
     sku: 'VIRTUAL123',
   },
   simple: {
-    urlPath: "/products/youth-tee/ADB150",
+    urlPath: "/products/default?sku=ADB150",
     sku: 'ADB150',
   },
   virtualGiftCard: {
-    urlPath: "/products/gift-card-virtual/gift-card-virtual",
+    urlPath: "/products/default?sku=gift-card-virtual",
     sku: 'gift-card-virtual',
   }
 };

--- a/cypress/src/fixtures/index.js
+++ b/cypress/src/fixtures/index.js
@@ -47,7 +47,7 @@ export const checkMoneyOrder = {
 
 export const products = {
   configurable: {
-    urlPath: "/products/default?sku=cypress456",
+    urlPath: "/products/default?sku=CYPRESS456",
     urlPathWithOptions: Cypress.env('productUrlWithOptions'),
   },
   virtual: {

--- a/cypress/src/tests/b2c/events/recs.spec.js
+++ b/cypress/src/tests/b2c/events/recs.spec.js
@@ -12,7 +12,7 @@ import { expectsEventWithContext } from "../../../assertions";
  *
  */
 // Skipping until events are updated with ticket https://jira.corp.adobe.com/browse/COMOPT-421
-const RECS_URL = "/products/default?sku=adb388";
+const RECS_URL = "/products/default?sku=ADB388";
 it(
   "api-request-sent, api-response-received, unit-impression-render",
   { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },

--- a/cypress/src/tests/b2c/events/recs.spec.js
+++ b/cypress/src/tests/b2c/events/recs.spec.js
@@ -12,7 +12,7 @@ import { expectsEventWithContext } from "../../../assertions";
  *
  */
 // Skipping until events are updated with ticket https://jira.corp.adobe.com/browse/COMOPT-421
-const RECS_URL = "/products/play-create-repeat-crewneck/adb388";
+const RECS_URL = "/products/default?sku=adb388";
 it(
   "api-request-sent, api-response-received, unit-impression-render",
   { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },

--- a/cypress/src/tests/b2c/verifyAemAssets.spec.js
+++ b/cypress/src/tests/b2c/verifyAemAssets.spec.js
@@ -103,7 +103,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   });
 
   it('[PDP Dropin]: should load and show AEM Assets optimized images', () => {
-    visitWithEagerImages('/products/default?sku=adb102');
+    visitWithEagerImages('/products/default?sku=ADB102');
     const expectedOptions = {
       protocol: 'http://',
       environment: aemAssetsEnvironment,
@@ -138,7 +138,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
       }
     });
 
-    visitWithEagerImages('/products/default?sku=adb119');
+    visitWithEagerImages('/products/default?sku=ADB119');
     waitForAemAssetImages('.pdp-carousel__wrapper ~ div img', (images) => {
       for (const image of images) {
         expectAemAssetsImage(image.src, {
@@ -174,7 +174,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
       height: 300,
     }
 
-    visitWithEagerImages('/products/default?sku=adb102');
+    visitWithEagerImages('/products/default?sku=ADB102');
     cy.wait(3000);
     cy.get('.product-details__buttons__add-to-cart button').click();
 
@@ -345,7 +345,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   });
 
   it('[Checkout Dropin]: should load and show AEM Assets optimized images', () => {
-    visitWithEagerImages('/products/default?sku=adb102');
+    visitWithEagerImages('/products/default?sku=ADB102');
 
     cy.get('.product-details__buttons__add-to-cart button')
       .should('be.visible')
@@ -383,10 +383,10 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   it('[Recommendations Dropin]: should load and show AEM Assets optimized images', () => {
     // Visit products to populate "Recently Viewed" recommendations.
     // Wait a bit to ensure data is collected by Adobe Analytics.
-    visitWithEagerImages('/products/default?sku=adb102');
+    visitWithEagerImages('/products/default?sku=ADB102');
     cy.wait(3000);
 
-    visitWithEagerImages('/products/default?sku=adb119');
+    visitWithEagerImages('/products/default?sku=ADB119');
     cy.wait(3000);
 
     visitWithEagerImages(envConfig.prexDraft);
@@ -417,7 +417,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   });
 
   it('[Wishlist Dropin]: should load and show AEM Assets optimized images', { tags: "@skipSaas" }, () => {
-    visitWithEagerImages('/products/default?sku=adb119');
+    visitWithEagerImages('/products/default?sku=ADB119');
     cy.get('.product-details__buttons__add-to-wishlist button')
       .should('be.visible')
       .click();

--- a/cypress/src/tests/b2c/verifyAemAssets.spec.js
+++ b/cypress/src/tests/b2c/verifyAemAssets.spec.js
@@ -103,7 +103,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   });
 
   it('[PDP Dropin]: should load and show AEM Assets optimized images', () => {
-    visitWithEagerImages('/products/gift-packaging/adb102');
+    visitWithEagerImages('/products/default?sku=adb102');
     const expectedOptions = {
       protocol: 'http://',
       environment: aemAssetsEnvironment,
@@ -138,7 +138,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
       }
     });
 
-    visitWithEagerImages('products/denim-apron/adb119');
+    visitWithEagerImages('/products/default?sku=adb119');
     waitForAemAssetImages('.pdp-carousel__wrapper ~ div img', (images) => {
       for (const image of images) {
         expectAemAssetsImage(image.src, {
@@ -174,7 +174,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
       height: 300,
     }
 
-    visitWithEagerImages('/products/gift-packaging/adb102');
+    visitWithEagerImages('/products/default?sku=adb102');
     cy.wait(3000);
     cy.get('.product-details__buttons__add-to-cart button').click();
 
@@ -345,7 +345,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   });
 
   it('[Checkout Dropin]: should load and show AEM Assets optimized images', () => {
-    visitWithEagerImages('/products/gift-packaging/adb102');
+    visitWithEagerImages('/products/default?sku=adb102');
 
     cy.get('.product-details__buttons__add-to-cart button')
       .should('be.visible')
@@ -383,10 +383,10 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   it('[Recommendations Dropin]: should load and show AEM Assets optimized images', () => {
     // Visit products to populate "Recently Viewed" recommendations.
     // Wait a bit to ensure data is collected by Adobe Analytics.
-    visitWithEagerImages('/products/gift-packaging/adb102');
+    visitWithEagerImages('/products/default?sku=adb102');
     cy.wait(3000);
 
-    visitWithEagerImages('/products/denim-apron/adb119');
+    visitWithEagerImages('/products/default?sku=adb119');
     cy.wait(3000);
 
     visitWithEagerImages(envConfig.prexDraft);
@@ -417,7 +417,7 @@ describe('AEM Assets enabled', { tags: ["@skipSaas", "@skipPaas", "@skipAco"] },
   });
 
   it('[Wishlist Dropin]: should load and show AEM Assets optimized images', { tags: "@skipSaas" }, () => {
-    visitWithEagerImages('/products/denim-apron/adb119');
+    visitWithEagerImages('/products/default?sku=adb119');
     cy.get('.product-details__buttons__add-to-wishlist button')
       .should('be.visible')
       .click();

--- a/cypress/src/tests/b2c/verifyAuthUserCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserCheckout.spec.js
@@ -110,7 +110,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
       '/products/default?sku=cypress456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.cart-mini-cart');
-    cy.visit("/products/default?sku=adb150");
+    cy.visit("/products/default?sku=ADB150");
     // Button can be visible before the product form finishes hydrating;
     // clicking while still disabled registers in the UI but never reaches
     // the cart model (see the same pattern guarded against above).
@@ -133,7 +133,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )(".cart-mini-cart");
     assertTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150",
+      "/products/default?sku=ADB150",
     )(".cart-mini-cart");
     assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
     assertCartSummaryProduct(
@@ -160,7 +160,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )(".commerce-cart-wrapper");
     assertTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150",
+      "/products/default?sku=ADB150",
     )(".commerce-cart-wrapper");
     assertProductImage(Cypress.env("productImageName"))(
       ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyAuthUserCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserCheckout.spec.js
@@ -54,7 +54,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.cart-mini-cart');
     assertTitleHasLink(
       'Configurable product',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.cart-mini-cart');
     editProductOptions("red", "green");
@@ -87,7 +87,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.commerce-cart-wrapper');
     assertTitleHasLink(
       'Configurable product',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     )('.commerce-cart-wrapper');
     cy.visit("/customer/create");
     cy.get(".minicart-wrapper").should("be.visible");
@@ -107,10 +107,10 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.cart-mini-cart');
     assertTitleHasLink(
       'Configurable product',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.cart-mini-cart');
-    cy.visit("/products/youth-tee/adb150");
+    cy.visit("/products/default?sku=adb150");
     // Button can be visible before the product form finishes hydrating;
     // clicking while still disabled registers in the UI but never reaches
     // the cart model (see the same pattern guarded against above).
@@ -133,7 +133,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )(".cart-mini-cart");
     assertTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150",
+      "/products/default?sku=adb150",
     )(".cart-mini-cart");
     assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
     assertCartSummaryProduct(
@@ -146,7 +146,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.cart-mini-cart');
     assertTitleHasLink(
       'Configurable product',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageName'))('.cart-mini-cart');
     cy.visit('/cart');
@@ -160,7 +160,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )(".commerce-cart-wrapper");
     assertTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150",
+      "/products/default?sku=adb150",
     )(".commerce-cart-wrapper");
     assertProductImage(Cypress.env("productImageName"))(
       ".commerce-cart-wrapper",
@@ -176,7 +176,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.commerce-cart-wrapper');
     assertTitleHasLink(
       'Configurable product',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     )('.commerce-cart-wrapper');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.commerce-cart-wrapper');
     cy.contains('Estimated Shipping').should('be.visible');

--- a/cypress/src/tests/b2c/verifyAuthUserCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserCheckout.spec.js
@@ -54,7 +54,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.cart-mini-cart');
     assertTitleHasLink(
       'Configurable product',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.cart-mini-cart');
     editProductOptions("red", "green");
@@ -87,7 +87,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.commerce-cart-wrapper');
     assertTitleHasLink(
       'Configurable product',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     )('.commerce-cart-wrapper');
     cy.visit("/customer/create");
     cy.get(".minicart-wrapper").should("be.visible");
@@ -107,7 +107,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.cart-mini-cart');
     assertTitleHasLink(
       'Configurable product',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.cart-mini-cart');
     cy.visit("/products/default?sku=ADB150");
@@ -146,7 +146,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.cart-mini-cart');
     assertTitleHasLink(
       'Configurable product',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageName'))('.cart-mini-cart');
     cy.visit('/cart');
@@ -176,7 +176,7 @@ describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
     )('.commerce-cart-wrapper');
     assertTitleHasLink(
       'Configurable product',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     )('.commerce-cart-wrapper');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.commerce-cart-wrapper');
     cy.contains('Estimated Shipping').should('be.visible');

--- a/cypress/src/tests/b2c/verifyAuthUserCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserCheckoutWithoutPaymentServices.spec.js
@@ -55,7 +55,7 @@ describe(
       )(".cart-mini-cart");
       assertTitleHasLink(
         "Configurable product",
-        "/products/cypress-configurable-product-latest/cypress456",
+        "/products/default?sku=CYPRESS456",
       )(".cart-mini-cart");
       assertProductImage(Cypress.env("productImageNameConfigurable"))(
         ".cart-mini-cart",
@@ -94,7 +94,7 @@ describe(
       )(".commerce-cart-wrapper");
       assertTitleHasLink(
         "Configurable product",
-        "/products/cypress-configurable-product-latest/cypress456",
+        "/products/default?sku=CYPRESS456",
       )(".commerce-cart-wrapper");
       cy.visit("/customer/create");
       cy.get(".minicart-wrapper").should("be.visible");
@@ -114,12 +114,12 @@ describe(
       )(".cart-mini-cart");
       assertTitleHasLink(
         "Configurable product",
-        "/products/cypress-configurable-product-latest/cypress456",
+        "/products/default?sku=CYPRESS456",
       )(".cart-mini-cart");
       assertProductImage(Cypress.env("productImageNameConfigurable"))(
         ".cart-mini-cart",
       );
-      cy.visit("/products/youth-tee/adb150");
+      cy.visit("/products/default?sku=ADB150");
       // Button can be visible before the product form finishes hydrating;
       // clicking while still disabled registers in the UI but never reaches
       // the cart model (see the same pattern guarded against above).
@@ -142,7 +142,7 @@ describe(
       )(".cart-mini-cart");
       assertTitleHasLink(
         "Youth tee",
-        "/products/youth-tee/adb150",
+        "/products/default?sku=ADB150",
       )(".cart-mini-cart");
       assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
       assertCartSummaryProduct(
@@ -155,7 +155,7 @@ describe(
       )(".cart-mini-cart");
       assertTitleHasLink(
         "Configurable product",
-        "/products/cypress-configurable-product-latest/cypress456",
+        "/products/default?sku=CYPRESS456",
       )(".cart-mini-cart");
       assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
       cy.visit("/cart");
@@ -169,7 +169,7 @@ describe(
       )(".commerce-cart-wrapper");
       assertTitleHasLink(
         "Youth tee",
-        "/products/youth-tee/adb150",
+        "/products/default?sku=ADB150",
       )(".commerce-cart-wrapper");
       assertProductImage(Cypress.env("productImageName"))(
         ".commerce-cart-wrapper",
@@ -185,7 +185,7 @@ describe(
       )(".commerce-cart-wrapper");
       assertTitleHasLink(
         "Configurable product",
-        "/products/cypress-configurable-product-latest/cypress456",
+        "/products/default?sku=CYPRESS456",
       )(".commerce-cart-wrapper");
       assertProductImage(Cypress.env("productImageNameConfigurable"))(
         ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyAuthUserWishlistFeature.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserWishlistFeature.spec.js
@@ -60,7 +60,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
 
     assertWishlistTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150"
+      "/products/default?sku=adb150"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env("productImageName"))(".commerce-wishlist-wrapper");
@@ -164,7 +164,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/cypress-configurable-product-latest-red/cypress456"
+      "/products/default?sku=cypress456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productWithOptionImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -272,7 +272,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/cypress-configurable-product-latest/cypress456"
+      "/products/default?sku=cypress456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -284,7 +284,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
     assertProductDetailPage(
       'Configurable product',
       'CYPRESS456',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     );
 
     // Verify item is back in wishlist

--- a/cypress/src/tests/b2c/verifyAuthUserWishlistFeature.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserWishlistFeature.spec.js
@@ -60,7 +60,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
 
     assertWishlistTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150"
+      "/products/default?sku=ADB150"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env("productImageName"))(".commerce-wishlist-wrapper");

--- a/cypress/src/tests/b2c/verifyAuthUserWishlistFeature.spec.js
+++ b/cypress/src/tests/b2c/verifyAuthUserWishlistFeature.spec.js
@@ -164,7 +164,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/default?sku=cypress456"
+      "/products/default?sku=CYPRESS456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productWithOptionImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -272,7 +272,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/default?sku=cypress456"
+      "/products/default?sku=CYPRESS456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -284,7 +284,7 @@ describe("Verify auth user can manage products across wishlist and cart", () => 
     assertProductDetailPage(
       'Configurable product',
       'CYPRESS456',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     );
 
     // Verify item is back in wishlist

--- a/cypress/src/tests/b2c/verifyCartUndo.spec.js
+++ b/cypress/src/tests/b2c/verifyCartUndo.spec.js
@@ -55,7 +55,7 @@ describe("Verify Cart undo feature", () => {
         )(".commerce-cart-wrapper");
         assertTitleHasLink(
             "Youth tee",
-            "/products/youth-tee/adb150",
+            "/products/default?sku=adb150",
         )(".commerce-cart-wrapper");
         assertProductImage(Cypress.env("productImageName"))(
             ".commerce-cart-wrapper",
@@ -80,7 +80,7 @@ describe("Verify Cart undo feature", () => {
         )(".commerce-cart-wrapper");
         assertTitleHasLink(
             "Youth tee",
-            "/products/youth-tee/adb150",
+            "/products/default?sku=adb150",
         )(".commerce-cart-wrapper");
         assertProductImage(Cypress.env("productImageName"))(
             ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyCartUndo.spec.js
+++ b/cypress/src/tests/b2c/verifyCartUndo.spec.js
@@ -55,7 +55,7 @@ describe("Verify Cart undo feature", () => {
         )(".commerce-cart-wrapper");
         assertTitleHasLink(
             "Youth tee",
-            "/products/default?sku=adb150",
+            "/products/default?sku=ADB150",
         )(".commerce-cart-wrapper");
         assertProductImage(Cypress.env("productImageName"))(
             ".commerce-cart-wrapper",
@@ -80,7 +80,7 @@ describe("Verify Cart undo feature", () => {
         )(".commerce-cart-wrapper");
         assertTitleHasLink(
             "Youth tee",
-            "/products/default?sku=adb150",
+            "/products/default?sku=ADB150",
         )(".commerce-cart-wrapper");
         assertProductImage(Cypress.env("productImageName"))(
             ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyGuestUserCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserCheckout.spec.js
@@ -57,7 +57,7 @@ describe("Verify guest user can place order", { tags: "@skipSaasProd" }, () => {
     )(".cart-mini-cart");
     assertTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150",
+      "/products/default?sku=ADB150",
     )(".cart-mini-cart");
     assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
     cy.contains("View Cart").click();
@@ -71,7 +71,7 @@ describe("Verify guest user can place order", { tags: "@skipSaasProd" }, () => {
     )(".commerce-cart-wrapper");
     assertTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150",
+      "/products/default?sku=ADB150",
     )(".commerce-cart-wrapper");
     assertProductImage(Cypress.env("productImageName"))(
       ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyGuestUserCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserCheckout.spec.js
@@ -57,7 +57,7 @@ describe("Verify guest user can place order", { tags: "@skipSaasProd" }, () => {
     )(".cart-mini-cart");
     assertTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150",
+      "/products/default?sku=adb150",
     )(".cart-mini-cart");
     assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
     cy.contains("View Cart").click();
@@ -71,7 +71,7 @@ describe("Verify guest user can place order", { tags: "@skipSaasProd" }, () => {
     )(".commerce-cart-wrapper");
     assertTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150",
+      "/products/default?sku=adb150",
     )(".commerce-cart-wrapper");
     assertProductImage(Cypress.env("productImageName"))(
       ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyGuestUserCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserCheckoutWithoutPaymentServices.spec.js
@@ -58,7 +58,7 @@ describe(
       )(".cart-mini-cart");
       assertTitleHasLink(
         "Youth tee",
-        "/products/youth-tee/adb150",
+        "/products/default?sku=ADB150",
       )(".cart-mini-cart");
       assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
       cy.contains("View Cart").click();
@@ -72,7 +72,7 @@ describe(
       )(".commerce-cart-wrapper");
       assertTitleHasLink(
         "Youth tee",
-        "/products/youth-tee/adb150",
+        "/products/default?sku=ADB150",
       )(".commerce-cart-wrapper");
       assertProductImage(Cypress.env("productImageName"))(
         ".commerce-cart-wrapper",

--- a/cypress/src/tests/b2c/verifyGuestUserVirtualCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserVirtualCheckout.spec.js
@@ -54,7 +54,7 @@ describe("Verify guest user can place order with virtual product", { tags: "@ski
 
     assertTitleHasLink(
       "Gift Card (Virtual)",
-      "/products/gift-card-virtual/gift-card-virtual",
+      "/products/default?sku=gift-card-virtual",
     )(".cart-mini-cart");
     cy.get('.dropin-cart-list__item').within(() => {
       cy.contains('Jane Smith (jane20@example.com)').should('be.visible');
@@ -81,7 +81,7 @@ describe("Verify guest user can place order with virtual product", { tags: "@ski
 
     assertTitleHasLink(
       "Virtual Product",
-      "/products/virtual-product/virtual123",
+      "/products/default?sku=virtual123",
     )(".cart-mini-cart");
     cy.contains("View Cart").click();
 
@@ -96,7 +96,7 @@ describe("Verify guest user can place order with virtual product", { tags: "@ski
 
     assertTitleHasLink(
       "Virtual Product",
-      "/products/virtual-product/virtual123",
+      "/products/default?sku=virtual123",
     )(".commerce-cart-wrapper");
 
     assertCartSummaryProduct(
@@ -110,7 +110,7 @@ describe("Verify guest user can place order with virtual product", { tags: "@ski
 
     assertTitleHasLink(
       "Gift Card (Virtual)",
-      "/products/gift-card-virtual/gift-card-virtual",
+      "/products/default?sku=gift-card-virtual",
     )(".commerce-cart-wrapper");
     cy.get('.cart-cart-summary-list__content').within(() => {
       cy.contains('Jane Smith (jane20@example.com)').should('be.visible');

--- a/cypress/src/tests/b2c/verifyGuestUserVirtualCheckout.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserVirtualCheckout.spec.js
@@ -81,7 +81,7 @@ describe("Verify guest user can place order with virtual product", { tags: "@ski
 
     assertTitleHasLink(
       "Virtual Product",
-      "/products/default?sku=virtual123",
+      "/products/default?sku=VIRTUAL123",
     )(".cart-mini-cart");
     cy.contains("View Cart").click();
 
@@ -96,7 +96,7 @@ describe("Verify guest user can place order with virtual product", { tags: "@ski
 
     assertTitleHasLink(
       "Virtual Product",
-      "/products/default?sku=virtual123",
+      "/products/default?sku=VIRTUAL123",
     )(".commerce-cart-wrapper");
 
     assertCartSummaryProduct(

--- a/cypress/src/tests/b2c/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js
@@ -58,7 +58,7 @@ describe(
 
         assertTitleHasLink(
           "Gift Card (Virtual)",
-          "/products/gift-card-virtual/gift-card-virtual",
+          "/products/default?sku=gift-card-virtual",
         )(".cart-mini-cart");
         cy.get(".dropin-cart-list__item").within(() => {
           cy.contains("Jane Smith (jane20@example.com)").should("be.visible");
@@ -87,7 +87,7 @@ describe(
 
         assertTitleHasLink(
           "Virtual Product",
-          "/products/virtual-product/virtual123",
+          "/products/default?sku=VIRTUAL123",
         )(".cart-mini-cart");
         cy.contains("View Cart").click();
 
@@ -102,7 +102,7 @@ describe(
 
         assertTitleHasLink(
           "Virtual Product",
-          "/products/virtual-product/virtual123",
+          "/products/default?sku=VIRTUAL123",
         )(".commerce-cart-wrapper");
 
         assertCartSummaryProduct(
@@ -116,7 +116,7 @@ describe(
 
         assertTitleHasLink(
           "Gift Card (Virtual)",
-          "/products/gift-card-virtual/gift-card-virtual",
+          "/products/default?sku=gift-card-virtual",
         )(".commerce-cart-wrapper");
         cy.get(".cart-cart-summary-list__content").within(() => {
           cy.contains("Jane Smith (jane20@example.com)").should("be.visible");

--- a/cypress/src/tests/b2c/verifyGuestUserWishlistFeature.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserWishlistFeature.spec.js
@@ -147,7 +147,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/default?sku=cypress456"
+      "/products/default?sku=CYPRESS456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productWithOptionImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -242,7 +242,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/default?sku=cypress456"
+      "/products/default?sku=CYPRESS456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -254,7 +254,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
     assertProductDetailPage(
       'Configurable product',
       'CYPRESS456',
-      '/products/default?sku=cypress456'
+      '/products/default?sku=CYPRESS456'
     );
 
     // Verify item is back in wishlist

--- a/cypress/src/tests/b2c/verifyGuestUserWishlistFeature.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserWishlistFeature.spec.js
@@ -54,7 +54,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150"
+      "/products/default?sku=adb150"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env("productImageName"))(".commerce-wishlist-wrapper");
@@ -147,7 +147,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/cypress-configurable-product-latest-red/cypress456"
+      "/products/default?sku=cypress456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productWithOptionImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -242,7 +242,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Configurable product",
-      "/products/cypress-configurable-product-latest/cypress456"
+      "/products/default?sku=cypress456"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env('productImageNameConfigurable'))(".commerce-wishlist-wrapper");
@@ -254,7 +254,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
     assertProductDetailPage(
       'Configurable product',
       'CYPRESS456',
-      '/products/cypress-configurable-product-latest/cypress456'
+      '/products/default?sku=cypress456'
     );
 
     // Verify item is back in wishlist
@@ -311,7 +311,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Youth tee",
-      "/products/youth-tee/adb150"
+      "/products/default?sku=adb150"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env("productImageName"))(".commerce-wishlist-wrapper");

--- a/cypress/src/tests/b2c/verifyGuestUserWishlistFeature.spec.js
+++ b/cypress/src/tests/b2c/verifyGuestUserWishlistFeature.spec.js
@@ -54,7 +54,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150"
+      "/products/default?sku=ADB150"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env("productImageName"))(".commerce-wishlist-wrapper");
@@ -311,7 +311,7 @@ describe("Verify guest user can manage products across wishlist and cart", () =>
 
     assertWishlistTitleHasLink(
       "Youth tee",
-      "/products/default?sku=adb150"
+      "/products/default?sku=ADB150"
     )(".commerce-wishlist-wrapper");
 
     assertWishlistProductImage(Cypress.env("productImageName"))(".commerce-wishlist-wrapper");

--- a/cypress/src/tests/b2c/verifyLowStockInfoMessage.spec.js
+++ b/cypress/src/tests/b2c/verifyLowStockInfoMessage.spec.js
@@ -1,6 +1,6 @@
 describe("Verify stock notification message", () => {
   it("Verify low stock and max qty allowed notification message", () => {
-    cy.visit("/products/default?sku=adb388");
+    cy.visit("/products/default?sku=ADB388");
     cy.get(".dropin-incrementer__input").clear().type("1000");
     cy.wait(1000);
     cy.get(".dropin-incrementer__increase-button").click();

--- a/cypress/src/tests/b2c/verifyLowStockInfoMessage.spec.js
+++ b/cypress/src/tests/b2c/verifyLowStockInfoMessage.spec.js
@@ -1,6 +1,6 @@
 describe("Verify stock notification message", () => {
   it("Verify low stock and max qty allowed notification message", () => {
-    cy.visit("/products/play-create-repeat-crewneck/adb388");
+    cy.visit("/products/default?sku=adb388");
     cy.get(".dropin-incrementer__input").clear().type("1000");
     cy.wait(1000);
     cy.get(".dropin-incrementer__increase-button").click();

--- a/cypress/src/tests/b2c/verifyProductListPage.spec.js
+++ b/cypress/src/tests/b2c/verifyProductListPage.spec.js
@@ -1,5 +1,6 @@
 import {
-    assertImageListDisplay
+    assertImageListDisplay,
+    assertProductLinksUseSkuQueryParam
 } from "../../assertions";
 
 describe("Verify Product List Page", () => {
@@ -16,6 +17,7 @@ describe("Verify Product List Page", () => {
         cy.waitForLoadingSkeletonToDisappear();
 
         assertImageListDisplay('.product-discovery-product-list__grid');
+        assertProductLinksUseSkuQueryParam();
 
         // If there is more than one sort option, change sort and assert it changed
         cy.get('select').then($select => {

--- a/cypress/src/tests/b2c/verifyProductSearch.spec.js
+++ b/cypress/src/tests/b2c/verifyProductSearch.spec.js
@@ -1,6 +1,7 @@
 
 import {
   assertImageListDisplay,
+  assertProductLinksUseSkuQueryParam,
   assertSearchResults
 } from "../../assertions";
 
@@ -21,6 +22,7 @@ describe("Search Feature", () => {
     assertSearchResults();
 
     assertImageListDisplay('.product-discovery-product-list__grid');
+    assertProductLinksUseSkuQueryParam();
   });
 
   it("Verify Search results page", () => {

--- a/cypress/src/tests/b2c/verifySellerAssistedBuying.spec.js
+++ b/cypress/src/tests/b2c/verifySellerAssistedBuying.spec.js
@@ -332,7 +332,7 @@ describe("Seller Assisted Buying", () => {
         cy.url().should("include", "/customer/account");
 
         cy.log("Step 17.5: Admin adding product for customer");
-        cy.visit("/products/youth-tee/adb150");
+        cy.visit("/products/default?sku=adb150");
         cy.reload();
         cy.wait(2000);
         cy.get(".product-details__buttons__add-to-cart button")

--- a/cypress/src/tests/b2c/verifySellerAssistedBuying.spec.js
+++ b/cypress/src/tests/b2c/verifySellerAssistedBuying.spec.js
@@ -332,7 +332,7 @@ describe("Seller Assisted Buying", () => {
         cy.url().should("include", "/customer/account");
 
         cy.log("Step 17.5: Admin adding product for customer");
-        cy.visit("/products/default?sku=adb150");
+        cy.visit("/products/default?sku=ADB150");
         cy.reload();
         cy.wait(2000);
         cy.get(".product-details__buttons__add-to-cart button")

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -623,7 +623,7 @@ export async function commerceEndpointWithQueryParams() {
 }
 
 /**
- * Extracts the SKU from the current URL query or path
+ * Extracts the SKU from the current URL .
  * @returns {string|null} The SKU extracted from the URL, or null if not found
  */
 function getSkuFromUrl() {

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -623,7 +623,7 @@ export async function commerceEndpointWithQueryParams() {
 }
 
 /**
- * Extracts the SKU from the current URL .
+ * Extracts the SKU from the current URL query or path.
  * @returns {string|null} The SKU extracted from the URL, or null if not found
  */
 function getSkuFromUrl() {

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -680,7 +680,9 @@ export function getProductLink(urlKey, sku) {
     if (!urlKey) {
       console.warn('getProductLink: urlKey is missing or empty', { urlKey, sku });
     }
-    return rootLink(`/products/${sanitizeName(urlKey)}/${sanitizeName(sku || '')}`);
+    const sanitizedUrlKey = urlKey ? sanitizeName(urlKey) : '';
+    const sanitizedSku = sku ? sanitizeName(sku) : '';
+    return rootLink(`/products/${sanitizedUrlKey}/${sanitizedSku}`);
   }
 
   // Use template page path + sku query parameter to render product

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -623,10 +623,16 @@ export async function commerceEndpointWithQueryParams() {
 }
 
 /**
- * Extracts the SKU from the current URL path.
+ * Extracts the SKU from the current URL query or path
  * @returns {string|null} The SKU extracted from the URL, or null if not found
  */
 function getSkuFromUrl() {
+  const sku = new URLSearchParams(window.location.search).get('sku');
+  if (sku) {
+    return decodeURIComponent(sku);
+  }
+
+  // Fall back to path based
   const path = window.location.pathname;
   const result = path.match(/\/products\/[\w|-]+\/([\w|-]+)$/);
   return result?.[1];
@@ -666,15 +672,21 @@ export function isProductTemplate() {
 }
 
 export function getProductLink(urlKey, sku) {
-  if (!urlKey) {
-    console.warn('getProductLink: urlKey is missing or empty', { urlKey, sku });
-  }
   if (!sku) {
     console.warn('getProductLink: sku is missing or empty', { urlKey, sku });
   }
-  const sanitizedUrlKey = urlKey ? sanitizeName(urlKey) : '';
-  const sanitizedSku = sku ? sanitizeName(sku) : '';
-  return rootLink(`/products/${sanitizedUrlKey}/${sanitizedSku}`);
+  // Use folder mapping path to route to product
+  if (getConfigValue('use-folder-mapping') === 'true') {
+    if (!urlKey) {
+      console.warn('getProductLink: urlKey is missing or empty', { urlKey, sku });
+    }
+    return rootLink(`/products/${sanitizeName(urlKey)}/${sanitizeName(sku || '')}`);
+  }
+
+  // Use template page path + sku query parameter to render product
+  const url = new URL(rootLink('/products/default'), window.location.origin);
+  url.searchParams.set('sku', sku || '');
+  return url.pathname + url.search;
 }
 
 /**

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -15,26 +15,6 @@ import {
 import initializeDropins from './initializers/index.js';
 
 /**
- * Sanitizes the given string by:
- * - convert to lower case
- * - normalize all unicode characters
- * - replace all non-alphanumeric characters with a dash
- * - remove all consecutive dashes
- * - remove all leading and trailing dashes
- *
- * @param {string} name
- * @returns {string} sanitized name
- */
-function sanitizeName(name) {
-  return name
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-/**
  * Fetch GraphQL Instances
  */
 
@@ -673,29 +653,9 @@ export function isProductTemplate() {
   });
 }
 
-export function getProductLink(urlKey, sku) {
+export function getProductLink(sku) {
   if (!sku) {
-    console.warn('getProductLink: sku is missing or empty', { urlKey, sku });
-  }
-  // getConfigValue throws if called before initializeConfig() has resolved.
-  // getProductLink is called from render paths (header, mini-cart, cart,
-  // wishlist, order lists) that can run before that promise settles, and an
-  // uncaught throw here breaks the whole render, not just this link. Default
-  // to the (non-folder-mapped) template link in that case.
-  let useFolderMapping = false;
-  try {
-    useFolderMapping = getConfigValue('use-folder-mapping') === 'true';
-  } catch (e) {
-    console.warn('getProductLink: config not yet initialized, defaulting to template link', e);
-  }
-  // Use folder mapping path to route to product
-  if (useFolderMapping) {
-    if (!urlKey) {
-      console.warn('getProductLink: urlKey is missing or empty', { urlKey, sku });
-    }
-    const sanitizedUrlKey = urlKey ? sanitizeName(urlKey) : '';
-    const sanitizedSku = sku ? sanitizeName(sku) : '';
-    return rootLink(`/products/${sanitizedUrlKey}/${sanitizedSku}`);
+    console.warn('getProductLink: sku is missing or empty', { sku });
   }
 
   // Use template page path + sku query parameter to render product

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -627,9 +627,11 @@ export async function commerceEndpointWithQueryParams() {
  * @returns {string|null} The SKU extracted from the URL, or null if not found
  */
 function getSkuFromUrl() {
+  // URLSearchParams already decodes the value; decoding again would corrupt
+  // any sku containing a literal % character.
   const sku = new URLSearchParams(window.location.search).get('sku');
   if (sku) {
-    return decodeURIComponent(sku);
+    return sku;
   }
 
   // Fall back to path based
@@ -675,8 +677,19 @@ export function getProductLink(urlKey, sku) {
   if (!sku) {
     console.warn('getProductLink: sku is missing or empty', { urlKey, sku });
   }
+  // getConfigValue throws if called before initializeConfig() has resolved.
+  // getProductLink is called from render paths (header, mini-cart, cart,
+  // wishlist, order lists) that can run before that promise settles, and an
+  // uncaught throw here breaks the whole render, not just this link. Default
+  // to the (non-folder-mapped) template link in that case.
+  let useFolderMapping = false;
+  try {
+    useFolderMapping = getConfigValue('use-folder-mapping') === 'true';
+  } catch (e) {
+    console.warn('getProductLink: config not yet initialized, defaulting to template link', e);
+  }
   // Use folder mapping path to route to product
-  if (getConfigValue('use-folder-mapping') === 'true') {
+  if (useFolderMapping) {
     if (!urlKey) {
       console.warn('getProductLink: urlKey is missing or empty', { urlKey, sku });
     }

--- a/scripts/components/commerce-mini-pdp/commerce-mini-pdp.js
+++ b/scripts/components/commerce-mini-pdp/commerce-mini-pdp.js
@@ -28,7 +28,7 @@ import ProductQuantity from '@dropins/storefront-pdp/containers/ProductQuantity.
 // Initializers
 import '../../initializers/cart.js';
 
-import { fetchPlaceholders, CS_FETCH_GRAPHQL } from '../../commerce.js';
+import { fetchPlaceholders, CS_FETCH_GRAPHQL, getProductLink } from '../../commerce.js';
 
 import { loadCSS } from '../../aem.js';
 
@@ -123,7 +123,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
       <div class="mini-pdp__alert"></div>
       <div class="mini-pdp__wrapper">
         <div class="mini-pdp__header">
-          <a href="/products/${product.urlKey}/${product.sku}" class="quick-view__close">
+          <a href="${getProductLink(product.sku)}" class="quick-view__close">
           ${product.name}
           </a>
         </div>
@@ -149,7 +149,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
           </div>
           <div class="mini-pdp__cancel-button"></div>
           <div class="mini-pdp__buttons__redirect-to-pdp">
-            <a href="/products/${product.urlKey}/${product.sku}">
+            <a href="${getProductLink(product.sku)}">
             </a>
           </div>
         </div>
@@ -316,7 +316,7 @@ export default async function createMiniPDP(cartItem, onUpdate, onClose) {
         onClick: () => {
           onClose();
           // Navigate to full PDP page
-          window.location.href = `/products/${product.urlKey}/${product.sku}`;
+          window.location.href = getProductLink(product.sku);
         },
       })($redirectButton),
     ]);


### PR DESCRIPTION
As [folder mapping is deprecated](https://www.aem.live/developer/folder-mapping), and [to be removed/disabled](https://github.com/adobe/helix-html-pipeline/issues/1037), we want to ensure the boilerplate leaves people in a better state, where it is:

1) Obvious that a template page is being used to render products.
2) Obvious that the path is not "final" (eg "/default") and should be updated.
3) Obvious that this is not SEO "compliant" for public catalogs and requires additional steps to move to a [compliant implementation](https://github.com/adobe-rnd/aem-commerce-prerender).

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/adobe-pattern-hoodie/adb127
- After: https://no-folder-mapping--aem-boilerplate-commerce--hlxsites.aem.live/products/default?sku=ADB127

