### PR TITLE
ACCS-1118: Add Adyen Drop-in OOPE payment to storefront checkout

### DIFF
--- a/blocks/adyen-payment/README.md
+++ b/blocks/adyen-payment/README.md
@@ -1,0 +1,90 @@
+# Adyen Payment Block
+
+## Overview
+
+Provides the **Adyen Drop-in** as an OOPE (Out-of-Process Extension) payment method in the storefront checkout. Uses the **Adyen Sessions API** flow:
+
+1. App Builder `create-session` action → Adyen session
+2. Adyen Drop-in mounts with `showPayButton: false`
+3. Place Order button calls `dropin.submit()` via `submitAdyenPayment()`
+4. `onPaymentCompleted` resolves with session result
+5. `setPaymentMethod` sends session data to Commerce
+6. `placeOrder` → App Builder `validate-payment` webhook confirms the session
+
+This block is not rendered directly in a page. It exports a slot renderer (`slot.js`) and session coordination helpers (`session.js`) consumed by the `commerce-checkout` block.
+
+## Configuration
+
+All configuration is pulled from `oope_payment_method_config` on the `adyen_gateway` payment method, registered in Commerce via `payment-methods.yaml`:
+
+| Field | Source | Description |
+|---|---|---|
+| `backend_integration_url` | `payment-methods.yaml` | Base URL of the App Builder Adyen actions |
+| `client_key` | `custom_config` | Adyen public client key (safe for browser) |
+| `environment` | `custom_config` | `TEST` or `LIVE` (controls SDK CDN endpoint) |
+
+No `config.json` keys are used — all values come from the OOPE config registered in Commerce.
+
+## Integration
+
+### Checkout Slot Registration
+
+In `containers.js`, the Adyen slot is registered as:
+
+```js
+import { ADYEN_PAYMENT_CODE } from '../adyen-payment/session.js';
+import renderAdyenGateway from '../adyen-payment/slot.js';
+
+// Inside renderPaymentMethods → slots.Methods:
+[ADYEN_PAYMENT_CODE]: { render: renderAdyenGateway }
+```
+
+### GraphQL Fragment Extension
+
+`build.mjs` extends the checkout dropin fragments to fetch OOPE config:
+
+```js
+fragment AVAILABLE_PAYMENT_METHOD_FRAGMENT on AvailablePaymentMethod {
+  oope_payment_method_config { backend_integration_url custom_config { key value } }
+}
+```
+
+Run `npm run install:dropins` after modifying `build.mjs`.
+
+### Events
+
+#### Consumed
+
+- `checkout/initialized` — read via `events.lastPayload()` to get `availablePaymentMethods` with OOPE config at slot render time
+- `cart/data` / `cart/initialized` — read via `events.lastPayload()` to get cart total and currency for the session amount
+- `checkout/updated` — listened to detect payment method switches and clean up the Drop-in instance
+
+#### Emitted
+
+None. Results flow through the `submitAdyenPayment()` / `resolveAdyenPayment()` promise bridge in `session.js`.
+
+## Behavior Patterns
+
+### SDK Loading
+
+`loadAdyenWebSDK(environment)` in `session.js` loads the Adyen Web SDK JS and CSS from the Adyen CDN lazily — only when the slot renders. A module-level promise (`sdkLoadPromise`) deduplicates concurrent calls so the script is never appended twice.
+
+### Session Creation
+
+`createAdyenSession(endpoint, payload)` POSTs to the App Builder `create-session` action with cart amount, currency, reference, return URL, and country code.
+
+### Drop-in Coordination
+
+`submitAdyenPayment()` returns a Promise that resolves when `onPaymentCompleted` fires or rejects after a 10-minute timeout (matching typical Adyen session expiry). `handlePlaceOrder` in `commerce-checkout.js` awaits this promise before calling `setPaymentMethod` and `placeOrder`.
+
+### Cleanup
+
+When the customer selects a different payment method, the `checkout/updated` listener calls `clearDropinInstance()`, which unmounts the Drop-in and rejects any pending payment promise.
+
+## Error Handling
+
+- **Missing OOPE config** — slot throws immediately with a descriptive error if `backend_integration_url` is absent
+- **SDK load failure** — `loadAdyenWebSDK` rejects; slot catches and renders `checkout__adyen-error` message
+- **Session creation failure** — same catch block; error is surfaced in the slot and re-thrown
+- **Payment timeout** — `submitAdyenPayment()` rejects after 10 minutes with a user-friendly message
+- **Payment failed / error** — `onPaymentFailed` / `onError` call `rejectAdyenPayment()`, which rejects the place-order flow

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -1,0 +1,150 @@
+/**
+ * Adyen Sessions API helpers.
+ *
+ * Covers the minimal frontend needs for the Sessions-based OOPE flow:
+ *   create-session (App Builder) → Drop-in → onPaymentCompleted
+ *   → setPaymentMethodOnCart → placeOrder → validate-payment webhook
+ */
+
+import { loadCSS } from '../../scripts/aem.js';
+
+const SDK_VERSION = '6.23.0';
+
+/**
+ * Commerce OOPE payment method code — must match payment-methods.yaml.
+ * Exported so containers.js and commerce-checkout.js share one definition.
+ */
+export const ADYEN_PAYMENT_CODE = 'adyen_gateway';
+
+// Single promise shared across concurrent callers so the script/CSS are never
+// appended twice even if the slot renders before the first load finishes.
+let sdkLoadPromise = null;
+
+/**
+ * Load the Adyen Web SDK (JS + CSS) from the Adyen CDN.
+ * Safe to call multiple times — deduplicates at both the promise and DOM level.
+ *
+ * @param {string} environment - 'test' | 'live'
+ */
+export async function loadAdyenWebSDK(environment = 'test') {
+  if (window.AdyenWeb?.AdyenCheckout || window.AdyenCheckout) return;
+  if (sdkLoadPromise) return sdkLoadPromise;
+
+  const base = `https://checkoutshopper-${environment}.adyen.com/checkoutshopper/sdk/${SDK_VERSION}`;
+
+  sdkLoadPromise = Promise.all([
+    loadCSS(`${base}/adyen.css`),
+    new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = `${base}/adyen.js`;
+      script.async = true;
+      script.crossOrigin = 'anonymous';
+      script.onload = resolve;
+      script.onerror = () => reject(new Error('Failed to load Adyen Web SDK'));
+      document.head.appendChild(script);
+    }),
+  ]).finally(() => {
+    sdkLoadPromise = null;
+  });
+
+  return sdkLoadPromise;
+}
+
+// ─── Session creation ─────────────────────────────────────────────────────────
+
+/**
+ * Call the App Builder create-session action.
+ *
+ * @param {string} endpoint  - Full URL of the adyen/create-session web action
+ * @param {{ amount, reference, returnUrl, countryCode }} payload
+ * @returns {Promise<{ id: string, sessionData: string, ... }>} Adyen session object
+ */
+export async function createAdyenSession(endpoint, payload) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) throw new Error(`create-session failed: ${response.status}`);
+  const body = await response.json();
+  // App Builder wraps the Adyen response in { message: { ... } }
+  return body.message ?? body;
+}
+
+// ─── Drop-in coordination ─────────────────────────────────────────────────────
+// Bridges the Drop-in slot (containers.js) with handlePlaceOrder
+// (commerce-checkout.js) so Place Order triggers Drop-in submission and the
+// result flows back synchronously before placeOrder is called.
+
+// 10-minute timeout matches typical Adyen session expiry.
+const PAYMENT_TIMEOUT_MS = 10 * 60 * 1000;
+
+let dropinInstance = null;
+let paymentResolve = null;
+let paymentReject = null;
+let paymentTimeoutId = null;
+
+function clearPaymentCallbacks() {
+  if (paymentTimeoutId) clearTimeout(paymentTimeoutId);
+  paymentTimeoutId = null;
+  paymentResolve = null;
+  paymentReject = null;
+}
+
+/**
+ * Store the mounted Drop-in instance so handlePlaceOrder can call submit().
+ * Unmounts any previously stored instance first.
+ */
+export function setDropinInstance(instance) {
+  if (dropinInstance && dropinInstance !== instance) {
+    try { dropinInstance.unmount(); } catch { /* ignore */ }
+  }
+  dropinInstance = instance;
+}
+
+/** Clear the instance when the payment method is deselected. */
+export function clearDropinInstance() {
+  if (paymentReject) {
+    paymentReject(new Error('Payment method deselected'));
+    clearPaymentCallbacks();
+  }
+  dropinInstance = null;
+}
+
+/**
+ * Programmatically submit the Drop-in and await payment completion.
+ * Rejects after PAYMENT_TIMEOUT_MS if onPaymentCompleted never fires.
+ *
+ * @returns {Promise<{ sessionId, resultCode, sessionData, sessionResult }>}
+ */
+export function submitAdyenPayment() {
+  if (!dropinInstance) throw new Error('[Adyen] Drop-in not initialised');
+
+  return new Promise((resolve, reject) => {
+    paymentResolve = resolve;
+    paymentReject = reject;
+
+    paymentTimeoutId = setTimeout(() => {
+      clearPaymentCallbacks();
+      reject(new Error('Payment timed out. Please try again.'));
+    }, PAYMENT_TIMEOUT_MS);
+
+    dropinInstance.submit();
+  });
+}
+
+/** Called from onPaymentCompleted — resolves the awaiting handlePlaceOrder. */
+export function resolveAdyenPayment(result) {
+  if (paymentResolve) {
+    clearPaymentCallbacks();
+    paymentResolve(result);
+  }
+}
+
+/** Called from onPaymentFailed / onError — rejects the awaiting handlePlaceOrder. */
+export function rejectAdyenPayment(reason) {
+  if (paymentReject) {
+    clearPaymentCallbacks();
+    paymentReject(new Error(reason || 'Payment failed'));
+  }
+}

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -90,12 +90,12 @@ let dropinInstance = null;
 /** Returns true if the Adyen Drop-in is currently mounted. */
 export function isDropinMounted() { return !!dropinInstance; }
 
-/** Returns true when submitAdyenPayment() has been called and is awaiting a result. */
-export function isPaymentPending() { return !!paymentResolve; }
-
 let paymentResolve = null;
 let paymentReject = null;
 let paymentTimeoutId = null;
+
+/** Returns true when submitAdyenPayment() has been called and is awaiting a result. */
+export function isPaymentPending() { return !!paymentResolve; }
 
 function clearPaymentCallbacks() {
   if (paymentTimeoutId) clearTimeout(paymentTimeoutId);

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -27,7 +27,7 @@ let sdkLoadPromise = null;
  * @param {string} environment - 'test' | 'live'
  */
 export async function loadAdyenWebSDK(environment = 'test') {
-  if (window.AdyenWeb?.AdyenCheckout || window.AdyenCheckout) return;
+  if (window.AdyenWeb?.AdyenCheckout || window.AdyenCheckout) return Promise.resolve();
   if (sdkLoadPromise) return sdkLoadPromise;
 
   const base = `https://checkoutshopper-${environment}.adyen.com/checkoutshopper/sdk/${SDK_VERSION}`;

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -142,15 +142,18 @@ export function submitAdyenPayment() {
 /** Called from onPaymentCompleted — resolves the awaiting handlePlaceOrder. */
 export function resolveAdyenPayment(result) {
   if (paymentResolve) {
+    // Save reference before clearPaymentCallbacks() nulls it out.
+    const resolve = paymentResolve;
     clearPaymentCallbacks();
-    paymentResolve(result);
+    resolve(result);
   }
 }
 
 /** Called from onPaymentFailed / onError — rejects the awaiting handlePlaceOrder. */
 export function rejectAdyenPayment(reason) {
   if (paymentReject) {
+    const reject = paymentReject;
     clearPaymentCallbacks();
-    paymentReject(new Error(reason || 'Payment failed'));
+    reject(new Error(reason || 'Payment failed'));
   }
 }

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -89,6 +89,10 @@ let dropinInstance = null;
 
 /** Returns true if the Adyen Drop-in is currently mounted. */
 export function isDropinMounted() { return !!dropinInstance; }
+
+/** Returns true when submitAdyenPayment() has been called and is awaiting a result. */
+export function isPaymentPending() { return !!paymentResolve; }
+
 let paymentResolve = null;
 let paymentReject = null;
 let paymentTimeoutId = null;

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -65,10 +65,16 @@ export async function createAdyenSession(endpoint, payload) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!response.ok) throw new Error(`create-session failed: ${response.status}`);
   const body = await response.json();
-  // App Builder wraps the Adyen response in { message: { ... } }
-  return body.message ?? body;
+  if (!response.ok || body.success === false) {
+    throw new Error(`create-session failed: ${JSON.stringify(body.error ?? body)}`);
+  }
+  // App Builder wraps the Adyen response in { success: true, message: { id, sessionData, ... } }
+  const session = body.message ?? body;
+  if (!session?.id || !session?.sessionData) {
+    throw new Error(`create-session returned invalid session — check App Builder logs. Response: ${JSON.stringify(body)}`);
+  }
+  return session;
 }
 
 // ─── Drop-in coordination ─────────────────────────────────────────────────────
@@ -79,7 +85,7 @@ export async function createAdyenSession(endpoint, payload) {
 // 10-minute timeout matches typical Adyen session expiry.
 const PAYMENT_TIMEOUT_MS = 10 * 60 * 1000;
 
-let dropinInstance = null;
+export let dropinInstance = null;
 let paymentResolve = null;
 let paymentReject = null;
 let paymentTimeoutId = null;

--- a/blocks/adyen-payment/session.js
+++ b/blocks/adyen-payment/session.js
@@ -85,7 +85,10 @@ export async function createAdyenSession(endpoint, payload) {
 // 10-minute timeout matches typical Adyen session expiry.
 const PAYMENT_TIMEOUT_MS = 10 * 60 * 1000;
 
-export let dropinInstance = null;
+let dropinInstance = null;
+
+/** Returns true if the Adyen Drop-in is currently mounted. */
+export function isDropinMounted() { return !!dropinInstance; }
 let paymentResolve = null;
 let paymentReject = null;
 let paymentTimeoutId = null;

--- a/blocks/adyen-payment/slot.js
+++ b/blocks/adyen-payment/slot.js
@@ -1,0 +1,111 @@
+/**
+ * Adyen payment method slot renderer for the checkout PaymentMethods container.
+ * Registered in containers.js as slots.Methods[ADYEN_PAYMENT_CODE].render.
+ */
+
+import { events } from '@dropins/tools/event-bus.js';
+import {
+  ADYEN_PAYMENT_CODE,
+  loadAdyenWebSDK,
+  createAdyenSession,
+  setDropinInstance,
+  clearDropinInstance,
+  resolveAdyenPayment,
+  rejectAdyenPayment,
+} from './session.js';
+
+/**
+ * Render the Adyen Drop-in inside the PaymentMethods slot.
+ * Called by the checkout dropin when the customer selects adyen_gateway.
+ *
+ * @param {object} ctx - Slot render context ({ cartId, replaceHTML, ... })
+ */
+export default async function renderAdyenGateway(ctx) {
+  // Read OOPE config from availablePaymentMethods — this is static data set at
+  // checkout initialization, so it's reliable regardless of render timing.
+  // selectedPaymentMethod is NOT available yet when render fires (notifyValues
+  // emits checkout/values in a useEffect that runs after the render cycle).
+  const checkoutData = events.lastPayload('checkout/initialized');
+  const oopeConfig = checkoutData?.availablePaymentMethods
+    ?.find((m) => m.code === ADYEN_PAYMENT_CODE)
+    ?.oope_payment_method_config;
+
+  if (!oopeConfig?.backend_integration_url) {
+    throw new Error(`[Adyen] backend_integration_url missing in oope_payment_method_config for ${ADYEN_PAYMENT_CODE}`);
+  }
+
+  const endpoint = `${oopeConfig.backend_integration_url.replace(/\/$/, '')}/create-session`;
+  const cfg = Object.fromEntries(
+    (oopeConfig.custom_config ?? []).map(({ key, value }) => [key, value]),
+  );
+  const clientKey = cfg.client_key;
+  const env = (cfg.environment || 'TEST').toLowerCase();
+
+  // Show skeleton immediately — before any async work.
+  const $skeleton = document.createElement('div');
+  $skeleton.className = 'checkout__adyen-skeleton';
+  ctx.replaceHTML($skeleton);
+
+  // Load SDK and create session in parallel — safe to call concurrently since
+  // loadAdyenWebSDK deduplicates in-flight requests via a module-level promise.
+  const cartData = events.lastPayload('cart/data') || events.lastPayload('cart/initialized');
+
+  let session;
+  try {
+    [, session] = await Promise.all([
+      loadAdyenWebSDK(env),
+      createAdyenSession(endpoint, {
+        amount: {
+          value: Math.round((cartData?.total?.includingTax?.value || 0) * 100),
+          currency: cartData?.total?.includingTax?.currency || 'USD',
+        },
+        reference: cartData?.id,
+        returnUrl: `${window.location.origin}/checkout`,
+        countryCode: checkoutData?.billingAddress?.country?.code
+          || checkoutData?.shippingAddresses?.[0]?.country?.code
+          || 'US',
+      }),
+    ]);
+  } catch (err) {
+    $skeleton.className = 'checkout__adyen-error';
+    $skeleton.textContent = 'Payment form could not be loaded. Please refresh and try again.';
+    throw err;
+  }
+
+  const $dropin = document.createElement('div');
+  ctx.replaceHTML($dropin);
+
+  const AdyenCheckoutFactory = window.AdyenWeb?.AdyenCheckout ?? window.AdyenCheckout;
+  const DropinComponent = window.AdyenWeb?.Dropin ?? window.Dropin;
+
+  const checkout = await AdyenCheckoutFactory({
+    session: { id: session.id, sessionData: session.sessionData },
+    clientKey,
+    environment: env,
+    onPaymentCompleted: (result) => {
+      resolveAdyenPayment({
+        sessionId: session.id,
+        resultCode: result.resultCode,
+        sessionData: result.sessionData ?? '',
+        sessionResult: result.sessionResult ?? '',
+      });
+    },
+    onPaymentFailed: (result) => {
+      rejectAdyenPayment(`Payment ${result.resultCode}`);
+    },
+    onError: (error) => {
+      rejectAdyenPayment(error.message);
+    },
+  });
+
+  const dropin = new DropinComponent(checkout, { showPayButton: false }).mount($dropin);
+  setDropinInstance(dropin);
+
+  // Clean up when the customer switches to a different payment method.
+  const unsubscribe = events.on('checkout/updated', (data) => {
+    if (data?.selectedPaymentMethod?.code !== ADYEN_PAYMENT_CODE) {
+      clearDropinInstance();
+      unsubscribe.off();
+    }
+  });
+}

--- a/blocks/adyen-payment/slot.js
+++ b/blocks/adyen-payment/slot.js
@@ -12,7 +12,7 @@ import {
   clearDropinInstance,
   resolveAdyenPayment,
   rejectAdyenPayment,
-  dropinInstance,
+  isDropinMounted,
 } from './session.js';
 
 // True while the async IIFE is running. Prevents a second IIFE from starting
@@ -39,7 +39,7 @@ let activeDropinEl = null;
 export default function renderAdyenGateway(ctx) {
   // Drop-in already mounted. Re-pass the existing element back so Preact keeps
   // the slot instead of clearing it (render returning void clears the slot).
-  if (dropinInstance) {
+  if (isDropinMounted()) {
     if (activeDropinEl) ctx.replaceHTML(activeDropinEl);
     return;
   }
@@ -122,7 +122,6 @@ export default function renderAdyenGateway(ctx) {
         clientKey,
         environment: env,
         onPaymentCompleted: (result) => {
-          console.log('[Adyen] onPaymentCompleted:', result.resultCode);
           resolveAdyenPayment({
             sessionId: session.id,
             resultCode: result.resultCode,

--- a/blocks/adyen-payment/slot.js
+++ b/blocks/adyen-payment/slot.js
@@ -122,6 +122,7 @@ export default function renderAdyenGateway(ctx) {
         clientKey,
         environment: env,
         onPaymentCompleted: (result) => {
+          console.log('[Adyen] onPaymentCompleted:', result.resultCode);
           resolveAdyenPayment({
             sessionId: session.id,
             resultCode: result.resultCode,
@@ -130,7 +131,9 @@ export default function renderAdyenGateway(ctx) {
           });
         },
         onPaymentFailed: (result) => {
+          console.error('[Adyen] onPaymentFailed:', result.resultCode, result);
           rejectAdyenPayment(`Payment ${result.resultCode}`);
+          showError(`Payment declined (${result.resultCode}). Please try a different card.`);
         },
         onError: (error) => {
           console.error('[Adyen] onError:', error);

--- a/blocks/adyen-payment/slot.js
+++ b/blocks/adyen-payment/slot.js
@@ -13,6 +13,7 @@ import {
   resolveAdyenPayment,
   rejectAdyenPayment,
   isDropinMounted,
+  isPaymentPending,
 } from './session.js';
 
 // True while the async IIFE is running. Prevents a second IIFE from starting
@@ -121,6 +122,16 @@ export default function renderAdyenGateway(ctx) {
         session: { id: session.id, sessionData: session.sessionData },
         clientKey,
         environment: env,
+        beforeSubmit: (data, _component, actions) => {
+          // Only allow Drop-in submission when Place Order triggered it.
+          // Without this guard, pressing Enter in the card fields would send
+          // the payment to Adyen without creating a Commerce order.
+          if (isPaymentPending()) {
+            actions.resolve(data);
+          } else {
+            actions.reject();
+          }
+        },
         onPaymentCompleted: (result) => {
           resolveAdyenPayment({
             sessionId: session.id,

--- a/blocks/adyen-payment/slot.js
+++ b/blocks/adyen-payment/slot.js
@@ -58,12 +58,11 @@ export default function renderAdyenGateway(ctx) {
   if (isRenderingAdyen) return;
   isRenderingAdyen = true;
 
-  // Read OOPE config from availablePaymentMethods — static data set at checkout
-  // initialization, reliable regardless of render timing.
+  // Read OOPE config from oopePaymentMethodConfigs — a map keyed by payment
+  // method code, separated from availablePaymentMethods so the dropin's
+  // setPaymentMethodOnCart input transformer never sees oope_payment_method_config.
   const checkoutData = events.lastPayload('checkout/initialized');
-  const oopeConfig = checkoutData?.availablePaymentMethods
-    ?.find((m) => m.code === ADYEN_PAYMENT_CODE)
-    ?.oope_payment_method_config;
+  const oopeConfig = checkoutData?.oopePaymentMethodConfigs?.[ADYEN_PAYMENT_CODE];
 
   if (!oopeConfig?.backend_integration_url) {
     $skeleton.className = 'checkout__adyen-error';

--- a/blocks/adyen-payment/slot.js
+++ b/blocks/adyen-payment/slot.js
@@ -12,26 +12,63 @@ import {
   clearDropinInstance,
   resolveAdyenPayment,
   rejectAdyenPayment,
+  dropinInstance,
 } from './session.js';
+
+// True while the async IIFE is running. Prevents a second IIFE from starting
+// when checkout/updated re-invokes render() during SDK / session setup.
+let isRenderingAdyen = false;
+
+// Updated on every render call so the single IIFE always uses the freshest ctx.
+let activeCtx = null;
+
+// DOM element the Adyen Drop-in was mounted into. Passed back to ctx.replaceHTML
+// on every subsequent render() call so Preact keeps the slot instead of clearing it
+// when render() would otherwise return void.
+let activeDropinEl = null;
 
 /**
  * Render the Adyen Drop-in inside the PaymentMethods slot.
  * Called by the checkout dropin when the customer selects adyen_gateway.
  *
+ * Intentionally synchronous so the dropin renders the skeleton immediately.
+ * SDK load and session creation run in a single background async IIFE.
+ *
  * @param {object} ctx - Slot render context ({ cartId, replaceHTML, ... })
  */
-export default async function renderAdyenGateway(ctx) {
-  // Read OOPE config from availablePaymentMethods — this is static data set at
-  // checkout initialization, so it's reliable regardless of render timing.
-  // selectedPaymentMethod is NOT available yet when render fires (notifyValues
-  // emits checkout/values in a useEffect that runs after the render cycle).
+export default function renderAdyenGateway(ctx) {
+  // Drop-in already mounted. Re-pass the existing element back so Preact keeps
+  // the slot instead of clearing it (render returning void clears the slot).
+  if (dropinInstance) {
+    if (activeDropinEl) ctx.replaceHTML(activeDropinEl);
+    return;
+  }
+
+  // Update the shared ctx pointer — the IIFE always uses the freshest one.
+  activeCtx = ctx;
+
+  // Always show a skeleton with the current ctx. If render() returns without
+  // calling ctx.replaceHTML the dropin clears the slot.
+  const $skeleton = document.createElement('div');
+  $skeleton.className = 'checkout__adyen-skeleton';
+  ctx.replaceHTML($skeleton);
+
+  // IIFE already running — ctx and skeleton updated, nothing else to do.
+  if (isRenderingAdyen) return;
+  isRenderingAdyen = true;
+
+  // Read OOPE config from availablePaymentMethods — static data set at checkout
+  // initialization, reliable regardless of render timing.
   const checkoutData = events.lastPayload('checkout/initialized');
   const oopeConfig = checkoutData?.availablePaymentMethods
     ?.find((m) => m.code === ADYEN_PAYMENT_CODE)
     ?.oope_payment_method_config;
 
   if (!oopeConfig?.backend_integration_url) {
-    throw new Error(`[Adyen] backend_integration_url missing in oope_payment_method_config for ${ADYEN_PAYMENT_CODE}`);
+    $skeleton.className = 'checkout__adyen-error';
+    $skeleton.textContent = `[Adyen] backend_integration_url missing in oope_payment_method_config for ${ADYEN_PAYMENT_CODE}`;
+    isRenderingAdyen = false;
+    return;
   }
 
   const endpoint = `${oopeConfig.backend_integration_url.replace(/\/$/, '')}/create-session`;
@@ -41,71 +78,111 @@ export default async function renderAdyenGateway(ctx) {
   const clientKey = cfg.client_key;
   const env = (cfg.environment || 'TEST').toLowerCase();
 
-  // Show skeleton immediately — before any async work.
-  const $skeleton = document.createElement('div');
-  $skeleton.className = 'checkout__adyen-skeleton';
-  ctx.replaceHTML($skeleton);
+  // Uses activeCtx so the error always lands in the slot the dropin expects.
+  const showError = (message) => {
+    const $error = document.createElement('div');
+    $error.className = 'checkout__adyen-error';
+    $error.textContent = message || 'Payment could not be processed. Please refresh and try again.';
+    activeCtx.replaceHTML($error);
+  };
 
-  // Load SDK and create session in parallel — safe to call concurrently since
-  // loadAdyenWebSDK deduplicates in-flight requests via a module-level promise.
-  const cartData = events.lastPayload('cart/data') || events.lastPayload('cart/initialized');
+  // Single background async IIFE. Subsequent render() calls only update
+  // activeCtx and show a fresh skeleton; they never start a second IIFE.
+  (async () => {
+    const cartData = events.lastPayload('cart/data') || events.lastPayload('cart/initialized');
 
-  let session;
-  try {
-    [, session] = await Promise.all([
-      loadAdyenWebSDK(env),
-      createAdyenSession(endpoint, {
-        amount: {
-          value: Math.round((cartData?.total?.includingTax?.value || 0) * 100),
-          currency: cartData?.total?.includingTax?.currency || 'USD',
-        },
-        reference: cartData?.id,
-        returnUrl: `${window.location.origin}/checkout`,
-        countryCode: checkoutData?.billingAddress?.country?.code
-          || checkoutData?.shippingAddresses?.[0]?.country?.code
-          || 'US',
-      }),
-    ]);
-  } catch (err) {
-    $skeleton.className = 'checkout__adyen-error';
-    $skeleton.textContent = 'Payment form could not be loaded. Please refresh and try again.';
-    throw err;
-  }
-
-  const $dropin = document.createElement('div');
-  ctx.replaceHTML($dropin);
-
-  const AdyenCheckoutFactory = window.AdyenWeb?.AdyenCheckout ?? window.AdyenCheckout;
-  const DropinComponent = window.AdyenWeb?.Dropin ?? window.Dropin;
-
-  const checkout = await AdyenCheckoutFactory({
-    session: { id: session.id, sessionData: session.sessionData },
-    clientKey,
-    environment: env,
-    onPaymentCompleted: (result) => {
-      resolveAdyenPayment({
-        sessionId: session.id,
-        resultCode: result.resultCode,
-        sessionData: result.sessionData ?? '',
-        sessionResult: result.sessionResult ?? '',
-      });
-    },
-    onPaymentFailed: (result) => {
-      rejectAdyenPayment(`Payment ${result.resultCode}`);
-    },
-    onError: (error) => {
-      rejectAdyenPayment(error.message);
-    },
-  });
-
-  const dropin = new DropinComponent(checkout, { showPayButton: false }).mount($dropin);
-  setDropinInstance(dropin);
-
-  // Clean up when the customer switches to a different payment method.
-  const unsubscribe = events.on('checkout/updated', (data) => {
-    if (data?.selectedPaymentMethod?.code !== ADYEN_PAYMENT_CODE) {
-      clearDropinInstance();
-      unsubscribe.off();
+    let session;
+    try {
+      [, session] = await Promise.all([
+        loadAdyenWebSDK(env),
+        createAdyenSession(endpoint, {
+          amount: {
+            value: Math.round((cartData?.total?.includingTax?.value || 0) * 100),
+            currency: cartData?.total?.includingTax?.currency || 'USD',
+          },
+          reference: cartData?.id,
+          returnUrl: `${window.location.origin}/checkout`,
+          countryCode: checkoutData?.billingAddress?.country?.code
+            || checkoutData?.shippingAddresses?.[0]?.country?.code
+            || 'US',
+        }),
+      ]);
+    } catch (err) {
+      showError('Payment form could not be loaded. Please refresh and try again.');
+      return;
     }
+
+    const AdyenCheckoutFactory = window.AdyenWeb?.AdyenCheckout ?? window.AdyenCheckout;
+    const DropinComponent = window.AdyenWeb?.Dropin ?? window.Dropin;
+
+    let checkout;
+    try {
+      checkout = await AdyenCheckoutFactory({
+        session: { id: session.id, sessionData: session.sessionData },
+        clientKey,
+        environment: env,
+        onPaymentCompleted: (result) => {
+          resolveAdyenPayment({
+            sessionId: session.id,
+            resultCode: result.resultCode,
+            sessionData: result.sessionData ?? '',
+            sessionResult: result.sessionResult ?? '',
+          });
+        },
+        onPaymentFailed: (result) => {
+          rejectAdyenPayment(`Payment ${result.resultCode}`);
+        },
+        onError: (error) => {
+          console.error('[Adyen] onError:', error);
+          rejectAdyenPayment(error.message);
+          showError('Payment could not be processed. Please refresh and try again.');
+        },
+      });
+    } catch (err) {
+      showError('Payment form could not be loaded. Please refresh and try again.');
+      throw err;
+    }
+
+    // Find the skeleton currently in the slot and get its parent — this IS the
+    // slot's DOM container managed by the dropin. We insert $dropin directly into
+    // the parent rather than via ctx.replaceHTML because ctx.replaceHTML goes
+    // through Preact's batched update cycle, which may delay DOM insertion past
+    // the synchronous mount() call, causing the Drop-in to mount into a detached
+    // node. Direct DOM manipulation is synchronous and guaranteed in-document.
+    const $currentSkeleton = document.querySelector('.checkout__adyen-skeleton');
+    const $slotParent = $currentSkeleton?.parentElement;
+
+    if (!$slotParent) {
+      showError('Payment slot not found. Please refresh and try again.');
+      return;
+    }
+
+    // Replace skeleton with the dropin container and mount synchronously.
+    // No await between these operations — the Drop-in claims $dropin before
+    // any Preact reconciliation can run.
+    const $dropin = document.createElement('div');
+    $slotParent.innerHTML = '';
+    $slotParent.appendChild($dropin);
+    const dropin = new DropinComponent(checkout, { showPayButton: false }).mount($dropin);
+
+    // Store the dropin element so render() can re-pass it to ctx.replaceHTML on
+    // subsequent checkout/updated calls, keeping the slot alive.
+    activeDropinEl = $dropin;
+    setDropinInstance(dropin);
+
+    // Clean up when the customer switches to a different payment method.
+    const unsubscribe = events.on('checkout/updated', (data) => {
+      if (data?.selectedPaymentMethod?.code !== ADYEN_PAYMENT_CODE) {
+        clearDropinInstance();
+        activeDropinEl = null;
+        isRenderingAdyen = false;
+        unsubscribe.off();
+      }
+    });
+  })().catch((err) => {
+    showError('Payment form could not be loaded. Please refresh and try again.');
+    console.error('[Adyen]', err);
+  }).finally(() => {
+    isRenderingAdyen = false;
   });
 }

--- a/blocks/commerce-checkout/commerce-checkout.css
+++ b/blocks/commerce-checkout/commerce-checkout.css
@@ -268,3 +268,22 @@
         margin-top: 0;
     }
 }
+
+.checkout__adyen-skeleton {
+    height: 220px;
+    background: #f0f0f0;
+    border-radius: 8px;
+    animation: adyen-pulse 1.5s ease-in-out infinite;
+}
+
+.checkout__adyen-error {
+    padding: 16px;
+    color: var(--color-alert-red, #c00);
+    font-size: 0.875rem;
+}
+
+@keyframes adyen-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+

--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -8,7 +8,6 @@ import { initReCaptcha } from '@dropins/tools/recaptcha.js';
 // Order Dropin Modules
 import * as orderApi from '@dropins/storefront-order/api.js';
 import * as checkoutApi from '@dropins/storefront-checkout/api.js';
-import { ADYEN_PAYMENT_CODE, submitAdyenPayment } from '../adyen-payment/session.js';
 
 // Checkout Dropin Libraries
 import {
@@ -20,6 +19,8 @@ import {
 
 // Payment Services Dropin
 import { PaymentMethodCode } from '@dropins/storefront-payment-services/api.js';
+
+import { ADYEN_PAYMENT_CODE, submitAdyenPayment } from '../adyen-payment/session.js';
 
 // Block Utilities
 import {

--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -7,6 +7,8 @@ import { initReCaptcha } from '@dropins/tools/recaptcha.js';
 
 // Order Dropin Modules
 import * as orderApi from '@dropins/storefront-order/api.js';
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import { ADYEN_PAYMENT_CODE, submitAdyenPayment } from '../adyen-payment/session.js';
 
 // Checkout Dropin Libraries
 import {
@@ -159,6 +161,17 @@ export default async function decorate(block) {
         }
         // Submit Payment Services credit card form
         await creditCardFormRef.current.submit();
+      } else if (code === ADYEN_PAYMENT_CODE) {
+        const result = await submitAdyenPayment();
+        await checkoutApi.setPaymentMethod({
+          code: ADYEN_PAYMENT_CODE,
+          additional_data: [
+            { key: 'sessionId', value: result.sessionId },
+            { key: 'resultCode', value: result.resultCode },
+            { key: 'sessionData', value: result.sessionData },
+            { key: 'sessionResult', value: result.sessionResult },
+          ],
+        });
       }
       // Place order
       await orderApi.placeOrder(cartId);

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -61,6 +61,8 @@ import {
 } from '@dropins/storefront-checkout/lib/utils.js';
 
 import { showModal, swatchImageSlot } from './utils.js';
+import { ADYEN_PAYMENT_CODE } from '../adyen-payment/session.js';
+import renderAdyenGateway from '../adyen-payment/slot.js';
 
 // External dependencies
 import {
@@ -333,7 +335,7 @@ export const renderShippingMethods = async (container) => renderContainer(
 );
 
 /**
- * Renders payment methods with credit card integration - original regular checkout functionality
+ * Renders payment methods with credit card integration and Adyen OOPE Drop-in
  * @param {HTMLElement} container - DOM element to render payment methods in
  * @param {Object} creditCardFormRef - React-style ref for credit card form
  * @returns {Promise<Object>} - The rendered payment methods component
@@ -372,6 +374,9 @@ export const renderPaymentMethods = async (container, creditCardFormRef) => rend
         },
         [PaymentMethodCode.FASTLANE]: {
           enabled: false,
+        },
+        [ADYEN_PAYMENT_CODE]: {
+          render: renderAdyenGateway,
         },
       },
     },

--- a/build.mjs
+++ b/build.mjs
@@ -12,10 +12,33 @@ overrideGQLOperations([
     skipFragments: ['DOWNLOADABLE_ORDER_ITEMS_FRAGMENT'],
     operations: [],
   },
-  // {
-  //   npm: '@dropins/storefront-checkout',
-  //   operations: [],
-  // },
+  {
+    npm: '@dropins/storefront-checkout',
+    operations: [
+      `
+      fragment AVAILABLE_PAYMENT_METHOD_FRAGMENT on AvailablePaymentMethod {
+        oope_payment_method_config {
+          backend_integration_url
+          custom_config {
+            key
+            value
+          }
+        }
+      }
+      `,
+      `
+      fragment SELECTED_PAYMENT_METHOD_FRAGMENT on SelectedPaymentMethod {
+        oope_payment_method_config {
+          backend_integration_url
+          custom_config {
+            key
+            value
+          }
+        }
+      }
+      `,
+    ],
+  },
   // {
   //   npm: '@dropins/storefront-pdp',
   //   operations: [

--- a/head.html
+++ b/head.html
@@ -4,11 +4,24 @@
   move-to-http-header="true"
 >
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+<link rel="preconnect" href="https://checkoutshopper-test.adyen.com" crossorigin />
+<link rel="dns-prefetch" href="https://checkoutshopper-test.adyen.com" />
+<link rel="preconnect" href="https://checkoutshopper-live.adyen.com" crossorigin />
+<link rel="dns-prefetch" href="https://checkoutshopper-live.adyen.com" />
+
+
 <script nonce="aem" type="speculationrules">
     {
         "prerender": [{
             "where": {
-                "href_matches": "/*"
+                "and": [
+                    { "href_matches": "/*" },
+                    { "not": { "href_matches": "/checkout*" } },
+                    { "not": { "href_matches": "/cart*" } },
+                    { "not": { "href_matches": "/customer/*" } },
+                    { "not": { "href_matches": "/order*" } }
+                ]
             },
             "eagerness": "moderate"
         }]

--- a/scripts/__dropins__/storefront-checkout/fragments.original.js
+++ b/scripts/__dropins__/storefront-checkout/fragments.original.js
@@ -1,4 +1,6 @@
-const n = `
+/*! Copyright 2026 Adobe
+All Rights Reserved. */
+const n=`
   fragment ESTIMATE_SHIPPING_METHOD_FRAGMENT on AvailableShippingMethod {
     amount {
       currency
@@ -19,7 +21,7 @@ const n = `
       currency
     }
   }
-`, e = `
+`,e=`
   fragment AVAILABLE_SHIPPING_METHOD_FRAGMENT on AvailableShippingMethod {
     amount {
       currency
@@ -39,7 +41,7 @@ const n = `
       currency
     }
   }
-`, _ = `
+`,_=`
   fragment SELECTED_SHIPPING_METHOD_FRAGMENT on SelectedShippingMethod {
     amount {
       currency
@@ -58,7 +60,7 @@ const n = `
       currency
     }
   }
-`, E = `
+`,E=`
   fragment BILLING_CART_ADDRESS_FRAGMENT on BillingCartAddress {
     city
     company
@@ -90,7 +92,7 @@ const n = `
     uid
     vat_id
   }
-`, i = `
+`,i=`
   fragment SHIPPING_CART_ADDRESS_FRAGMENT on ShippingCartAddress {
     available_shipping_methods {
       ...AVAILABLE_SHIPPING_METHOD_FRAGMENT
@@ -132,28 +134,18 @@ const n = `
 
   ${e}
   ${_}
-`, t = `fragment AVAILABLE_PAYMENT_METHOD_FRAGMENT on AvailablePaymentMethod {
-  code
-  title
-  oope_payment_method_config {
-    backend_integration_url
-    custom_config {
-      key
-      value
-    }
+`,t=`
+  fragment AVAILABLE_PAYMENT_METHOD_FRAGMENT on AvailablePaymentMethod {
+    code
+    title
   }
-}`, a = (`fragment SELECTED_PAYMENT_METHOD_FRAGMENT on SelectedPaymentMethod {
-  code
-  title
-  purchase_order_number
-  oope_payment_method_config {
-    backend_integration_url
-    custom_config {
-      key
-      value
-    }
+`,a=`
+  fragment SELECTED_PAYMENT_METHOD_FRAGMENT on SelectedPaymentMethod {
+    code
+    title
+    purchase_order_number
   }
-}`), A = `
+`,A=`
   fragment CHECKOUT_DATA_FRAGMENT on Cart {
     id
     is_virtual
@@ -177,13 +169,13 @@ const n = `
   ${i}
   ${t}
   ${a}
-`, l = `
+`,l=`
   fragment CUSTOMER_FRAGMENT on Customer {
     firstname
     lastname
     email
   }
-`, o = `
+`,o=`
   fragment NEGOTIABLE_QUOTE_BILLING_ADDRESS_FRAGMENT on NegotiableQuoteBillingAddress {
     city
     company
@@ -215,7 +207,7 @@ const n = `
     uid
     vat_id
   }
-`, r = `
+`,r=`
   fragment NEGOTIABLE_QUOTE_SHIPPING_ADDRESS_FRAGMENT on NegotiableQuoteShippingAddress {
     available_shipping_methods {
       ...AVAILABLE_SHIPPING_METHOD_FRAGMENT
@@ -256,7 +248,7 @@ const n = `
 
   ${e}
   ${_}
-`, T = `
+`,T=`
   fragment NEGOTIABLE_QUOTE_FRAGMENT on NegotiableQuote {
     available_payment_methods {
       ...AVAILABLE_PAYMENT_METHOD_FRAGMENT
@@ -282,18 +274,5 @@ const n = `
   ${r}
   ${t}
   ${a}
-`;
-export {
-t as AVAILABLE_PAYMENT_METHOD_FRAGMENT,
-e as AVAILABLE_SHIPPING_METHOD_FRAGMENT,
-E as BILLING_CART_ADDRESS_FRAGMENT,
-A as CHECKOUT_DATA_FRAGMENT,
-l as CUSTOMER_FRAGMENT,
-n as ESTIMATE_SHIPPING_METHOD_FRAGMENT,
-o as NEGOTIABLE_QUOTE_BILLING_ADDRESS_FRAGMENT,
-T as NEGOTIABLE_QUOTE_FRAGMENT,
-r as NEGOTIABLE_QUOTE_SHIPPING_ADDRESS_FRAGMENT,
-a as SELECTED_PAYMENT_METHOD_FRAGMENT,
-_ as SELECTED_SHIPPING_METHOD_FRAGMENT,
-i as SHIPPING_CART_ADDRESS_FRAGMENT
-};
+`;export{t as AVAILABLE_PAYMENT_METHOD_FRAGMENT,e as AVAILABLE_SHIPPING_METHOD_FRAGMENT,E as BILLING_CART_ADDRESS_FRAGMENT,A as CHECKOUT_DATA_FRAGMENT,l as CUSTOMER_FRAGMENT,n as ESTIMATE_SHIPPING_METHOD_FRAGMENT,o as NEGOTIABLE_QUOTE_BILLING_ADDRESS_FRAGMENT,T as NEGOTIABLE_QUOTE_FRAGMENT,r as NEGOTIABLE_QUOTE_SHIPPING_ADDRESS_FRAGMENT,a as SELECTED_PAYMENT_METHOD_FRAGMENT,_ as SELECTED_SHIPPING_METHOD_FRAGMENT,i as SHIPPING_CART_ADDRESS_FRAGMENT};
+//# sourceMappingURL=fragments.js.map

--- a/scripts/initializers/checkout.js
+++ b/scripts/initializers/checkout.js
@@ -28,7 +28,10 @@ await initializeDropin(async () => {
           const methods = data?.available_payment_methods ?? [];
           return {
             // eslint-disable-next-line camelcase
-            availablePaymentMethods: methods.map(({ oope_payment_method_config: _, ...rest }) => rest),
+            availablePaymentMethods: methods.map(
+              // eslint-disable-next-line camelcase
+              ({ oope_payment_method_config: _, ...rest }) => rest,
+            ),
             oopePaymentMethodConfigs: Object.fromEntries(
               // eslint-disable-next-line camelcase
               methods.map(({ code, oope_payment_method_config: cfg }) => [code, cfg]),

--- a/scripts/initializers/checkout.js
+++ b/scripts/initializers/checkout.js
@@ -27,13 +27,11 @@ await initializeDropin(async () => {
         transformer: (data) => {
           const methods = data?.available_payment_methods ?? [];
           return {
-            availablePaymentMethods: methods.map(
-              // eslint-disable-next-line camelcase
-              ({ oope_payment_method_config, ...rest }) => rest,
-            ),
+            // eslint-disable-next-line camelcase
+            availablePaymentMethods: methods.map(({ oope_payment_method_config: _, ...rest }) => rest),
             oopePaymentMethodConfigs: Object.fromEntries(
               // eslint-disable-next-line camelcase
-              methods.map(({ code, oope_payment_method_config }) => [code, oope_payment_method_config]),
+              methods.map(({ code, oope_payment_method_config: cfg }) => [code, cfg]),
             ),
           };
         },

--- a/scripts/initializers/checkout.js
+++ b/scripts/initializers/checkout.js
@@ -20,10 +20,23 @@ await initializeDropin(async () => {
     langDefinitions,
     models: {
       CartModel: {
-        transformer: (data) => ({
-          availablePaymentMethods: data?.available_payment_methods,
-          selectedPaymentMethod: data?.selected_payment_method,
-        }),
+        // Strip oope_payment_method_config from payment method objects — if left
+        // in, the dropin's input transformer passes it to setPaymentMethodOnCart
+        // which the Commerce schema rejects (not a field of PaymentMethodInput).
+        // Expose it separately as oopePaymentMethodConfigs for the Adyen slot.
+        transformer: (data) => {
+          const methods = data?.available_payment_methods ?? [];
+          return {
+            availablePaymentMethods: methods.map(
+              // eslint-disable-next-line camelcase
+              ({ oope_payment_method_config, ...rest }) => rest,
+            ),
+            oopePaymentMethodConfigs: Object.fromEntries(
+              // eslint-disable-next-line camelcase
+              methods.map(({ code, oope_payment_method_config }) => [code, oope_payment_method_config]),
+            ),
+          };
+        },
       },
     },
   });

--- a/scripts/initializers/checkout.js
+++ b/scripts/initializers/checkout.js
@@ -15,6 +15,16 @@ await initializeDropin(async () => {
     },
   };
 
-  // Initialize checkout
-  return initializers.mountImmediately(initialize, { langDefinitions });
+  // Initialize checkout — expose OOPE payment method config to dropin event payloads
+  return initializers.mountImmediately(initialize, {
+    langDefinitions,
+    models: {
+      CartModel: {
+        transformer: (data) => ({
+          availablePaymentMethods: data?.available_payment_methods,
+          selectedPaymentMethod: data?.selected_payment_method,
+        }),
+      },
+    },
+  });
 })();


### PR DESCRIPTION
Test URLs:
- Before: https://pay-by-link--aem-boilerplate-commerce--hlxsites.aem.page/checkout
- After: https://accs-1118-checkout--aem-boilerplate-commerce--hlxsites.aem.page/checkout

### Summary
- Integrates Adyen Drop-in as an OOPE payment method (adyen_gateway) in the EDS storefront checkout using the Adyen Sessions API flow
- All Adyen configuration (client_key, environment, backend_integration_url) is sourced from oope_payment_method_config registered in Commerce via payment-methods.yaml — no client-side config files
Flow

Place Order click
  → submitAdyenPayment()       # triggers Drop-in submit()
  → onPaymentCompleted         # resolves with { sessionId, resultCode, sessionData, sessionResult }
  → checkoutApi.setPaymentMethod(adyen_gateway, [...additional_data])
  → orderApi.placeOrder(cartId)
  → App Builder validate-payment webhook confirms session with Adyen

- The checkout flow is following the example in https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/add-payment-method/