### PR TITLE
ACCS-877: Pay By Link success redirect & confirmation page (/pay/confirmation)

### DIFF
--- a/blocks/commerce-pay-by-link-confirmation/README.md
+++ b/blocks/commerce-pay-by-link-confirmation/README.md
@@ -1,6 +1,6 @@
 # Commerce Pay By Link Confirmation
 
-Standalone EDS page block that hosts the Pay By Link post-payment confirmation surface. Drop the block onto an authored page at `/pay/confirmation`. The block reads `?order=<order_number>` from the URL, optionally consumes a full order object from `window.history.state.orderData`, and renders either the complete order summary (via the `storefront-order` dropin) or a degraded "thank you" view when state is not available.
+Standalone EDS page block that hosts the Pay By Link post-payment confirmation surface. Drop the block onto an authored page at `/pay/confirmation`. The block reads `?order=<order_number>` from the URL, optionally consumes a full order object from `window.history.state.orderData`, and renders either the complete order summary (via the `storefront-order` dropin) or a thank-you "thank you" view when state is not available.
 
 ## Authored content
 
@@ -41,13 +41,13 @@ window.history.pushState(
 
 `orderData` must be the shape `payByLinkOrder` returns — the `storefront-order` dropin's `orderApi.initialize({ orderData })` consumes it directly.
 
-When `history.state.orderData` is absent (refresh, direct nav, email link), the block falls through to a degraded thank-you view rendered from the URL's `order_number` alone. The customer's confirmation email is the durable record.
+When `history.state.orderData` is absent (refresh, direct nav, email link), the block falls through to a thank-you thank-you view rendered from the URL's `order_number` alone. The customer's confirmation email is the durable record.
 
 ## Events
 
 ### Event Emitters
 
-- `events.emit('pay-by-link/confirmation', { orderNumber })` — fires once per page load whenever `?order` is a structurally valid order number, before the block decides between the full-summary and degraded views. Subscribers (e.g. analytics, ACCS-878) should treat this as a "confirmation page rendered for order X" signal. Not emitted when `?order` is missing or malformed.
+- `events.emit('pay-by-link/confirmation', { orderNumber })` — fires once per page load whenever `?order` is a structurally valid order number, before the block decides between the full-summary and thank-you views. Subscribers (e.g. analytics, ACCS-878) should treat this as a "confirmation page rendered for order X" signal. Not emitted when `?order` is missing or malformed.
 
 Payload:
 
@@ -77,10 +77,10 @@ The block reads i18n strings via `fetchPlaceholders()` (no path argument), which
 
 | Key | Used for |
 | --- | --- |
-| `PayByLinkConfirmation.DegradedTitle` | Heading on the degraded view |
-| `PayByLinkConfirmation.DegradedBody` | Body copy on the degraded view |
+| `PayByLinkConfirmation.ThankYouTitle` | Heading on the thank-you view |
+| `PayByLinkConfirmation.ThankYouBody` | Body copy on the thank-you view |
 | `PayByLinkConfirmation.OrderNumberLabel` | Label preceding the order number |
-| `PayByLinkConfirmation.ContinueShoppingLabel` | CTA label on the degraded view |
+| `PayByLinkConfirmation.ContinueShoppingLabel` | CTA label on the thank-you view |
 | `PayByLinkConfirmation.ErrorMissingOrderTitle` | Heading when `?order` is missing |
 | `PayByLinkConfirmation.ErrorMissingOrderBody` | Body when `?order` is missing |
 | `PayByLinkConfirmation.ErrorMalformedOrderTitle` | Heading when `?order` fails format validation |

--- a/blocks/commerce-pay-by-link-confirmation/README.md
+++ b/blocks/commerce-pay-by-link-confirmation/README.md
@@ -1,0 +1,90 @@
+# Commerce Pay By Link Confirmation
+
+Standalone EDS page block that hosts the Pay By Link post-payment confirmation surface. Drop the block onto an authored page at `/pay/confirmation`. The block reads `?order=<order_number>` from the URL, optionally consumes a full order object from `window.history.state.orderData`, and renders either the complete order summary (via the `storefront-order` dropin) or a degraded "thank you" view when state is not available.
+
+## Authored content
+
+The block takes no authored content. Drop it onto the `/pay/confirmation` page with no children; everything visible is rendered by the block.
+
+## Required page metadata
+
+The authored `/pay/confirmation` document needs the following metadata:
+
+| Metadata | Value | Effect |
+| --- | --- | --- |
+| `robots` | `noindex,nofollow` | Confirmation URLs are per-order and should not be indexed. |
+| `placeholders` | path to the shared PBL placeholders sheet | The block calls `fetchPlaceholders()` with no path, so this metadata is the single source of truth. |
+
+## URL contract
+
+- `/pay/confirmation?order=<order_number>` → renders the confirmation page.
+- `/pay/confirmation` (no `order`) → renders the "missing order" error state.
+- `/pay/confirmation?order=<anything failing the format check>` → renders the "malformed order" error state.
+
+Accepted `order_number` format: `^[A-Za-z0-9_-]{4,32}$`.
+
+## Authentication
+
+This page does **not** auth-check the visitor. The PBL flow is token-only and by the time the customer reaches this page the token has been consumed at payment time. Do not add `checkIsAuthenticated` guards here.
+
+## history.state handoff
+
+To render the full order summary without a refetch, the upstream payment-success callback must push the order into `history.state` before navigating:
+
+```js
+window.history.pushState(
+  { orderData },
+  '',
+  `/pay/confirmation?order=${encodeURIComponent(orderData.number)}`,
+);
+```
+
+`orderData` must be the shape `payByLinkOrder` returns — the `storefront-order` dropin's `orderApi.initialize({ orderData })` consumes it directly.
+
+When `history.state.orderData` is absent (refresh, direct nav, email link), the block falls through to a degraded thank-you view rendered from the URL's `order_number` alone. The customer's confirmation email is the durable record.
+
+## Events
+
+### Event Emitters
+
+- `events.emit('pay-by-link/confirmation', { orderNumber })` — fires once per page load whenever `?order` is a structurally valid order number, before the block decides between the full-summary and degraded views. Subscribers (e.g. analytics, ACCS-878) should treat this as a "confirmation page rendered for order X" signal. Not emitted when `?order` is missing or malformed.
+
+Payload:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `orderNumber` | `string` | The validated order number from the URL (matches `^[A-Za-z0-9_-]{4,32}$`). |
+
+The event is emitted synchronously during the block's `decorate` and only fires once per page load — subscribers must be registered before the block decorates (e.g. in an EDS initializer or in `scripts.js`). Late subscribers will miss the emit on the current page.
+
+Example subscriber:
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.on('pay-by-link/confirmation', ({ orderNumber }) => {
+  // forward to your analytics layer, e.g. window.adobeDataLayer.push(...)
+});
+```
+
+### Event Listeners
+
+This block does not subscribe to any events.
+
+## Placeholders
+
+The block reads i18n strings via `fetchPlaceholders()` (no path argument), which resolves the sheet declared in the page's `<meta name="placeholders">` metadata. All keys are under the `PayByLinkConfirmation.*` namespace.
+
+| Key | Used for |
+| --- | --- |
+| `PayByLinkConfirmation.DegradedTitle` | Heading on the degraded view |
+| `PayByLinkConfirmation.DegradedBody` | Body copy on the degraded view |
+| `PayByLinkConfirmation.OrderNumberLabel` | Label preceding the order number |
+| `PayByLinkConfirmation.ContinueShoppingLabel` | CTA label on the degraded view |
+| `PayByLinkConfirmation.ErrorMissingOrderTitle` | Heading when `?order` is missing |
+| `PayByLinkConfirmation.ErrorMissingOrderBody` | Body when `?order` is missing |
+| `PayByLinkConfirmation.ErrorMalformedOrderTitle` | Heading when `?order` fails format validation |
+| `PayByLinkConfirmation.ErrorMalformedOrderBody` | Body when `?order` fails format validation |
+| `PayByLinkConfirmation.ErrorContinueShoppingLabel` | CTA label on the error card |
+
+Strings consumed by the dropin containers (OrderHeader, OrderStatus, CustomerDetails, OrderCostSummary, OrderProductList) are passed through `langDefinitions` and follow the dropin's own placeholder keys.

--- a/blocks/commerce-pay-by-link-confirmation/_commerce-pay-by-link-confirmation.json
+++ b/blocks/commerce-pay-by-link-confirmation/_commerce-pay-by-link-confirmation.json
@@ -1,0 +1,15 @@
+{
+  "definitions": [{
+    "title": "Commerce Pay By Link Confirmation",
+    "id": "commerce-pay-by-link-confirmation",
+    "model": "commerce-pay-by-link-confirmation",
+    "plugins": {
+      "da": {
+        "rows": 1,
+        "columns": 2
+      }
+    }
+  }],
+  "models": [],
+  "filters": []
+}

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.css
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.css
@@ -92,7 +92,6 @@
 @media (min-width: 900px) {
   .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) {
     grid-template-columns: repeat(var(--grid-4-columns), 1fr);
-    grid-template-areas: 'main aside';
     column-gap: var(--grid-4-gutters);
     padding-top: var(--spacing-xxlarge);
   }

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.css
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.css
@@ -20,7 +20,7 @@
 /* --- Error state (missing or malformed order_number) --- */
 
 .pay-by-link-confirmation.pay-by-link-confirmation--error,
-.pay-by-link-confirmation.pay-by-link-confirmation--degraded {
+.pay-by-link-confirmation.pay-by-link-confirmation--thank-you {
   min-height: 60vh;
   align-content: center;
   justify-items: center;
@@ -29,7 +29,7 @@
 }
 
 .pay-by-link-confirmation .pay-by-link-confirmation__error-card,
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-card {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-card {
   width: 100%;
   max-width: 520px;
   display: grid;
@@ -38,7 +38,7 @@
 }
 
 .pay-by-link-confirmation .pay-by-link-confirmation__error-title,
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-title {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-title {
   margin: 0;
   font: var(--type-headline-2-strong-font);
   letter-spacing: var(--type-headline-2-strong-letter-spacing);
@@ -47,21 +47,21 @@
 }
 
 .pay-by-link-confirmation .pay-by-link-confirmation__error-title:focus-visible,
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-title:focus-visible {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-title:focus-visible {
   outline: var(--shape-border-width-3) solid var(--color-brand-500);
   outline-offset: 4px;
   border-radius: var(--shape-border-radius-2);
 }
 
 .pay-by-link-confirmation .pay-by-link-confirmation__error-body,
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-body {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-body {
   margin: 0;
   font: var(--type-body-1-default-font);
   letter-spacing: var(--type-body-1-default-letter-spacing);
   color: var(--color-neutral-700);
 }
 
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-order-number {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-order-number {
   margin: 0;
   font: var(--type-body-1-default-font);
   letter-spacing: var(--type-body-1-default-letter-spacing);
@@ -70,18 +70,18 @@
   row-gap: var(--spacing-xxsmall);
 }
 
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-order-number-label {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-order-number-label {
   color: var(--color-neutral-700);
 }
 
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-order-number-value {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-order-number-value {
   font: var(--type-headline-3-strong-font);
   letter-spacing: var(--type-headline-3-strong-letter-spacing);
   color: var(--color-neutral-900);
 }
 
 .pay-by-link-confirmation .pay-by-link-confirmation__error-cta,
-.pay-by-link-confirmation .pay-by-link-confirmation__degraded-cta {
+.pay-by-link-confirmation .pay-by-link-confirmation__thank-you-cta {
   display: flex;
   justify-content: center;
   margin-top: var(--spacing-small);
@@ -90,17 +90,17 @@
 /* --- Full summary layout (desktop) --- */
 
 @media (min-width: 900px) {
-  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) {
+  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--thank-you) {
     grid-template-columns: repeat(var(--grid-4-columns), 1fr);
     column-gap: var(--grid-4-gutters);
     padding-top: var(--spacing-xxlarge);
   }
 
-  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) .pay-by-link-confirmation__main {
+  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--thank-you) .pay-by-link-confirmation__main {
     grid-column: 1 / span 7;
   }
 
-  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) .pay-by-link-confirmation__aside {
+  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--thank-you) .pay-by-link-confirmation__aside {
     grid-column: 9 / span 4;
   }
 }

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.css
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.css
@@ -1,0 +1,107 @@
+/* stylelint-disable selector-class-pattern */
+
+.pay-by-link-confirmation {
+  display: grid;
+  row-gap: var(--spacing-big);
+  padding-top: var(--spacing-medium);
+  margin-bottom: var(--spacing-xbig);
+}
+
+.pay-by-link-confirmation__main,
+.pay-by-link-confirmation__aside {
+  display: grid;
+  row-gap: var(--spacing-big);
+}
+
+.pay-by-link-confirmation__block:empty {
+  display: none;
+}
+
+/* --- Error state (missing or malformed order_number) --- */
+
+.pay-by-link-confirmation.pay-by-link-confirmation--error,
+.pay-by-link-confirmation.pay-by-link-confirmation--degraded {
+  min-height: 60vh;
+  align-content: center;
+  justify-items: center;
+  padding-left: var(--spacing-small);
+  padding-right: var(--spacing-small);
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__error-card,
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-card {
+  width: 100%;
+  max-width: 520px;
+  display: grid;
+  row-gap: var(--spacing-medium);
+  text-align: center;
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__error-title,
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-title {
+  margin: 0;
+  font: var(--type-headline-2-strong-font);
+  letter-spacing: var(--type-headline-2-strong-letter-spacing);
+  color: var(--color-neutral-900);
+  outline: none;
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__error-title:focus-visible,
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-title:focus-visible {
+  outline: var(--shape-border-width-3) solid var(--color-brand-500);
+  outline-offset: 4px;
+  border-radius: var(--shape-border-radius-2);
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__error-body,
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-body {
+  margin: 0;
+  font: var(--type-body-1-default-font);
+  letter-spacing: var(--type-body-1-default-letter-spacing);
+  color: var(--color-neutral-700);
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-order-number {
+  margin: 0;
+  font: var(--type-body-1-default-font);
+  letter-spacing: var(--type-body-1-default-letter-spacing);
+  color: var(--color-neutral-900);
+  display: grid;
+  row-gap: var(--spacing-xxsmall);
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-order-number-label {
+  color: var(--color-neutral-700);
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-order-number-value {
+  font: var(--type-headline-3-strong-font);
+  letter-spacing: var(--type-headline-3-strong-letter-spacing);
+  color: var(--color-neutral-900);
+}
+
+.pay-by-link-confirmation .pay-by-link-confirmation__error-cta,
+.pay-by-link-confirmation .pay-by-link-confirmation__degraded-cta {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-small);
+}
+
+/* --- Full summary layout (desktop) --- */
+
+@media (min-width: 900px) {
+  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) {
+    grid-template-columns: repeat(var(--grid-4-columns), 1fr);
+    grid-template-areas: 'main aside';
+    column-gap: var(--grid-4-gutters);
+    padding-top: var(--spacing-xxlarge);
+  }
+
+  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) .pay-by-link-confirmation__main {
+    grid-column: 1 / span 7;
+  }
+
+  .pay-by-link-confirmation:not(.pay-by-link-confirmation--error, .pay-by-link-confirmation--degraded) .pay-by-link-confirmation__aside {
+    grid-column: 9 / span 4;
+  }
+}

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
@@ -36,9 +36,10 @@ function consumeOrderDataFromHistory(expectedOrderNumber) {
   const { state } = window.history;
   const orderData = state && typeof state === 'object' ? state.orderData : undefined;
   if (!orderData) return null;
-  if (expectedOrderNumber && orderData.number && orderData.number !== expectedOrderNumber) {
-    return null;
-  }
+  // The URL's order_number is the ground truth. orderData must carry the same
+  // number; anything else is mismatched navigation or tampered state, in which
+  // case we fall back to the degraded view.
+  if (orderData.number !== expectedOrderNumber) return null;
   return orderData;
 }
 
@@ -159,8 +160,16 @@ export default async function decorate(block) {
   const labels = await fetchPlaceholders();
 
   if (orderData) {
-    await renderFullSummary(block, orderData, labels);
-    return;
+    try {
+      await renderFullSummary(block, orderData, labels);
+      return;
+    } catch (e) {
+      // orderData shape didn't satisfy the dropin (initialize or a container
+      // render threw). Fall back to degraded — a customer who has already paid
+      // should never see a broken page.
+      // eslint-disable-next-line no-console
+      console.error('Pay By Link confirmation: full-summary render failed, falling back to degraded.', e);
+    }
   }
 
   renderDegraded(block, result.orderNumber, labels);

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
@@ -38,7 +38,7 @@ function consumeOrderDataFromHistory(expectedOrderNumber) {
   if (!orderData) return null;
   // The URL's order_number is the ground truth. orderData must carry the same
   // number; anything else is mismatched navigation or tampered state, in which
-  // case we fall back to the degraded view.
+  // case we fall back to the thank-you view.
   if (orderData.number !== expectedOrderNumber) return null;
   return orderData;
 }
@@ -74,29 +74,32 @@ function renderError(block, kind, labels) {
   }, 0);
 }
 
-// Degraded view: we know an order_number but have no order data to render
-// containers against. Happens on refresh / direct nav / link from email.
-function renderDegraded(block, orderNumber, labels) {
+// Successful payment, leaner view: the order_number is known but we don't have
+// the order object needed to mount the storefront-order containers (e.g.
+// refresh, direct nav, link from email dropped the history.state handoff).
+// Renders thank-you + order number + CTA — the confirmation email is the
+// durable record of the full transaction.
+function renderThankYou(block, orderNumber, labels) {
   const ns = labels?.PayByLinkConfirmation || {};
 
   block.innerHTML = `
-    <div class="pay-by-link-confirmation pay-by-link-confirmation--degraded">
-      <div class="pay-by-link-confirmation__degraded-card">
-        <h1 class="pay-by-link-confirmation__degraded-title" tabindex="-1"></h1>
-        <p class="pay-by-link-confirmation__degraded-order-number">
-          <span class="pay-by-link-confirmation__degraded-order-number-label"></span>
-          <strong class="pay-by-link-confirmation__degraded-order-number-value" data-testid="pay-by-link-confirmation-order-number"></strong>
+    <div class="pay-by-link-confirmation pay-by-link-confirmation--thank-you">
+      <div class="pay-by-link-confirmation__thank-you-card">
+        <h1 class="pay-by-link-confirmation__thank-you-title" tabindex="-1"></h1>
+        <p class="pay-by-link-confirmation__thank-you-order-number">
+          <span class="pay-by-link-confirmation__thank-you-order-number-label"></span>
+          <strong class="pay-by-link-confirmation__thank-you-order-number-value" data-testid="pay-by-link-confirmation-order-number"></strong>
         </p>
-        <p class="pay-by-link-confirmation__degraded-body"></p>
-        <div class="pay-by-link-confirmation__degraded-cta"></div>
+        <p class="pay-by-link-confirmation__thank-you-body"></p>
+        <div class="pay-by-link-confirmation__thank-you-cta"></div>
       </div>
     </div>
   `;
 
-  block.querySelector('.pay-by-link-confirmation__degraded-title').textContent = ns.DegradedTitle || '';
-  block.querySelector('.pay-by-link-confirmation__degraded-order-number-label').textContent = ns.OrderNumberLabel || '';
-  block.querySelector('.pay-by-link-confirmation__degraded-order-number-value').textContent = orderNumber;
-  block.querySelector('.pay-by-link-confirmation__degraded-body').textContent = ns.DegradedBody || '';
+  block.querySelector('.pay-by-link-confirmation__thank-you-title').textContent = ns.ThankYouTitle || '';
+  block.querySelector('.pay-by-link-confirmation__thank-you-order-number-label').textContent = ns.OrderNumberLabel || '';
+  block.querySelector('.pay-by-link-confirmation__thank-you-order-number-value').textContent = orderNumber;
+  block.querySelector('.pay-by-link-confirmation__thank-you-body').textContent = ns.ThankYouBody || '';
 
   UI.render(Button, {
     children: ns.ContinueShoppingLabel || '',
@@ -104,10 +107,10 @@ function renderDegraded(block, orderNumber, labels) {
     size: 'medium',
     href: rootLink('/'),
     'data-testid': 'pay-by-link-confirmation-continue-cta',
-  })(block.querySelector('.pay-by-link-confirmation__degraded-cta'));
+  })(block.querySelector('.pay-by-link-confirmation__thank-you-cta'));
 
   setTimeout(() => {
-    block.querySelector('.pay-by-link-confirmation__degraded-title')?.focus();
+    block.querySelector('.pay-by-link-confirmation__thank-you-title')?.focus();
   }, 0);
 }
 
@@ -168,12 +171,12 @@ export default async function decorate(block) {
       return;
     } catch (e) {
       // orderData shape didn't satisfy the dropin (initialize or a container
-      // render threw). Fall back to degraded — a customer who has already paid
+      // render threw). Fall back to thank-you — a customer who has already paid
       // should never see a broken page.
       // eslint-disable-next-line no-console
-      console.error('Pay By Link confirmation: full-summary render failed, falling back to degraded.', e);
+      console.error('Pay By Link confirmation: full-summary render failed, falling back to thank-you.', e);
     }
   }
 
-  renderDegraded(block, result.orderNumber, labels);
+  renderThankYou(block, result.orderNumber, labels);
 }

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
@@ -69,8 +69,9 @@ function renderError(block, kind, labels) {
     href: rootLink('/'),
     'data-testid': 'pay-by-link-confirmation-error-cta',
   })(block.querySelector('.pay-by-link-confirmation__error-cta'));
-
-  block.querySelector('.pay-by-link-confirmation__error-title').focus();
+  setTimeout(() => {
+    block.querySelector('.pay-by-link-confirmation__error-title')?.focus();
+  }, 0);
 }
 
 // Degraded view: we know an order_number but have no order data to render
@@ -105,7 +106,9 @@ function renderDegraded(block, orderNumber, labels) {
     'data-testid': 'pay-by-link-confirmation-continue-cta',
   })(block.querySelector('.pay-by-link-confirmation__degraded-cta'));
 
-  block.querySelector('.pay-by-link-confirmation__degraded-title').focus();
+  setTimeout(() => {
+    block.querySelector('.pay-by-link-confirmation__degraded-title')?.focus();
+  }, 0);
 }
 
 async function renderFullSummary(block, orderData, labels) {

--- a/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
+++ b/blocks/commerce-pay-by-link-confirmation/commerce-pay-by-link-confirmation.js
@@ -1,0 +1,167 @@
+/* eslint-disable import/no-unresolved */
+
+import { Button, provider as UI } from '@dropins/tools/components.js';
+import { initializers } from '@dropins/tools/initializer.js';
+import { events } from '@dropins/tools/event-bus.js';
+
+import * as orderApi from '@dropins/storefront-order/api.js';
+import { render as OrderProvider } from '@dropins/storefront-order/render.js';
+import OrderHeader from '@dropins/storefront-order/containers/OrderHeader.js';
+import OrderStatus from '@dropins/storefront-order/containers/OrderStatus.js';
+import CustomerDetails from '@dropins/storefront-order/containers/CustomerDetails.js';
+import OrderCostSummary from '@dropins/storefront-order/containers/OrderCostSummary.js';
+import OrderProductList from '@dropins/storefront-order/containers/OrderProductList.js';
+
+import { fetchPlaceholders, rootLink } from '../../scripts/commerce.js';
+
+import '../../scripts/initializers/order.js';
+
+// Order numbers are alphanumeric (with -/_ allowed). Keep the bound permissive
+// enough for any backend format but tight enough to reject URL garbage.
+export const ORDER_NUMBER_REGEX = /^[A-Za-z0-9_-]{4,32}$/;
+
+export function extractOrderNumber(search) {
+  const raw = new URLSearchParams(search).get('order');
+  if (raw === null) return { status: 'missing' };
+  const orderNumber = raw.trim();
+  if (orderNumber === '') return { status: 'missing' };
+  if (!ORDER_NUMBER_REGEX.test(orderNumber)) return { status: 'malformed' };
+  return { status: 'valid', orderNumber };
+}
+
+// /pay block hands us the full order via history.state on a successful
+// payment. The dropin's orderApi.initialize accepts the same shape that
+// payByLinkOrder returns, so no transformation is needed — we just forward it.
+function consumeOrderDataFromHistory(expectedOrderNumber) {
+  const { state } = window.history;
+  const orderData = state && typeof state === 'object' ? state.orderData : undefined;
+  if (!orderData) return null;
+  if (expectedOrderNumber && orderData.number && orderData.number !== expectedOrderNumber) {
+    return null;
+  }
+  return orderData;
+}
+
+function renderError(block, kind, labels) {
+  const ns = labels?.PayByLinkConfirmation || {};
+  const isMissing = kind === 'missing';
+  const title = isMissing ? ns.ErrorMissingOrderTitle : ns.ErrorMalformedOrderTitle;
+  const body = isMissing ? ns.ErrorMissingOrderBody : ns.ErrorMalformedOrderBody;
+
+  block.innerHTML = `
+    <div class="pay-by-link-confirmation pay-by-link-confirmation--error">
+      <div class="pay-by-link-confirmation__error-card" role="alert" aria-live="assertive">
+        <h1 class="pay-by-link-confirmation__error-title" tabindex="-1"></h1>
+        <p class="pay-by-link-confirmation__error-body"></p>
+        <div class="pay-by-link-confirmation__error-cta"></div>
+      </div>
+    </div>
+  `;
+
+  block.querySelector('.pay-by-link-confirmation__error-title').textContent = title || '';
+  block.querySelector('.pay-by-link-confirmation__error-body').textContent = body || '';
+
+  UI.render(Button, {
+    children: ns.ErrorContinueShoppingLabel || '',
+    variant: 'primary',
+    size: 'medium',
+    href: rootLink('/'),
+    'data-testid': 'pay-by-link-confirmation-error-cta',
+  })(block.querySelector('.pay-by-link-confirmation__error-cta'));
+
+  block.querySelector('.pay-by-link-confirmation__error-title').focus();
+}
+
+// Degraded view: we know an order_number but have no order data to render
+// containers against. Happens on refresh / direct nav / link from email.
+function renderDegraded(block, orderNumber, labels) {
+  const ns = labels?.PayByLinkConfirmation || {};
+
+  block.innerHTML = `
+    <div class="pay-by-link-confirmation pay-by-link-confirmation--degraded">
+      <div class="pay-by-link-confirmation__degraded-card">
+        <h1 class="pay-by-link-confirmation__degraded-title" tabindex="-1"></h1>
+        <p class="pay-by-link-confirmation__degraded-order-number">
+          <span class="pay-by-link-confirmation__degraded-order-number-label"></span>
+          <strong class="pay-by-link-confirmation__degraded-order-number-value" data-testid="pay-by-link-confirmation-order-number"></strong>
+        </p>
+        <p class="pay-by-link-confirmation__degraded-body"></p>
+        <div class="pay-by-link-confirmation__degraded-cta"></div>
+      </div>
+    </div>
+  `;
+
+  block.querySelector('.pay-by-link-confirmation__degraded-title').textContent = ns.DegradedTitle || '';
+  block.querySelector('.pay-by-link-confirmation__degraded-order-number-label').textContent = ns.OrderNumberLabel || '';
+  block.querySelector('.pay-by-link-confirmation__degraded-order-number-value').textContent = orderNumber;
+  block.querySelector('.pay-by-link-confirmation__degraded-body').textContent = ns.DegradedBody || '';
+
+  UI.render(Button, {
+    children: ns.ContinueShoppingLabel || '',
+    variant: 'primary',
+    size: 'medium',
+    href: rootLink('/'),
+    'data-testid': 'pay-by-link-confirmation-continue-cta',
+  })(block.querySelector('.pay-by-link-confirmation__degraded-cta'));
+
+  block.querySelector('.pay-by-link-confirmation__degraded-title').focus();
+}
+
+async function renderFullSummary(block, orderData, labels) {
+  block.innerHTML = `
+    <div class="pay-by-link-confirmation">
+      <div class="pay-by-link-confirmation__main">
+        <div class="pay-by-link-confirmation__order-header pay-by-link-confirmation__block"></div>
+        <div class="pay-by-link-confirmation__order-status pay-by-link-confirmation__block"></div>
+        <div class="pay-by-link-confirmation__customer-details pay-by-link-confirmation__block"></div>
+      </div>
+      <aside class="pay-by-link-confirmation__aside">
+        <div class="pay-by-link-confirmation__order-cost-summary pay-by-link-confirmation__block"></div>
+        <div class="pay-by-link-confirmation__order-product-list pay-by-link-confirmation__block"></div>
+      </aside>
+    </div>
+  `;
+
+  const langDefinitions = { default: { ...labels } };
+  await initializers.mountImmediately(orderApi.initialize, { langDefinitions, orderData });
+
+  await Promise.all([
+    OrderProvider.render(OrderHeader, { orderData })(
+      block.querySelector('.pay-by-link-confirmation__order-header'),
+    ),
+    OrderProvider.render(OrderStatus, { slots: { OrderActions: () => null } })(
+      block.querySelector('.pay-by-link-confirmation__order-status'),
+    ),
+    OrderProvider.render(CustomerDetails)(
+      block.querySelector('.pay-by-link-confirmation__customer-details'),
+    ),
+    OrderProvider.render(OrderCostSummary)(
+      block.querySelector('.pay-by-link-confirmation__order-cost-summary'),
+    ),
+    OrderProvider.render(OrderProductList)(
+      block.querySelector('.pay-by-link-confirmation__order-product-list'),
+    ),
+  ]);
+}
+
+export default async function decorate(block) {
+  const result = extractOrderNumber(window.location.search);
+
+  if (result.status !== 'valid') {
+    const labels = await fetchPlaceholders();
+    renderError(block, result.status, labels);
+    return;
+  }
+
+  events.emit('pay-by-link/confirmation', { orderNumber: result.orderNumber });
+
+  const orderData = consumeOrderDataFromHistory(result.orderNumber);
+  const labels = await fetchPlaceholders();
+
+  if (orderData) {
+    await renderFullSummary(block, orderData, labels);
+    return;
+  }
+
+  renderDegraded(block, result.orderNumber, labels);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -520,6 +520,17 @@
           }
         },
         {
+          "title": "Commerce Pay By Link Confirmation",
+          "id": "commerce-pay-by-link-confirmation",
+          "model": "commerce-pay-by-link-confirmation",
+          "plugins": {
+            "da": {
+              "rows": 1,
+              "columns": 2
+            }
+          }
+        },
+        {
           "title": "Commerce Pay By Link",
           "id": "commerce-pay-by-link",
           "model": "commerce-pay-by-link",

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -173,11 +173,7 @@ async function loadEager(doc) {
  * @param {Element} doc The container element
  */
 async function loadLazy(doc) {
-  const isStandalone = doc.body.classList.contains('pay-by-link-page');
-
-  if (!isStandalone) {
-    loadHeader(doc.querySelector('header'));
-  }
+  loadHeader(doc.querySelector('header'));
 
   const main = doc.querySelector('main');
   await loadSections(main);
@@ -186,9 +182,7 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  if (!isStandalone) {
-    loadFooter(doc.querySelector('footer'));
-  }
+  loadFooter(doc.querySelector('footer'));
 
   loadCommerceLazy();
 


### PR DESCRIPTION
Adds the `/pay/confirmation` landing page for the Pay By Link flow (ACCS-877). On successful payment the customer lands here and sees their order summary; if the page is hit directly or reloaded, it gracefully degrades to a thank-you view with the order number and no GraphQL refetch.

  ## What's in this PR
  
  ### New block: `blocks/commerce-pay-by-link-confirmation/`
  
  - `commerce-pay-by-link-confirmation.js` — reads `?order=<order_number>` from the URL, validates against `^[A-Za-z0-9_-]{4,32}$`, optionally consumes a full order from `window.history.state.orderData`, then renders one of three
    views:
    - **Full summary** when the order param is valid AND `history.state.orderData` is present. Mounts the `storefront-order` dropin's `OrderHeader`, `OrderStatus`, `CustomerDetails`, `OrderCostSummary`, `OrderProductList` containers via `OrderProvider.render`. The `OrderActions` slot on `OrderStatus` is suppressed (reorder/return don't apply to a freshly-paid PBL order).
    -  **Degraded** when the order param is valid but no `history.state.orderData` is present (refresh, direct nav, email link). Renders title + order number + Continue Shopping CTA. No refetch.
    - **Error** when `?order` is missing or fails format validation. Renders an accessible card (`role="alert" aria-live="assertive"`, focus moved to the title) with a Continue Shopping CTA.
  - `commerce-pay-by-link-confirmation.css` — mobile-first; centered 520px card for error/degraded; two-column main+aside grid above 900px for full summary.
  - `_commerce-pay-by-link-confirmation.json` — DA block model.

  ## Cross-block contract (upstream handoff)
  
  To render the full summary without a refetch, the upstream caller must push the order object into `history.state` before navigating:
  
  ```js
  window.history.pushState(
    { orderData },
    '',
    `/pay/confirmation?order=${encodeURIComponent(orderData.number)}`,
  );
```

<img width="1714" height="927" alt="image" src="https://github.com/user-attachments/assets/50fc4699-9ae2-4b81-a791-de3d9ed5dbd4" />


Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/ 
- After: https://accs-877--aem-boilerplate-commerce--hlxsites.aem.live/
