### PR TITLE
ACCS-873 - Add order summary to the /pay page

### DIFF
--- a/blocks/commerce-pay-by-link/README.md
+++ b/blocks/commerce-pay-by-link/README.md
@@ -1,0 +1,63 @@
+# commerce-pay-by-link
+
+Renders the Pay By Link payment page. Resolves a token from the URL, fetches the order summary via GraphQL, and displays items, totals, and addresses. Exposes a `Payment` slot for mounting a gateway SDK.
+
+## URL parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `token` | Yes | 64-char lowercase hex token from the payment link email |
+
+Missing or malformed tokens render an error state immediately without making a network request.
+
+## Slots
+
+Import the `slots` object to mount a payment gateway SDK into the payment container. Override must happen before the block's `decorate` function runs (i.e., during the eager phase).
+
+```js
+import { slots } from '/blocks/commerce-pay-by-link/commerce-pay-by-link.js';
+
+slots.Payment = async (ctx) => {
+  const container = document.createElement('div');
+  await mountGatewaySDK(container, {
+    token: ctx.token,
+    amount: ctx.order.totals.grand_total,
+  });
+  ctx.replaceWith(container);
+};
+```
+
+### Slot context (`ctx`)
+
+| Property | Type | Description |
+|---|---|---|
+| `ctx.order` | Object | Full `payByLinkOrder` GraphQL response |
+| `ctx.token` | String | Raw token string from the URL |
+| `ctx.replaceWith(el)` | Function | Replace the slot container's content |
+| `ctx.appendChild(el)` | Function | Append to the slot container |
+| `ctx.prependChild(el)` | Function | Prepend to the slot container |
+
+## Error states
+
+| Condition | Error kind | Notes |
+|---|---|---|
+| No `token` param | `missing` | Shown before any network call |
+| Token fails regex | `malformed` | Shown before any network call |
+| `TOKEN_NOT_FOUND` from API | `not-found` | |
+| `TOKEN_EXPIRED` from API | `expired` | |
+| `ORDER_ALREADY_PAID` from API | `already-paid` | |
+| `ORDER_CANCELLED` from API | `cancelled` | |
+
+All error states render a focusable alert card with a support CTA.
+
+## Loading skeleton
+
+While the GraphQL query is in flight, slots `.pay-by-link__order-header`, `.pay-by-link__order-summary`, `.pay-by-link__addresses`, and `.pay-by-link__order-totals` carry the `pay-by-link__skeleton` class and `aria-busy="true"`. Both are removed once the response resolves.
+
+## i18n
+
+Labels are loaded via `fetchPlaceholders()` from the AEM CMS spreadsheet under the `PayByLink` namespace. See [scripts/commerce.js](../../scripts/commerce.js) for the placeholder loading pattern. Required keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyPaidTitle`, `ErrorAlreadyPaidBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorContactSupportLabel`, `CustomerEmailLabel`, `OrderItemsHeading`, `QtyLabel`, `OrderTotalsHeading`, `SubtotalLabel`, `TaxLabel`, `ShippingLabel`, `GrandTotalLabel`, `ShippingAddressHeading`, `BillingAddressHeading`.
+
+## Page shell
+
+This block expects `body.pay-by-link-page` to be set by the AEM page template. That class drives the simplified header (logo only, no nav) defined in `blocks/header/header.css`.

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.css
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.css
@@ -81,3 +81,156 @@
     grid-column: 9 / span 4;
   }
 }
+
+/* --- Loading skeleton --- */
+
+@keyframes pay-by-link-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.pay-by-link .pay-by-link__skeleton {
+  min-height: 6rem;
+  background: linear-gradient(
+    90deg,
+    var(--color-neutral-100) 25%,
+    var(--color-neutral-200) 50%,
+    var(--color-neutral-100) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--shape-border-radius-2);
+  animation: pay-by-link-shimmer 1.5s ease-in-out infinite;
+}
+
+/* --- Section heading shared style --- */
+
+.pay-by-link .pay-by-link__section-heading {
+  margin: 0 0 var(--spacing-small);
+  font: var(--type-headline-3-strong-font);
+  letter-spacing: var(--type-headline-3-strong-letter-spacing);
+  color: var(--color-neutral-900);
+}
+
+/* --- Order header: customer email --- */
+
+.pay-by-link .pay-by-link__customer-email {
+  margin: 0;
+  font: var(--type-body-1-default-font);
+  letter-spacing: var(--type-body-1-default-letter-spacing);
+  color: var(--color-neutral-700);
+}
+
+.pay-by-link .pay-by-link__customer-email-label {
+  color: var(--color-neutral-500);
+}
+
+.pay-by-link .pay-by-link__customer-email-value {
+  color: var(--color-brand-500);
+}
+
+/* --- Line items table --- */
+
+.pay-by-link .pay-by-link__items {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pay-by-link .pay-by-link__item {
+  border-bottom: var(--shape-border-width-1) solid var(--color-neutral-200);
+}
+
+.pay-by-link .pay-by-link__item:last-child {
+  border-bottom: none;
+}
+
+.pay-by-link .pay-by-link__item td {
+  padding: var(--spacing-small) 0;
+  font: var(--type-body-2-default-font);
+  letter-spacing: var(--type-body-2-default-letter-spacing);
+  color: var(--color-neutral-800);
+  vertical-align: top;
+}
+
+.pay-by-link .pay-by-link__item-name {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+  width: 60%;
+}
+
+.pay-by-link .pay-by-link__item-sku {
+  font: var(--type-body-2-default-font);
+  color: var(--color-neutral-500);
+}
+
+.pay-by-link .pay-by-link__item-qty {
+  text-align: center;
+  color: var(--color-neutral-600);
+}
+
+.pay-by-link .pay-by-link__item-price {
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* --- Addresses --- */
+
+.pay-by-link .pay-by-link__addresses {
+  display: grid;
+  gap: var(--spacing-big);
+}
+
+@media (min-width: 600px) {
+  .pay-by-link .pay-by-link__addresses {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.pay-by-link .pay-by-link__address {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+  font: var(--type-body-2-default-font);
+  letter-spacing: var(--type-body-2-default-letter-spacing);
+  color: var(--color-neutral-800);
+  font-style: normal;
+}
+
+.pay-by-link .pay-by-link__address-name {
+  font: var(--type-body-2-strong-font);
+  letter-spacing: var(--type-body-2-strong-letter-spacing);
+}
+
+.pay-by-link .pay-by-link__address-phone {
+  color: var(--color-neutral-600);
+}
+
+/* --- Order totals --- */
+
+.pay-by-link .pay-by-link__totals {
+  display: grid;
+  gap: var(--spacing-xsmall);
+  margin: 0;
+}
+
+.pay-by-link .pay-by-link__totals-row {
+  display: flex;
+  justify-content: space-between;
+  font: var(--type-body-1-default-font);
+  letter-spacing: var(--type-body-1-default-letter-spacing);
+  color: var(--color-neutral-700);
+}
+
+.pay-by-link .pay-by-link__totals-row dt,
+.pay-by-link .pay-by-link__totals-row dd {
+  margin: 0;
+}
+
+.pay-by-link .pay-by-link__totals-row--grand {
+  margin-top: var(--spacing-small);
+  padding-top: var(--spacing-small);
+  border-top: var(--shape-border-width-1) solid var(--color-neutral-200);
+  font: var(--type-body-1-strong-font);
+  letter-spacing: var(--type-body-1-strong-letter-spacing);
+  color: var(--color-neutral-900);
+}

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -1,11 +1,57 @@
 /* eslint-disable import/no-unresolved */
 
 import { Button, provider as UI } from '@dropins/tools/components.js';
+import {
+  CORE_FETCH_GRAPHQL,
+  fetchPlaceholders,
+  rootLink,
+  SUPPORT_PATH,
+} from '../../scripts/commerce.js';
 
-import { fetchPlaceholders, rootLink, SUPPORT_PATH } from '../../scripts/commerce.js';
-
-// token is varchar(64) secure random hash. Strict lowercase hex.
+// Token is varchar(64) secure random hash. Strict lowercase hex.
 export const TOKEN_REGEX = /^[a-f0-9]{64}$/;
+
+const QUERY = `
+  query PAY_BY_LINK_ORDER($token: String!) {
+    payByLinkOrder(token: $token) {
+      customer_email
+      expires_at
+      items {
+        name
+        sku
+        quantity
+        price { value currency }
+      }
+      totals {
+        subtotal { value currency }
+        tax { value currency }
+        shipping { value currency }
+        grand_total { value currency }
+      }
+      shipping_address {
+        firstname lastname street city region region_code country_code postcode telephone
+      }
+      billing_address {
+        firstname lastname street city region region_code country_code postcode telephone
+      }
+    }
+  }
+`;
+
+// Maps backend error extension codes to i18n kinds.
+const ERROR_CODE_MAP = {
+  TOKEN_NOT_FOUND: 'not-found',
+  TOKEN_EXPIRED: 'expired',
+  ORDER_ALREADY_PAID: 'already-paid',
+  ORDER_CANCELLED: 'cancelled',
+};
+
+// Override slots.Payment to mount a gateway payment SDK.
+// ctx.order = full payByLinkOrder payload; ctx.token = the raw token string.
+// ctx.replaceWith(el) replaces the empty payment container with your element.
+export const slots = {
+  Payment: () => {},
+};
 
 export function extractToken(search) {
   const raw = new URLSearchParams(search).get('token');
@@ -16,11 +62,25 @@ export function extractToken(search) {
   return { status: 'valid', token };
 }
 
+function formatMoney({ value, currency }) {
+  return new Intl.NumberFormat(document.documentElement.lang || 'en', {
+    style: 'currency',
+    currency,
+  }).format(value);
+}
+
 function renderError(block, kind, labels) {
   const ns = labels?.PayByLink || {};
-  const isMissing = kind === 'missing';
-  const title = isMissing ? ns.ErrorMissingTokenTitle : ns.ErrorMalformedTokenTitle;
-  const body = isMissing ? ns.ErrorMissingTokenBody : ns.ErrorMalformedTokenBody;
+  const errorLabels = {
+    missing: { title: ns.ErrorMissingTokenTitle, body: ns.ErrorMissingTokenBody },
+    malformed: { title: ns.ErrorMalformedTokenTitle, body: ns.ErrorMalformedTokenBody },
+    'not-found': { title: ns.ErrorNotFoundTitle, body: ns.ErrorNotFoundBody },
+    expired: { title: ns.ErrorExpiredTitle, body: ns.ErrorExpiredBody },
+    'already-paid': { title: ns.ErrorAlreadyPaidTitle, body: ns.ErrorAlreadyPaidBody },
+    cancelled: { title: ns.ErrorCancelledTitle, body: ns.ErrorCancelledBody },
+  };
+
+  const { title = '', body = '' } = errorLabels[kind] || errorLabels['not-found'];
 
   block.innerHTML = `
     <div class="pay-by-link pay-by-link--error">
@@ -32,8 +92,8 @@ function renderError(block, kind, labels) {
     </div>
   `;
 
-  block.querySelector('.pay-by-link__error-title').textContent = title || '';
-  block.querySelector('.pay-by-link__error-body').textContent = body || '';
+  block.querySelector('.pay-by-link__error-title').textContent = title;
+  block.querySelector('.pay-by-link__error-body').textContent = body;
 
   UI.render(Button, {
     children: ns.ErrorContactSupportLabel || '',
@@ -63,14 +123,192 @@ function renderShell(block) {
   `;
 }
 
+function setSkeleton(block, on) {
+  block.querySelectorAll(
+    '.pay-by-link__order-header, .pay-by-link__order-summary, .pay-by-link__addresses, .pay-by-link__order-totals',
+  ).forEach((slot) => {
+    slot.classList.toggle('pay-by-link__skeleton', on);
+    slot.setAttribute('aria-busy', String(on));
+  });
+}
+
+function buildSection(headingId, headingText) {
+  const section = document.createElement('section');
+  section.setAttribute('aria-labelledby', headingId);
+  const h2 = document.createElement('h2');
+  h2.id = headingId;
+  h2.className = 'pay-by-link__section-heading';
+  h2.textContent = headingText;
+  section.append(h2);
+  return section;
+}
+
+function buildAddress(addr) {
+  const el = document.createElement('address');
+  el.className = 'pay-by-link__address';
+
+  const name = document.createElement('span');
+  name.className = 'pay-by-link__address-name';
+  name.textContent = `${addr.firstname} ${addr.lastname}`;
+  el.append(name);
+
+  (addr.street || []).forEach((line) => {
+    const span = document.createElement('span');
+    span.className = 'pay-by-link__address-street';
+    span.textContent = line;
+    el.append(span);
+  });
+
+  const cityLine = document.createElement('span');
+  cityLine.className = 'pay-by-link__address-city';
+  const region = addr.region || addr.region_code || '';
+  cityLine.textContent = [addr.city, region, addr.postcode].filter(Boolean).join(', ');
+  el.append(cityLine);
+
+  const country = document.createElement('span');
+  country.className = 'pay-by-link__address-country';
+  country.textContent = addr.country_code;
+  el.append(country);
+
+  if (addr.telephone) {
+    const phone = document.createElement('span');
+    phone.className = 'pay-by-link__address-phone';
+    phone.textContent = addr.telephone;
+    el.append(phone);
+  }
+
+  return el;
+}
+
+function populateSlots(block, data, ns) {
+  // Customer email
+  const header = block.querySelector('.pay-by-link__order-header');
+  const emailPara = document.createElement('p');
+  emailPara.className = 'pay-by-link__customer-email';
+  const emailLabel = document.createElement('span');
+  emailLabel.className = 'pay-by-link__customer-email-label';
+  emailLabel.textContent = ns.CustomerEmailLabel || '';
+  const emailLink = document.createElement('a');
+  emailLink.className = 'pay-by-link__customer-email-value';
+  emailLink.href = `mailto:${data.customer_email}`;
+  emailLink.textContent = data.customer_email;
+  emailPara.append(emailLabel, ' ', emailLink);
+  header.append(emailPara);
+
+  // Line items
+  const summary = block.querySelector('.pay-by-link__order-summary');
+  const itemsSection = buildSection('pay-by-link-items-heading', ns.OrderItemsHeading || '');
+  const table = document.createElement('table');
+  table.className = 'pay-by-link__items';
+  const tbody = document.createElement('tbody');
+  data.items.forEach(({
+    name, sku, quantity, price,
+  }) => {
+    const tr = document.createElement('tr');
+    tr.className = 'pay-by-link__item';
+
+    const tdName = document.createElement('td');
+    tdName.className = 'pay-by-link__item-name';
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = name;
+    const skuSpan = document.createElement('span');
+    skuSpan.className = 'pay-by-link__item-sku';
+    skuSpan.textContent = sku;
+    tdName.append(nameSpan, skuSpan);
+
+    const tdQty = document.createElement('td');
+    tdQty.className = 'pay-by-link__item-qty';
+    tdQty.textContent = `${ns.QtyLabel || 'Qty'}: ${quantity}`;
+
+    const tdPrice = document.createElement('td');
+    tdPrice.className = 'pay-by-link__item-price';
+    tdPrice.textContent = formatMoney(price);
+
+    tr.append(tdName, tdQty, tdPrice);
+    tbody.append(tr);
+  });
+  table.append(tbody);
+  itemsSection.append(table);
+  summary.append(itemsSection);
+
+  // Addresses
+  const addresses = block.querySelector('.pay-by-link__addresses');
+  if (data.shipping_address) {
+    const section = buildSection('pay-by-link-shipping-heading', ns.ShippingAddressHeading || '');
+    section.append(buildAddress(data.shipping_address));
+    addresses.append(section);
+  }
+  if (data.billing_address) {
+    const section = buildSection('pay-by-link-billing-heading', ns.BillingAddressHeading || '');
+    section.append(buildAddress(data.billing_address));
+    addresses.append(section);
+  }
+
+  // Totals
+  const totalsSlot = block.querySelector('.pay-by-link__order-totals');
+  const totalsSection = buildSection('pay-by-link-totals-heading', ns.OrderTotalsHeading || '');
+  const dl = document.createElement('dl');
+  dl.className = 'pay-by-link__totals';
+  [
+    [ns.SubtotalLabel, data.totals.subtotal],
+    [ns.TaxLabel, data.totals.tax],
+    [ns.ShippingLabel, data.totals.shipping],
+    [ns.GrandTotalLabel, data.totals.grand_total, true],
+  ].forEach(([rowLabel, money, grand = false]) => {
+    const div = document.createElement('div');
+    div.className = `pay-by-link__totals-row${grand ? ' pay-by-link__totals-row--grand' : ''}`;
+    const dt = document.createElement('dt');
+    dt.textContent = rowLabel || '';
+    const dd = document.createElement('dd');
+    dd.textContent = formatMoney(money);
+    div.append(dt, dd);
+    dl.append(div);
+  });
+  totalsSection.append(dl);
+  totalsSlot.append(totalsSection);
+}
+
+function createCtx(element, order, token) {
+  return {
+    order,
+    token,
+    replaceWith(el) { element.replaceChildren(el); },
+    appendChild(el) { element.append(el); },
+    prependChild(el) { element.prepend(el); },
+  };
+}
+
+async function invokeSlots(block, order, token) {
+  const el = block.querySelector('.pay-by-link__payment');
+  if (el) await slots.Payment(createCtx(el, order, token));
+}
+
 export default async function decorate(block) {
   const result = extractToken(window.location.search);
 
-  if (result.status === 'valid') {
-    renderShell(block);
+  if (result.status !== 'valid') {
+    const labels = await fetchPlaceholders();
+    renderError(block, result.status, labels);
     return;
   }
 
-  const labels = await fetchPlaceholders();
-  renderError(block, result.status, labels);
+  renderShell(block);
+  setSkeleton(block, true);
+
+  const [labels, response] = await Promise.all([
+    fetchPlaceholders(),
+    CORE_FETCH_GRAPHQL.fetchGraphQl(QUERY, { variables: { token: result.token } }),
+  ]);
+
+  setSkeleton(block, false);
+
+  if (response.errors?.length || !response.data?.payByLinkOrder) {
+    const code = response.errors?.[0]?.extensions?.code;
+    renderError(block, ERROR_CODE_MAP[code] || 'not-found', labels);
+    return;
+  }
+
+  const order = response.data.payByLinkOrder;
+  populateSlots(block, order, labels?.PayByLink || {});
+  await invokeSlots(block, order, result.token);
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -857,3 +857,18 @@ body:has(.seller-assisted-buying-banner) {
   }
 }
 
+/* --- Simplified header for the pay-by-link page --- */
+
+body.pay-by-link-page header :is(.nav-sections, .nav-tools, .nav-hamburger) {
+  display: none;
+}
+
+body.pay-by-link-page header nav {
+  display: flex;
+  justify-content: center;
+}
+
+body.pay-by-link-page header .nav-brand {
+  padding: var(--spacing-small) 0;
+}
+

--- a/cypress/src/fixtures/payByLinkOrder.json
+++ b/cypress/src/fixtures/payByLinkOrder.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "payByLinkOrder": {
+      "customer_email": "jane.doe@example.com",
+      "expires_at": "2099-12-31 23:59:59",
+      "items": [
+        {
+          "name": "Joust Duffle Bag",
+          "sku": "24-MB01",
+          "quantity": 1,
+          "price": { "value": 34.00, "currency": "USD" }
+        },
+        {
+          "name": "Chaz Kangeroo Hoodie",
+          "sku": "MH01-XS-Black",
+          "quantity": 2,
+          "price": { "value": 52.00, "currency": "USD" }
+        }
+      ],
+      "totals": {
+        "subtotal": { "value": 138.00, "currency": "USD" },
+        "tax": { "value": 10.35, "currency": "USD" },
+        "shipping": { "value": 5.00, "currency": "USD" },
+        "grand_total": { "value": 153.35, "currency": "USD" }
+      },
+      "shipping_address": {
+        "firstname": "Jane",
+        "lastname": "Doe",
+        "street": ["123 Main St", "Suite 400"],
+        "city": "Austin",
+        "region": "Texas",
+        "region_code": "TX",
+        "country_code": "US",
+        "postcode": "78701",
+        "telephone": "512-555-0100"
+      },
+      "billing_address": {
+        "firstname": "Jane",
+        "lastname": "Doe",
+        "street": ["456 Billing Ave"],
+        "city": "Austin",
+        "region": "Texas",
+        "region_code": "TX",
+        "country_code": "US",
+        "postcode": "78702",
+        "telephone": null
+      }
+    }
+  }
+}

--- a/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
@@ -1,0 +1,125 @@
+// Path of the authored Pay By Link page. Lives under /drafts/aries/ during
+// the demo phase; update to /pay when the document graduates out of drafts.
+const PAY_PATH = '/drafts/aries/pay';
+
+// Structurally-valid 64-char hex token used across all tests.
+const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
+
+describe('Pay By Link — Order Summary (ACCS-873)', () => {
+  function stubPayByLinkOrder(body) {
+    cy.intercept('POST', Cypress.env('graphqlEndPoint'), (req) => {
+      const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+      if (query.includes('PAY_BY_LINK_ORDER')) {
+        req.reply({ body });
+      }
+    }).as('payByLinkOrder');
+  }
+
+  it('renders the order summary for a valid token (happy path)', () => {
+    cy.fixture('payByLinkOrder').then((fixture) => {
+      stubPayByLinkOrder(fixture);
+      cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+      cy.wait('@payByLinkOrder');
+
+      // Customer email
+      cy.get('.pay-by-link__customer-email').should('be.visible');
+      cy.get('.pay-by-link__customer-email-value')
+        .should('contain.text', 'jane.doe@example.com');
+
+      // Line items
+      cy.get('.pay-by-link__items tbody tr').should('have.length', 2);
+      cy.get('.pay-by-link__items tbody tr').first()
+        .find('.pay-by-link__item-name')
+        .should('contain.text', 'Joust Duffle Bag');
+
+      // Addresses
+      cy.get('.pay-by-link__address').should('have.length', 2);
+      cy.get('.pay-by-link__address').first()
+        .should('contain.text', 'Jane Doe');
+
+      // Totals
+      cy.get('.pay-by-link__totals').should('be.visible');
+      cy.get('.pay-by-link__totals-row--grand').should('be.visible');
+
+      // No error state
+      cy.get('.pay-by-link--error').should('not.exist');
+    });
+  });
+
+  it('renders the expired-token error state', () => {
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{
+        message: 'Pay By Link token has expired.',
+        extensions: { code: 'TOKEN_EXPIRED', category: 'graphql-input' },
+      }],
+    });
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
+    cy.get('.pay-by-link__error-card[role="alert"]')
+      .should('be.visible')
+      .should('have.attr', 'aria-live', 'assertive');
+    cy.get('.pay-by-link__error-title')
+      .should('have.attr', 'tabindex', '-1')
+      .invoke('text')
+      .should('match', /\S/);
+    cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+  });
+
+  it('renders the already-paid error state', () => {
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{
+        message: 'Order has already been paid.',
+        extensions: { code: 'ORDER_ALREADY_PAID', category: 'graphql-input' },
+      }],
+    });
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
+    cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
+    cy.get('.pay-by-link__error-title').invoke('text').should('match', /\S/);
+  });
+
+  it('renders the cancelled-order error state', () => {
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{
+        message: 'Order has been cancelled.',
+        extensions: { code: 'ORDER_CANCELLED', category: 'graphql-input' },
+      }],
+    });
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
+    cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
+    cy.get('.pay-by-link__error-title').invoke('text').should('match', /\S/);
+  });
+
+  it('shows the loading skeleton while the query is in flight and removes it after', () => {
+    let resolveQuery;
+    cy.intercept('POST', Cypress.env('graphqlEndPoint'), (req) => {
+      const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+      if (query.includes('PAY_BY_LINK_ORDER')) {
+        return new Promise((resolve) => {
+          resolveQuery = () => {
+            cy.fixture('payByLinkOrder').then((fixture) => {
+              req.reply({ body: fixture });
+              resolve();
+            });
+          };
+        });
+      }
+    }).as('payByLinkOrder');
+
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.get('.pay-by-link__skeleton').should('exist');
+    cy.then(() => resolveQuery?.());
+    cy.wait('@payByLinkOrder');
+    cy.get('.pay-by-link__skeleton').should('not.exist');
+  });
+});

--- a/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
@@ -7,7 +7,7 @@ const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec6
 
 describe('Pay By Link — Order Summary (ACCS-873)', () => {
   function stubPayByLinkOrder(body) {
-    cy.intercept('POST', Cypress.env('graphqlEndPoint'), (req) => {
+    cy.intercept('POST', '**/graphql*', (req) => {
       const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
       if (query.includes('PAY_BY_LINK_ORDER')) {
         req.reply({ body });
@@ -101,25 +101,26 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
   });
 
   it('shows the loading skeleton while the query is in flight and removes it after', () => {
-    let resolveQuery;
-    cy.intercept('POST', Cypress.env('graphqlEndPoint'), (req) => {
-      const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
-      if (query.includes('PAY_BY_LINK_ORDER')) {
-        return new Promise((resolve) => {
-          resolveQuery = () => {
-            cy.fixture('payByLinkOrder').then((fixture) => {
+    cy.fixture('payByLinkOrder').then((fixture) => {
+      let resolveQuery;
+
+      cy.intercept('POST', '**/graphql*', (req) => {
+        const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+        if (query.includes('PAY_BY_LINK_ORDER')) {
+          return new Promise((resolve) => {
+            resolveQuery = () => {
               req.reply({ body: fixture });
               resolve();
-            });
-          };
-        });
-      }
-    }).as('payByLinkOrder');
+            };
+          });
+        }
+      }).as('payByLinkOrder');
 
-    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
-    cy.get('.pay-by-link__skeleton').should('exist');
-    cy.then(() => resolveQuery?.());
-    cy.wait('@payByLinkOrder');
-    cy.get('.pay-by-link__skeleton').should('not.exist');
+      cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+      cy.get('.pay-by-link__skeleton').should('exist');
+      cy.then(() => resolveQuery?.());
+      cy.wait('@payByLinkOrder');
+      cy.get('.pay-by-link__skeleton').should('not.exist');
+    });
   });
 });

--- a/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
@@ -50,15 +50,15 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
   });
 
   it('renders the shell and fires one payByLinkOrder query when /pay has a structurally valid token', () => {
-    // Stub the order query so the page renders the summary, not an error state.
-    cy.intercept('POST', Cypress.env('graphqlEndPoint'), (req) => {
+    cy.intercept('POST', '**/graphql*', (req) => {
       const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
       if (body.includes('PAY_BY_LINK_ORDER')) {
         req.reply({ fixture: 'payByLinkOrder' });
       }
-    });
+    }).as('payByLinkOrder');
 
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
 
     cy.get('.pay-by-link').should('exist').should('not.have.class', 'pay-by-link--error');
     cy.get('.pay-by-link__main').should('exist');
@@ -71,7 +71,5 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
     cy.get('.pay-by-link__order-totals').should('exist');
     cy.get('.pay-by-link__payment').should('exist');
     cy.get('.pay-by-link__footer').should('exist');
-
-    cy.then(() => expect(payByLinkOrderCalls.length).to.be.greaterThan(0));
   });
 });

--- a/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
@@ -49,14 +49,22 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
     cy.then(() => expect(payByLinkOrderCalls).to.have.length(0));
   });
 
-  it('renders the shell with empty mount points when /pay has a structurally valid token', () => {
+  it('renders the shell and fires one payByLinkOrder query when /pay has a structurally valid token', () => {
+    // Stub the order query so the page renders the summary, not an error state.
+    cy.intercept('POST', Cypress.env('graphqlEndPoint'), (req) => {
+      const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+      if (body.includes('PAY_BY_LINK_ORDER')) {
+        req.reply({ fixture: 'payByLinkOrder' });
+      }
+    });
+
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
 
     cy.get('.pay-by-link').should('exist').should('not.have.class', 'pay-by-link--error');
     cy.get('.pay-by-link__main').should('exist');
     cy.get('.pay-by-link__aside').should('exist');
 
-    // Slot DOM contract — downstream stories (ACCS-873 +) fill these.
+    // Slot DOM contract — populated by ACCS-873.
     cy.get('.pay-by-link__order-header').should('exist');
     cy.get('.pay-by-link__order-summary').should('exist');
     cy.get('.pay-by-link__addresses').should('exist');
@@ -64,8 +72,6 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
     cy.get('.pay-by-link__payment').should('exist');
     cy.get('.pay-by-link__footer').should('exist');
 
-    // Story 1 has no payByLinkOrder call yet; downstream stories will replace
-    // this assertion with positive ones.
-    cy.then(() => expect(payByLinkOrderCalls).to.have.length(0));
+    cy.then(() => expect(payByLinkOrderCalls.length).to.be.greaterThan(0));
   });
 });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -173,11 +173,7 @@ async function loadEager(doc) {
  * @param {Element} doc The container element
  */
 async function loadLazy(doc) {
-  const isStandalone = doc.body.classList.contains('pay-by-link-page');
-
-  if (!isStandalone) {
-    loadHeader(doc.querySelector('header'));
-  }
+  loadHeader(doc.querySelector('header'));
 
   const main = doc.querySelector('main');
   await loadSections(main);
@@ -186,9 +182,7 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  if (!isStandalone) {
-    loadFooter(doc.querySelector('footer'));
-  }
+  loadFooter(doc.querySelector('footer'));
 
   loadCommerceLazy();
 


### PR DESCRIPTION
## Summary

<img width="1460" height="722" alt="Screenshot 2026-06-12 at 15 18 52" src="https://github.com/user-attachments/assets/6a7a2a7c-7de3-4456-baaf-685f8a924336" />

- Implements the `payByLinkOrder` GraphQL query and renders the full order summary (items, totals, shipping/billing addresses, customer email)
- Loading skeleton during in-flight query; 4 distinct API error states (expired, already-paid, cancelled, not-found) plus client-side missing/malformed token states
- Reverts ACCS-869's `isStandalone` JS guard in favour of CSS-only simplified header (`body.pay-by-link-page` hook) — keeps header/footer in the EDS lazy-load phase, no boilerplate divergence
- Exposes `slots.Payment` for ACCS-874 to mount the gateway SDK
- Added these placeholders to da.live:
PayByLink.ErrorExpiredTitle, PayByLink.ErrorExpiredBody, PayByLink.ErrorCancelledTitle, PayByLink.ErrorCancelledBody, PayByLink.ErrorNotFoundTitle, PayByLink.ErrorNotFoundBody, PayByLink.ErrorAlreadyPaidTitle, PayByLink.ErrorAlreadyPaidBody

## Preview

https://accs-873-order-summary-pay--aem-boilerplate-commerce--hlxsites.aem.page/drafts/aries/pay

_(no token → renders missing-token error state; add `?token=<64-char hex>` for a live order)_

https://accs-873-order-summary-pay--aem-boilerplate-commerce--hlxsites.aem.page/drafts/aries/pay?token=bcfad8554a22d18ed529b38b8f35e0e8c5f037459c66e73907d99e51631c3fa8

_(valid token → renders order summary)_

https://accs-873-order-summary-pay--aem-boilerplate-commerce--hlxsites.aem.page/drafts/aries/pay?token=03b70aaa0eb76dfd759a117cd37eaf5f9fe196938ae35c7123e5dd746f397f49

_(expired token → renders expire-token error state)

https://accs-873-order-summary-pay--aem-boilerplate-commerce--hlxsites.aem.page/drafts/aries/pay?token=e7aba33e259b72fad0e830e03952f55927e4cd8034bccd4988e66bea84b5f44d

## Test plan

- [x] `cd cypress && npm install && npm run cypress:run` — `verifyPayByLinkOrderSummary.spec.js` (5 tests) and updated `verifyPayByLinkPageShell.spec.js` pass
- [x] Visit preview URL without token → missing-token error card visible, support CTA present
- [x] Visit preview URL with a valid QA token → order summary renders (items, totals, addresses)
- [x] Visit preview URL with expired token → expired error state renders
- [x] Header shows logo only (no nav); footer renders in full

## Notes

- i18n keys (`PayByLink.*` namespace) must be published in the AEM CMS spreadsheet before QA — they are not in git
- `slots.Payment` is a no-op until ACCS-874; the payment container renders as an empty div