### PR TITLE
ACCS-871: Add Error State Handling on /pay Page

### DIFF
--- a/blocks/commerce-pay-by-link/README.md
+++ b/blocks/commerce-pay-by-link/README.md
@@ -1,0 +1,125 @@
+# Commerce Pay By Link Block
+
+## Overview
+
+The Commerce Pay By Link block renders the standalone `/pay` page for token-based order payment. It validates the `token` URL parameter, renders a page shell with mount points for downstream stories (order summary, payment, etc.), or shows an accessible error card when the token is missing or malformed.
+
+A shared error library under `errors/` provides consistent error UI and error-to-state mapping for this block and for downstream order-summary, Payment Services, and OOPE submission flows.
+
+## Integration
+
+### Block Configuration
+
+No block configuration is read via `readBlockConfig()`.
+
+### URL Parameters
+
+- `token` — 64-character lowercase hex string (secure random hash). Required for a valid pay session.
+  - Absent or empty → `missing` error state (no API call).
+  - Present but invalid format → `malformed` error state (no API call).
+  - Valid format → page shell is rendered; downstream stories load order data via `payByLinkOrder`.
+
+### Placeholders
+
+Error copy is authored in Document Authoring under the `PayByLink.*` namespace (`fetchPlaceholders()`). Keys used by `ERROR_STATE_CONFIG`:
+
+| Placeholder key | Used for |
+|-----------------|----------|
+| `ErrorMissingTokenTitle` / `ErrorMissingTokenBody` | Missing token |
+| `ErrorMalformedTokenTitle` / `ErrorMalformedTokenBody` | Malformed token |
+| `ErrorNotFoundTitle` / `ErrorNotFoundBody` | Token not found |
+| `ErrorExpiredTitle` / `ErrorExpiredBody` | Expired token |
+| `ErrorAlreadyCompletedTitle` / `ErrorAlreadyCompletedBody` | Order already paid |
+| `ErrorCancelledTitle` / `ErrorCancelledBody` | Cancelled token |
+| `ErrorGatewayDeclineTitle` / `ErrorGatewayDeclineBody` | Payment declined |
+| `ErrorSdkLoadFailureTitle` / `ErrorSdkLoadFailureBody` | Payment SDK failed to load |
+| `ErrorGenericTitle` / `ErrorGenericBody` | Unexpected error |
+| `ErrorContactSupportLabel` | Contact support CTA |
+| `ErrorTryAgainLabel` | Try again CTA |
+
+### Local Storage
+
+No localStorage keys are used by this block.
+
+### Events
+
+No event listeners or emitters in the block today. Downstream stories may subscribe to commerce drop-in events when payment and order flows are wired.
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Missing or malformed token**: Block renders the shared error card immediately; no GraphQL call is made.
+- **Valid token**: Block renders the two-column page shell with empty mount points for order summary, addresses, totals, payment, and footer content.
+
+### User Interaction Flows
+
+1. **Land on `/pay`**: Block reads `token` from the query string via `extractToken()`.
+2. **Pre-flight validation failure**: `renderErrorCard()` shows title, body, and optional CTA; focus moves to the error heading for screen readers.
+3. **Valid token**: Shell DOM is created; downstream stories populate `.pay-by-link__*` slots and handle payment.
+
+### Page Shell Mount Points
+
+| Element | Purpose |
+|---------|---------|
+| `.pay-by-link__order-header` | Order header |
+| `.pay-by-link__order-summary` | Line items / order summary |
+| `.pay-by-link__addresses` | Shipping / billing addresses |
+| `.pay-by-link__order-totals` | Order totals |
+| `.pay-by-link__payment` | Payment method / SDK |
+| `.pay-by-link__footer` | Footer actions |
+
+## Error Handling
+
+### Error states (`errors/error-states.js`)
+
+| State | When |
+|-------|------|
+| `missing` | No `token` query parameter |
+| `malformed` | `token` fails format validation |
+| `not-found` | Backend: token not found (404 / `PAY_BY_LINK_TOKEN_NOT_FOUND`) |
+| `expired` | Backend: token expired (410 / `PAY_BY_LINK_TOKEN_EXPIRED`) |
+| `cancelled` | Backend: token cancelled (409 / `PAY_BY_LINK_TOKEN_CANCELLED`) |
+| `already-completed` | Backend: order already paid |
+| `gateway-decline` | Payment gateway declined the charge |
+| `sdk-load-failure` | Payment SDK failed to initialize |
+| `generic` | Any unmapped error |
+
+Use `mapErrorToState(error)` to resolve a thrown error, GraphQL/Apollo error, or OOPE response to one of the states above. Resolution order: known state string → backend error code → HTTP status → `generic`.
+
+Backend error codes in `BACKEND_CODE_TO_STATE` are placeholders pending backend sign-off.
+
+### Error card (`errors/error-card.js`)
+
+`renderErrorCard(container, state, options)` renders the shared error UI:
+
+- `role="alert"` and `aria-live="assertive"` on the card
+- Programmatic focus on the error title (`tabindex="-1"`)
+- `data-state` attribute on the root for testing and styling
+- Optional CTA per state: **Contact support** (`rootLink(SUPPORT_PATH)`), **Try again** (in-place `onRetry` callback), or none
+
+Options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `labels` | — | Result of `fetchPlaceholders()` |
+| `onRetry` | — | Handler for try-again CTAs; keeps the payment SDK mounted |
+| `headingLevel` | `1` | Heading level (`1`–`6`) for inline error cards inside an existing page |
+
+### CTA behavior by state
+
+| State | CTA |
+|-------|-----|
+| `missing`, `malformed`, `not-found`, `expired`, `cancelled` | Contact support |
+| `already-completed` | None |
+| `gateway-decline`, `sdk-load-failure`, `generic` | Try again |
+
+## Exports
+
+| Export | Module | Description |
+|--------|--------|-------------|
+| `extractToken(search)` | `commerce-pay-by-link.js` | Parse and validate the `token` query parameter |
+| `TOKEN_REGEX` | `commerce-pay-by-link.js` | Token format: `/^[a-f0-9]{64}$/` |
+| `renderErrorCard()` | `errors/error-card.js` | Render the shared error card |
+| `mapErrorToState()` | `errors/error-states.js` | Map an error object to a named state |
+| `PAY_BY_LINK_ERROR`, `ERROR_CTA`, `ERROR_STATE_CONFIG` | `errors/error-states.js` | State taxonomy and per-state UI config |

--- a/blocks/commerce-pay-by-link/README.md
+++ b/blocks/commerce-pay-by-link/README.md
@@ -37,18 +37,40 @@ slots.Payment = async (ctx) => {
 | `ctx.appendChild(el)` | Function | Append to the slot container |
 | `ctx.prependChild(el)` | Function | Prepend to the slot container |
 
-## Error states
+## Error handling
 
-| Condition | Error kind | Notes |
+Token validation and `payByLinkOrder` failures use the shared error library in `errors/`. The block calls `renderErrorCard()` with states from `mapErrorToState()`. Payment Services and OOPE submission stories should import the same modules for consistent UI.
+
+```js
+import { renderErrorCard } from './errors/error-card.js';
+import { mapErrorToState, PAY_BY_LINK_ERROR } from './errors/error-states.js';
+```
+
+### Error states
+
+| State | Source | CTA |
 |---|---|---|
-| No `token` param | `missing` | Shown before any network call |
-| Token fails regex | `malformed` | Shown before any network call |
-| `TOKEN_NOT_FOUND` from API | `not-found` | |
-| `TOKEN_EXPIRED` from API | `expired` | |
-| `ORDER_ALREADY_PAID` from API | `already-paid` | |
-| `ORDER_CANCELLED` from API | `cancelled` | |
+| `missing` | No `token` param (pre-flight) | Contact support |
+| `malformed` | Token fails regex (pre-flight) | Contact support |
+| `not-found` | `TOKEN_NOT_FOUND` / HTTP 404 | Contact support |
+| `expired` | `TOKEN_EXPIRED` / HTTP 410 | Contact support |
+| `already-completed` | `ORDER_ALREADY_PAID` | None |
+| `cancelled` | `ORDER_CANCELLED` / HTTP 409 | Contact support |
+| `gateway-decline` | Payment gateway decline | Try again (in-place) |
+| `sdk-load-failure` | Payment SDK failed to load | Try again (in-place) |
+| `generic` | Unmapped API or transport error | Try again (in-place) |
 
-All error states render a focusable alert card with a support CTA.
+Each error card sets `data-state`, uses `role="alert"` with `aria-live="assertive"`, and moves focus to the error heading on render. Copy comes from the `PayByLink.*` placeholder namespace — no hardcoded strings.
+
+For gateway decline, pass an `onRetry` handler to `renderErrorCard()` so the user can retry without a full page reload and the SDK stays mounted:
+
+```js
+renderErrorCard(container, PAY_BY_LINK_ERROR.GATEWAY_DECLINE, {
+  labels,
+  headingLevel: 2,
+  onRetry: () => { /* re-submit payment */ },
+});
+```
 
 ## Loading skeleton
 
@@ -56,8 +78,20 @@ While the GraphQL query is in flight, slots `.pay-by-link__order-header`, `.pay-
 
 ## i18n
 
-Labels are loaded via `fetchPlaceholders()` from the AEM CMS spreadsheet under the `PayByLink` namespace. See [scripts/commerce.js](../../scripts/commerce.js) for the placeholder loading pattern. Required keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyPaidTitle`, `ErrorAlreadyPaidBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorContactSupportLabel`, `CustomerEmailLabel`, `OrderItemsHeading`, `QtyLabel`, `OrderTotalsHeading`, `SubtotalLabel`, `TaxLabel`, `ShippingLabel`, `GrandTotalLabel`, `ShippingAddressHeading`, `BillingAddressHeading`.
+Labels are loaded via `fetchPlaceholders()` from the AEM CMS spreadsheet under the `PayByLink` namespace. See [scripts/commerce.js](../../scripts/commerce.js) for the placeholder loading pattern.
+
+Error keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyCompletedTitle`, `ErrorAlreadyCompletedBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorGatewayDeclineTitle`, `ErrorGatewayDeclineBody`, `ErrorSdkLoadFailureTitle`, `ErrorSdkLoadFailureBody`, `ErrorGenericTitle`, `ErrorGenericBody`, `ErrorContactSupportLabel`, `ErrorTryAgainLabel`.
+
+Order summary keys: `CustomerEmailLabel`, `OrderItemsHeading`, `QtyLabel`, `OrderTotalsHeading`, `SubtotalLabel`, `TaxLabel`, `ShippingLabel`, `GrandTotalLabel`, `ShippingAddressHeading`, `BillingAddressHeading`.
 
 ## Page shell
 
 This block expects `body.pay-by-link-page` to be set by the AEM page template. That class drives the simplified header (logo only, no nav) defined in `blocks/header/header.css`.
+
+## Exports
+
+| Export | Module | Description |
+|---|---|---|
+| `extractToken`, `TOKEN_REGEX`, `slots` | `commerce-pay-by-link.js` | Token validation and payment slot |
+| `renderErrorCard` | `errors/error-card.js` | Render the shared error card |
+| `mapErrorToState`, `PAY_BY_LINK_ERROR`, `ERROR_STATE_CONFIG` | `errors/error-states.js` | Error taxonomy and mapping |

--- a/blocks/commerce-pay-by-link/README.md
+++ b/blocks/commerce-pay-by-link/README.md
@@ -80,7 +80,7 @@ While the GraphQL query is in flight, slots `.pay-by-link__order-header`, `.pay-
 
 Labels are loaded via `fetchPlaceholders()` from the AEM CMS spreadsheet under the `PayByLink` namespace. See [scripts/commerce.js](../../scripts/commerce.js) for the placeholder loading pattern.
 
-Error keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyCompletedTitle`, `ErrorAlreadyCompletedBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorGatewayDeclineTitle`, `ErrorGatewayDeclineBody`, `ErrorSdkLoadFailureTitle`, `ErrorSdkLoadFailureBody`, `ErrorGenericTitle`, `ErrorGenericBody`, `ErrorContactSupportLabel`, `ErrorTryAgainLabel`.
+Error keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyPaidTitle`, `ErrorAlreadyPaidBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorGatewayDeclineTitle`, `ErrorGatewayDeclineBody`, `ErrorSdkLoadFailureTitle`, `ErrorSdkLoadFailureBody`, `ErrorContactSupportLabel`.
 
 Order summary keys: `CustomerEmailLabel`, `OrderItemsHeading`, `QtyLabel`, `OrderTotalsHeading`, `SubtotalLabel`, `TaxLabel`, `ShippingLabel`, `GrandTotalLabel`, `ShippingAddressHeading`, `BillingAddressHeading`.
 

--- a/blocks/commerce-pay-by-link/README.md
+++ b/blocks/commerce-pay-by-link/README.md
@@ -39,11 +39,14 @@ slots.Payment = async (ctx) => {
 
 ## Error handling
 
-Token validation and `payByLinkOrder` failures use the shared error library in `errors/`. The block calls `renderErrorCard()` with states from `mapErrorToState()`. Payment Services and OOPE submission stories should import the same modules for consistent UI.
+Token validation and `payByLinkOrder` failures use the shared error library in `errors/`. The block calls `renderErrorCard()` for pre-flight errors and `renderMappedError()` for API failures. Payment Services and OOPE submission stories should import the same modules for consistent UI.
 
 ```js
-import { renderErrorCard } from './errors/error-card.js';
-import { mapErrorToState, PAY_BY_LINK_ERROR } from './errors/error-states.js';
+import { renderErrorCard, renderMappedError } from './errors/error-card.js';
+import { mapErrorToState, resolveOnRetry, PAY_BY_LINK_ERROR } from './errors/error-states.js';
+
+// API / transport failure — maps error to state and wires retry when appropriate
+renderMappedError(container, error, { labels, retry: () => { /* re-fetch or re-submit */ } });
 ```
 
 ### Error states
@@ -58,7 +61,7 @@ import { mapErrorToState, PAY_BY_LINK_ERROR } from './errors/error-states.js';
 | `cancelled` | `ORDER_CANCELLED` / HTTP 409 | Contact support |
 | `gateway-decline` | Payment gateway decline | Try again (in-place) |
 | `sdk-load-failure` | Payment SDK failed to load | Try again (in-place) |
-| `generic` | Unmapped API or transport error | Try again (in-place) |
+| `generic` | Unmapped API or transport error | Try again (re-fetches order) |
 
 Each error card sets `data-state`, uses `role="alert"` with `aria-live="assertive"`, and moves focus to the error heading on render. Copy comes from the `PayByLink.*` placeholder namespace — no hardcoded strings.
 
@@ -72,15 +75,26 @@ renderErrorCard(container, PAY_BY_LINK_ERROR.GATEWAY_DECLINE, {
 });
 ```
 
+For generic API errors, the block passes a `retry` callback to `renderMappedError()` that re-runs the `payByLinkOrder` query automatically.
+
 ## Loading skeleton
 
 While the GraphQL query is in flight, slots `.pay-by-link__order-header`, `.pay-by-link__order-summary`, `.pay-by-link__addresses`, and `.pay-by-link__order-totals` carry the `pay-by-link__skeleton` class and `aria-busy="true"`. Both are removed once the response resolves.
 
 ## i18n
 
-Labels are loaded via `fetchPlaceholders()` from the AEM CMS spreadsheet under the `PayByLink` namespace. See [scripts/commerce.js](../../scripts/commerce.js) for the placeholder loading pattern.
+Labels are loaded via `fetchPlaceholders()` from the AEM CMS spreadsheet at `placeholders/pay-by-link.json` under the `PayByLink` namespace. See [scripts/commerce.js](../../scripts/commerce.js) for the placeholder loading pattern.
 
-Error keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyPaidTitle`, `ErrorAlreadyPaidBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorGatewayDeclineTitle`, `ErrorGatewayDeclineBody`, `ErrorSdkLoadFailureTitle`, `ErrorSdkLoadFailureBody`, `ErrorContactSupportLabel`.
+All error and CTA copy must be authored in da.live — no hardcoded strings in code. Required keys:
+
+| da.live key | Used for |
+|---|---|
+| `PayByLink.ErrorContactSupportLabel` | Contact support CTA button |
+| `PayByLink.ErrorTryAgainLabel` | Try again CTA button |
+| `PayByLink.ErrorGenericTitle` | Generic error heading |
+| `PayByLink.ErrorGenericBody` | Generic error body |
+
+Error title/body keys: `ErrorMissingTokenTitle`, `ErrorMissingTokenBody`, `ErrorMalformedTokenTitle`, `ErrorMalformedTokenBody`, `ErrorNotFoundTitle`, `ErrorNotFoundBody`, `ErrorExpiredTitle`, `ErrorExpiredBody`, `ErrorAlreadyPaidTitle`, `ErrorAlreadyPaidBody`, `ErrorCancelledTitle`, `ErrorCancelledBody`, `ErrorGatewayDeclineTitle`, `ErrorGatewayDeclineBody`, `ErrorSdkLoadFailureTitle`, `ErrorSdkLoadFailureBody`, `ErrorGenericTitle`, `ErrorGenericBody`.
 
 Order summary keys: `CustomerEmailLabel`, `OrderItemsHeading`, `QtyLabel`, `OrderTotalsHeading`, `SubtotalLabel`, `TaxLabel`, `ShippingLabel`, `GrandTotalLabel`, `ShippingAddressHeading`, `BillingAddressHeading`.
 
@@ -93,5 +107,5 @@ This block expects `body.pay-by-link-page` to be set by the AEM page template. T
 | Export | Module | Description |
 |---|---|---|
 | `extractToken`, `TOKEN_REGEX`, `slots` | `commerce-pay-by-link.js` | Token validation and payment slot |
-| `renderErrorCard` | `errors/error-card.js` | Render the shared error card |
-| `mapErrorToState`, `PAY_BY_LINK_ERROR`, `ERROR_STATE_CONFIG` | `errors/error-states.js` | Error taxonomy and mapping |
+| `renderErrorCard`, `renderMappedError` | `errors/error-card.js` | Render error UI; map API errors automatically |
+| `mapErrorToState`, `resolveOnRetry`, `PAY_BY_LINK_ERROR`, `ERROR_STATE_CONFIG` | `errors/error-states.js` | Error taxonomy and mapping |

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -249,11 +249,17 @@ export default async function decorate(block) {
   renderShell(block);
   setSkeleton(block, true);
 
-  const [labels, response] = await Promise.all([
-    fetchPlaceholders(),
-    CORE_FETCH_GRAPHQL.fetchGraphQl(QUERY, { variables: { token: result.token } }),
-  ]);
+  const labelsPromise = fetchPlaceholders();
+  let response;
+  try {
+    response = await CORE_FETCH_GRAPHQL.fetchGraphQl(QUERY, { variables: { token: result.token } });
+  } catch (error) {
+    setSkeleton(block, false);
+    renderErrorCard(block, mapErrorToState(error), { labels: await labelsPromise });
+    return;
+  }
 
+  const labels = await labelsPromise;
   setSkeleton(block, false);
 
   if (response.errors?.length || !response.data?.payByLinkOrder) {

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -7,6 +7,8 @@ import {
   rootLink,
   SUPPORT_PATH,
 } from '../../scripts/commerce.js';
+import { renderErrorCard } from './errors/error-card.js';
+import { mapErrorToState } from './errors/error-states.js';
 
 // Token is varchar(64) secure random hash. Strict lowercase hex.
 export const TOKEN_REGEX = /^[a-f0-9]{64}$/;
@@ -38,14 +40,6 @@ const QUERY = `
   }
 `;
 
-// Maps backend error extension codes to i18n kinds.
-const ERROR_CODE_MAP = {
-  TOKEN_NOT_FOUND: 'not-found',
-  TOKEN_EXPIRED: 'expired',
-  ORDER_ALREADY_PAID: 'already-paid',
-  ORDER_CANCELLED: 'cancelled',
-};
-
 // Override slots.Payment to mount a gateway payment SDK.
 // ctx.order = full payByLinkOrder payload; ctx.token = the raw token string.
 // ctx.replaceWith(el) replaces the empty payment container with your element.
@@ -67,43 +61,6 @@ function formatMoney({ value, currency }) {
     style: 'currency',
     currency,
   }).format(value);
-}
-
-function renderError(block, kind, labels) {
-  const ns = labels?.PayByLink || {};
-  const errorLabels = {
-    missing: { title: ns.ErrorMissingTokenTitle, body: ns.ErrorMissingTokenBody },
-    malformed: { title: ns.ErrorMalformedTokenTitle, body: ns.ErrorMalformedTokenBody },
-    'not-found': { title: ns.ErrorNotFoundTitle, body: ns.ErrorNotFoundBody },
-    expired: { title: ns.ErrorExpiredTitle, body: ns.ErrorExpiredBody },
-    'already-paid': { title: ns.ErrorAlreadyPaidTitle, body: ns.ErrorAlreadyPaidBody },
-    cancelled: { title: ns.ErrorCancelledTitle, body: ns.ErrorCancelledBody },
-  };
-
-  const { title = '', body = '' } = errorLabels[kind] || errorLabels['not-found'];
-
-  block.innerHTML = `
-    <div class="pay-by-link pay-by-link--error">
-      <div class="pay-by-link__error-card" role="alert" aria-live="assertive">
-        <h1 class="pay-by-link__error-title" tabindex="-1"></h1>
-        <p class="pay-by-link__error-body"></p>
-        <div class="pay-by-link__error-cta"></div>
-      </div>
-    </div>
-  `;
-
-  block.querySelector('.pay-by-link__error-title').textContent = title;
-  block.querySelector('.pay-by-link__error-body').textContent = body;
-
-  UI.render(Button, {
-    children: ns.ErrorContactSupportLabel || '',
-    variant: 'primary',
-    size: 'medium',
-    href: rootLink(SUPPORT_PATH),
-    'data-testid': 'pay-by-link-error-cta',
-  })(block.querySelector('.pay-by-link__error-cta'));
-
-  block.querySelector('.pay-by-link__error-title').focus();
 }
 
 function renderShell(block) {
@@ -288,7 +245,7 @@ export default async function decorate(block) {
 
   if (result.status !== 'valid') {
     const labels = await fetchPlaceholders();
-    renderError(block, result.status, labels);
+    renderErrorCard(block, result.status, { labels });
     return;
   }
 
@@ -303,8 +260,7 @@ export default async function decorate(block) {
   setSkeleton(block, false);
 
   if (response.errors?.length || !response.data?.payByLinkOrder) {
-    const code = response.errors?.[0]?.extensions?.code;
-    renderError(block, ERROR_CODE_MAP[code] || 'not-found', labels);
+    renderErrorCard(block, mapErrorToState(response), { labels });
     return;
   }
 

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -1,11 +1,8 @@
 /* eslint-disable import/no-unresolved */
 
-import { Button, provider as UI } from '@dropins/tools/components.js';
 import {
   CORE_FETCH_GRAPHQL,
   fetchPlaceholders,
-  rootLink,
-  SUPPORT_PATH,
 } from '../../scripts/commerce.js';
 import { renderErrorCard } from './errors/error-card.js';
 import { mapErrorToState } from './errors/error-states.js';

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -4,6 +4,8 @@ import { Button, provider as UI } from '@dropins/tools/components.js';
 
 import { fetchPlaceholders, rootLink, SUPPORT_PATH } from '../../scripts/commerce.js';
 
+import { renderErrorCard } from './errors/error-card.js';
+
 // token is varchar(64) secure random hash. Strict lowercase hex.
 export const TOKEN_REGEX = /^[a-f0-9]{64}$/;
 
@@ -72,5 +74,5 @@ export default async function decorate(block) {
   }
 
   const labels = await fetchPlaceholders();
-  renderError(block, result.status, labels);
+  renderErrorCard(block, result.status, { labels });
 }

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -4,8 +4,14 @@ import {
   CORE_FETCH_GRAPHQL,
   fetchPlaceholders,
 } from '../../scripts/commerce.js';
+import { getMetadata } from '../../scripts/aem.js';
 import { renderErrorCard } from './errors/error-card.js';
 import { mapErrorToState } from './errors/error-states.js';
+
+function loadPayByLinkLabels() {
+  const path = getMetadata('placeholders')?.replace(/^\//, '');
+  return fetchPlaceholders(path || 'placeholders/pay-by-link.json');
+}
 
 // Token is varchar(64) secure random hash. Strict lowercase hex.
 export const TOKEN_REGEX = /^[a-f0-9]{64}$/;
@@ -241,7 +247,7 @@ export default async function decorate(block) {
   const result = extractToken(window.location.search);
 
   if (result.status !== 'valid') {
-    const labels = await fetchPlaceholders();
+    const labels = await loadPayByLinkLabels();
     renderErrorCard(block, result.status, { labels });
     return;
   }
@@ -249,7 +255,7 @@ export default async function decorate(block) {
   renderShell(block);
   setSkeleton(block, true);
 
-  const labelsPromise = fetchPlaceholders();
+  const labelsPromise = loadPayByLinkLabels();
   let response;
   try {
     response = await CORE_FETCH_GRAPHQL.fetchGraphQl(QUERY, { variables: { token: result.token } });

--- a/blocks/commerce-pay-by-link/commerce-pay-by-link.js
+++ b/blocks/commerce-pay-by-link/commerce-pay-by-link.js
@@ -5,8 +5,7 @@ import {
   fetchPlaceholders,
 } from '../../scripts/commerce.js';
 import { getMetadata } from '../../scripts/aem.js';
-import { renderErrorCard } from './errors/error-card.js';
-import { mapErrorToState } from './errors/error-states.js';
+import { renderErrorCard, renderMappedError } from './errors/error-card.js';
 
 function loadPayByLinkLabels() {
   const path = getMetadata('placeholders')?.replace(/^\//, '');
@@ -243,37 +242,39 @@ async function invokeSlots(block, order, token) {
   if (el) await slots.Payment(createCtx(el, order, token));
 }
 
-export default async function decorate(block) {
-  const result = extractToken(window.location.search);
-
-  if (result.status !== 'valid') {
-    const labels = await loadPayByLinkLabels();
-    renderErrorCard(block, result.status, { labels });
-    return;
-  }
-
+async function fetchOrder(block, token, labelsPromise) {
   renderShell(block);
   setSkeleton(block, true);
 
-  const labelsPromise = loadPayByLinkLabels();
-  let response;
+  const retry = () => fetchOrder(block, token, labelsPromise);
+
   try {
-    response = await CORE_FETCH_GRAPHQL.fetchGraphQl(QUERY, { variables: { token: result.token } });
+    const response = await CORE_FETCH_GRAPHQL.fetchGraphQl(QUERY, { variables: { token } });
+    const labels = await labelsPromise;
+    setSkeleton(block, false);
+
+    if (response.errors?.length || !response.data?.payByLinkOrder) {
+      renderMappedError(block, response, { labels, retry });
+      return;
+    }
+
+    const order = response.data.payByLinkOrder;
+    populateSlots(block, order, labels?.PayByLink || {});
+    await invokeSlots(block, order, token);
   } catch (error) {
     setSkeleton(block, false);
-    renderErrorCard(block, mapErrorToState(error), { labels: await labelsPromise });
+    renderMappedError(block, error, { labels: await labelsPromise, retry });
+  }
+}
+
+export default async function decorate(block) {
+  const result = extractToken(window.location.search);
+  const labelsPromise = loadPayByLinkLabels();
+
+  if (result.status !== 'valid') {
+    renderErrorCard(block, result.status, { labels: await labelsPromise });
     return;
   }
 
-  const labels = await labelsPromise;
-  setSkeleton(block, false);
-
-  if (response.errors?.length || !response.data?.payByLinkOrder) {
-    renderErrorCard(block, mapErrorToState(response), { labels });
-    return;
-  }
-
-  const order = response.data.payByLinkOrder;
-  populateSlots(block, order, labels?.PayByLink || {});
-  await invokeSlots(block, order, result.token);
+  await fetchOrder(block, result.token, labelsPromise);
 }

--- a/blocks/commerce-pay-by-link/errors/error-card.js
+++ b/blocks/commerce-pay-by-link/errors/error-card.js
@@ -1,0 +1,60 @@
+import { Button, provider as UI } from '@dropins/tools/components.js';
+import { rootLink, SUPPORT_PATH } from '../../../scripts/commerce.js';
+import { ERROR_STATE_CONFIG, ERROR_CTA, PAY_BY_LINK_ERROR } from './error-states.js';
+
+function renderCta(ctaEl, cta, ns, onRetry) {
+  if (cta === ERROR_CTA.CONTACT_SUPPORT) {
+    UI.render(Button, {
+      children: ns.ErrorContactSupportLabel || '',
+      variant: 'primary',
+      size: 'medium',
+      href: rootLink(SUPPORT_PATH),
+      'data-testid': 'pay-by-link-error-cta',
+    })(ctaEl);
+    return;
+  }
+
+  if (cta === ERROR_CTA.TRY_AGAIN) {
+    UI.render(Button, {
+      children: ns.ErrorTryAgainLabel || '',
+      variant: 'primary',
+      size: 'medium',
+      onClick: () => { if (typeof onRetry === 'function') onRetry(); },
+      'data-testid': 'pay-by-link-error-cta',
+    })(ctaEl);
+    return;
+  }
+
+  ctaEl.remove();
+}
+
+export function renderErrorCard(container, state, { labels, onRetry, headingLevel = 1 } = {}) {
+  const resolvedState = ERROR_STATE_CONFIG[state] ? state : PAY_BY_LINK_ERROR.GENERIC;
+  const config = ERROR_STATE_CONFIG[resolvedState];
+  const ns = labels?.PayByLink || {};
+
+  const level = Number.isInteger(headingLevel) && headingLevel >= 1 && headingLevel <= 6
+    ? headingLevel
+    : 1;
+  const h = `h${level}`;
+
+  container.innerHTML = `
+    <div class="pay-by-link pay-by-link--error" data-state="${resolvedState}">
+      <div class="pay-by-link__error-card" role="alert" aria-live="assertive">
+        <${h} class="pay-by-link__error-title" tabindex="-1"></${h}>
+        <p class="pay-by-link__error-body"></p>
+        <div class="pay-by-link__error-cta"></div>
+      </div>
+    </div>
+  `;
+
+  const titleEl = container.querySelector('.pay-by-link__error-title');
+  const bodyEl = container.querySelector('.pay-by-link__error-body');
+  const ctaEl = container.querySelector('.pay-by-link__error-cta');
+
+  titleEl.textContent = ns[config.titleKey] || '';
+  bodyEl.textContent = ns[config.bodyKey] || '';
+
+  renderCta(ctaEl, config.cta, ns, onRetry);
+  titleEl.focus();
+}

--- a/blocks/commerce-pay-by-link/errors/error-card.js
+++ b/blocks/commerce-pay-by-link/errors/error-card.js
@@ -1,6 +1,8 @@
 import { Button, provider as UI } from '@dropins/tools/components.js';
 import { rootLink, SUPPORT_PATH } from '../../../scripts/commerce.js';
-import { ERROR_STATE_CONFIG, ERROR_CTA, PAY_BY_LINK_ERROR } from './error-states.js';
+import {
+  ERROR_STATE_CONFIG, ERROR_CTA, PAY_BY_LINK_ERROR, mapErrorToState, resolveOnRetry,
+} from './error-states.js';
 
 function renderCta(ctaEl, cta, ns, onRetry) {
   if (cta === ERROR_CTA.CONTACT_SUPPORT) {
@@ -57,4 +59,18 @@ export function renderErrorCard(container, state, { labels, onRetry, headingLeve
 
   renderCta(ctaEl, config.cta, ns, onRetry);
   titleEl.focus();
+}
+
+/**
+ * Map an API/transport error to a state and render the matching error card.
+ * @param {Element} container
+ * @param {unknown} error - GraphQL response, thrown error, or pre-flight state string.
+ * @param {{ labels?: object, retry?: Function }} options
+ */
+export function renderMappedError(container, error, { labels, retry } = {}) {
+  const state = mapErrorToState(error);
+  renderErrorCard(container, state, {
+    labels,
+    onRetry: resolveOnRetry(state, retry),
+  });
 }

--- a/blocks/commerce-pay-by-link/errors/error-states.js
+++ b/blocks/commerce-pay-by-link/errors/error-states.js
@@ -58,9 +58,9 @@ export const ERROR_STATE_CONFIG = {
     cta: ERROR_CTA.TRY_AGAIN,
   },
   [PAY_BY_LINK_ERROR.GENERIC]: {
-    titleKey: 'ErrorSdkLoadFailureTitle',
-    bodyKey: 'ErrorSdkLoadFailureBody',
-    cta: ERROR_CTA.CONTACT_SUPPORT,
+    titleKey: 'ErrorGenericTitle',
+    bodyKey: 'ErrorGenericBody',
+    cta: ERROR_CTA.TRY_AGAIN,
   },
 };
 
@@ -113,4 +113,9 @@ export function mapErrorToState(error) {
   if (status && HTTP_STATUS_TO_STATE[status]) return HTTP_STATUS_TO_STATE[status];
 
   return PAY_BY_LINK_ERROR.GENERIC;
+}
+
+export function resolveOnRetry(state, retry) {
+  const { cta } = ERROR_STATE_CONFIG[state] || ERROR_STATE_CONFIG[PAY_BY_LINK_ERROR.GENERIC];
+  return cta === ERROR_CTA.TRY_AGAIN ? retry : undefined;
 }

--- a/blocks/commerce-pay-by-link/errors/error-states.js
+++ b/blocks/commerce-pay-by-link/errors/error-states.js
@@ -72,8 +72,11 @@ const HTTP_STATUS_TO_STATE = {
   410: PAY_BY_LINK_ERROR.EXPIRED,
 };
 
-// TODO(ACCS-<ticket>): confirm backend error codes before relying on these.
 const BACKEND_CODE_TO_STATE = {
+  TOKEN_NOT_FOUND: PAY_BY_LINK_ERROR.NOT_FOUND,
+  TOKEN_EXPIRED: PAY_BY_LINK_ERROR.EXPIRED,
+  ORDER_ALREADY_PAID: PAY_BY_LINK_ERROR.ALREADY_COMPLETED,
+  ORDER_CANCELLED: PAY_BY_LINK_ERROR.CANCELLED,
   PAY_BY_LINK_TOKEN_NOT_FOUND: PAY_BY_LINK_ERROR.NOT_FOUND,
   PAY_BY_LINK_TOKEN_CANCELLED: PAY_BY_LINK_ERROR.CANCELLED,
   PAY_BY_LINK_TOKEN_EXPIRED: PAY_BY_LINK_ERROR.EXPIRED,
@@ -94,6 +97,7 @@ function getBackendCode(error) {
   if (!error || typeof error !== 'object') return undefined;
   const code = error.extensions?.code
       ?? error.graphQLErrors?.[0]?.extensions?.code
+      ?? error.errors?.[0]?.extensions?.code
       ?? error.body?.error?.code
       ?? error.code;
   return typeof code === 'string' ? code : undefined;

--- a/blocks/commerce-pay-by-link/errors/error-states.js
+++ b/blocks/commerce-pay-by-link/errors/error-states.js
@@ -38,8 +38,8 @@ export const ERROR_STATE_CONFIG = {
     cta: ERROR_CTA.CONTACT_SUPPORT,
   },
   [PAY_BY_LINK_ERROR.ALREADY_COMPLETED]: {
-    titleKey: 'ErrorAlreadyCompletedTitle',
-    bodyKey: 'ErrorAlreadyCompletedBody',
+    titleKey: 'ErrorAlreadyPaidTitle',
+    bodyKey: 'ErrorAlreadyPaidBody',
     cta: ERROR_CTA.NONE,
   },
   [PAY_BY_LINK_ERROR.CANCELLED]: {
@@ -58,9 +58,9 @@ export const ERROR_STATE_CONFIG = {
     cta: ERROR_CTA.TRY_AGAIN,
   },
   [PAY_BY_LINK_ERROR.GENERIC]: {
-    titleKey: 'ErrorGenericTitle',
-    bodyKey: 'ErrorGenericBody',
-    cta: ERROR_CTA.TRY_AGAIN,
+    titleKey: 'ErrorSdkLoadFailureTitle',
+    bodyKey: 'ErrorSdkLoadFailureBody',
+    cta: ERROR_CTA.CONTACT_SUPPORT,
   },
 };
 

--- a/blocks/commerce-pay-by-link/errors/error-states.js
+++ b/blocks/commerce-pay-by-link/errors/error-states.js
@@ -1,0 +1,112 @@
+export const PAY_BY_LINK_ERROR = Object.freeze({
+  MISSING: 'missing',
+  MALFORMED: 'malformed',
+  NOT_FOUND: 'not-found',
+  EXPIRED: 'expired',
+  ALREADY_COMPLETED: 'already-completed',
+  CANCELLED: 'cancelled',
+  GATEWAY_DECLINE: 'gateway-decline',
+  SDK_LOAD_FAILURE: 'sdk-load-failure',
+  GENERIC: 'generic',
+});
+
+export const ERROR_CTA = Object.freeze({
+  NONE: 'none',
+  CONTACT_SUPPORT: 'contactSupport',
+  TRY_AGAIN: 'tryAgain',
+});
+
+export const ERROR_STATE_CONFIG = {
+  [PAY_BY_LINK_ERROR.MISSING]: {
+    titleKey: 'ErrorMissingTokenTitle',
+    bodyKey: 'ErrorMissingTokenBody',
+    cta: ERROR_CTA.CONTACT_SUPPORT,
+  },
+  [PAY_BY_LINK_ERROR.MALFORMED]: {
+    titleKey: 'ErrorMalformedTokenTitle',
+    bodyKey: 'ErrorMalformedTokenBody',
+    cta: ERROR_CTA.CONTACT_SUPPORT,
+  },
+  [PAY_BY_LINK_ERROR.NOT_FOUND]: {
+    titleKey: 'ErrorNotFoundTitle',
+    bodyKey: 'ErrorNotFoundBody',
+    cta: ERROR_CTA.CONTACT_SUPPORT,
+  },
+  [PAY_BY_LINK_ERROR.EXPIRED]: {
+    titleKey: 'ErrorExpiredTitle',
+    bodyKey: 'ErrorExpiredBody',
+    cta: ERROR_CTA.CONTACT_SUPPORT,
+  },
+  [PAY_BY_LINK_ERROR.ALREADY_COMPLETED]: {
+    titleKey: 'ErrorAlreadyCompletedTitle',
+    bodyKey: 'ErrorAlreadyCompletedBody',
+    cta: ERROR_CTA.NONE,
+  },
+  [PAY_BY_LINK_ERROR.CANCELLED]: {
+    titleKey: 'ErrorCancelledTitle',
+    bodyKey: 'ErrorCancelledBody',
+    cta: ERROR_CTA.CONTACT_SUPPORT,
+  },
+  [PAY_BY_LINK_ERROR.GATEWAY_DECLINE]: {
+    titleKey: 'ErrorGatewayDeclineTitle',
+    bodyKey: 'ErrorGatewayDeclineBody',
+    cta: ERROR_CTA.TRY_AGAIN,
+  },
+  [PAY_BY_LINK_ERROR.SDK_LOAD_FAILURE]: {
+    titleKey: 'ErrorSdkLoadFailureTitle',
+    bodyKey: 'ErrorSdkLoadFailureBody',
+    cta: ERROR_CTA.TRY_AGAIN,
+  },
+  [PAY_BY_LINK_ERROR.GENERIC]: {
+    titleKey: 'ErrorGenericTitle',
+    bodyKey: 'ErrorGenericBody',
+    cta: ERROR_CTA.TRY_AGAIN,
+  },
+};
+
+const KNOWN_STATES = new Set(Object.values(PAY_BY_LINK_ERROR));
+
+const HTTP_STATUS_TO_STATE = {
+  404: PAY_BY_LINK_ERROR.NOT_FOUND,
+  409: PAY_BY_LINK_ERROR.CANCELLED,
+  410: PAY_BY_LINK_ERROR.EXPIRED,
+};
+
+// TODO(ACCS-<ticket>): confirm backend error codes before relying on these.
+const BACKEND_CODE_TO_STATE = {
+  PAY_BY_LINK_TOKEN_NOT_FOUND: PAY_BY_LINK_ERROR.NOT_FOUND,
+  PAY_BY_LINK_TOKEN_CANCELLED: PAY_BY_LINK_ERROR.CANCELLED,
+  PAY_BY_LINK_TOKEN_EXPIRED: PAY_BY_LINK_ERROR.EXPIRED,
+  PAY_BY_LINK_ALREADY_COMPLETED: PAY_BY_LINK_ERROR.ALREADY_COMPLETED,
+  PAY_BY_LINK_GATEWAY_DECLINE: PAY_BY_LINK_ERROR.GATEWAY_DECLINE,
+};
+
+function getHttpStatus(error) {
+  if (!error || typeof error !== 'object') return undefined;
+  const status = error.status
+      ?? error.statusCode
+      ?? error.response?.status
+      ?? error.networkError?.statusCode;
+  return typeof status === 'number' ? status : undefined;
+}
+
+function getBackendCode(error) {
+  if (!error || typeof error !== 'object') return undefined;
+  const code = error.extensions?.code
+      ?? error.graphQLErrors?.[0]?.extensions?.code
+      ?? error.body?.error?.code
+      ?? error.code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+export function mapErrorToState(error) {
+  if (typeof error === 'string' && KNOWN_STATES.has(error)) return error;
+
+  const code = getBackendCode(error);
+  if (code && BACKEND_CODE_TO_STATE[code]) return BACKEND_CODE_TO_STATE[code];
+
+  const status = getHttpStatus(error);
+  if (status && HTTP_STATUS_TO_STATE[status]) return HTTP_STATUS_TO_STATE[status];
+
+  return PAY_BY_LINK_ERROR.GENERIC;
+}

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -1,16 +1,43 @@
 const PAY_PATH = '/drafts/aries/pay';
 const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 
+function stubNonPayByLinkGraphql() {
+  cy.intercept('GET', '**/graphql*', {
+    body: {
+      data: {
+        storeConfig: {
+          share_active_segments: false,
+          graphql_share_customer_group: false,
+          share_applied_cart_rule: false,
+        },
+      },
+    },
+  });
+  cy.intercept('POST', '**/graphql*', (req) => {
+    const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+    if (!query.includes('PAY_BY_LINK_ORDER')) {
+      req.reply({ body: { data: {} } });
+    }
+  });
+}
+
 function stubPayByLinkOrder(body) {
+  stubNonPayByLinkGraphql();
   cy.intercept('POST', '**/graphql*', (req) => {
     const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
     if (query.includes('PAY_BY_LINK_ORDER')) {
       const responseBody = typeof body === 'function' ? body(req) : body;
       req.reply({ body: responseBody });
-      return;
     }
-    req.reply({ body: { data: {} } });
   }).as('payByLinkOrder');
+}
+
+function warmUpPayPage() {
+  cy.request({
+    url: PAY_PATH,
+    retryOnStatusCodeFailure: true,
+    timeout: 120000,
+  });
 }
 
 function assertErrorCard(state, { cta = 'contactSupport' } = {}) {
@@ -48,6 +75,8 @@ function assertErrorCard(state, { cta = 'contactSupport' } = {}) {
 }
 
 describe('Pay By Link — API-driven error states', () => {
+  before(warmUpPayPage);
+
   it('renders the not-found token error state', () => {
     stubPayByLinkOrder({
       data: { payByLinkOrder: null },

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -9,7 +9,7 @@ function stubPayByLinkOrder(body) {
       req.reply({ body: responseBody });
       return;
     }
-    req.continue();
+    req.reply({ body: { data: {} } });
   }).as('payByLinkOrder');
 }
 

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -5,7 +5,9 @@ function stubPayByLinkOrder(body) {
     const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
     if (query.includes('PAY_BY_LINK_ORDER')) {
       req.reply({ body });
+      return;
     }
+    req.continue();
   }).as('payByLinkOrder');
 }
 
@@ -17,7 +19,6 @@ function assertApiErrorCard(state, { expectCta = true } = {}) {
   cy.get('.pay-by-link__error-title')
     .should('be.visible')
     .should('have.attr', 'tabindex', '-1')
-    .should('have.focus')
     .invoke('text')
     .should('match', /\S/);
 

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -1,0 +1,83 @@
+const PAY_PATH = '/drafts/aries/pay';
+
+const runner = Cypress.env('payByLinkQueryWired') ? describe : describe.skip;
+
+function interceptPayByLinkOrder(response) {
+  cy.intercept('**/graphql*', (req) => {
+    const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+    if (body.includes('payByLinkOrder')) {
+      req.reply(response);
+    }
+  }).as('payByLinkOrder');
+}
+
+function assertApiErrorCard(state, { expectCta = true } = {}) {
+  cy.get(`.pay-by-link.pay-by-link--error[data-state="${state}"]`).should('be.visible');
+  cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
+  cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
+
+  cy.get('.pay-by-link__error-title')
+    .should('be.visible')
+    .should('have.attr', 'tabindex', '-1')
+    .should('have.focus')
+    .invoke('text')
+    .should('match', /\S/);
+
+  cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+
+  if (expectCta) {
+    cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
+  } else {
+    cy.get('[data-testid="pay-by-link-error-cta"]').should('not.exist');
+  }
+}
+
+runner('Pay By Link — API-driven error states', () => {
+  // 64-char lowercase hex — required for the block to attempt the query at all.
+  const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
+
+  it('renders the expired token error state', () => {
+    // Backend codes mirror BACKEND_CODE_TO_STATE in errors/error-states.js.
+    interceptPayByLinkOrder({
+      statusCode: 200,
+      body: {
+        errors: [{ message: 'token expired', extensions: { code: 'PAY_BY_LINK_TOKEN_EXPIRED' } }],
+        data: { payByLinkOrder: null },
+      },
+    });
+
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    assertApiErrorCard('expired');
+  });
+
+  it('renders the already-completed token error state', () => {
+    interceptPayByLinkOrder({
+      statusCode: 200,
+      body: {
+        errors: [{ message: 'already completed', extensions: { code: 'PAY_BY_LINK_ALREADY_COMPLETED' } }],
+        data: { payByLinkOrder: null },
+      },
+    });
+
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    assertApiErrorCard('already-completed', { expectCta: false });
+  });
+
+  it('renders the generic / unexpected error state', () => {
+    interceptPayByLinkOrder({
+      statusCode: 500,
+      body: {
+        errors: [{ message: 'internal error' }],
+      },
+    });
+
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    assertApiErrorCard('generic');
+  });
+});

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -1,7 +1,5 @@
 const PAY_PATH = '/drafts/aries/pay';
 
-const runner = Cypress.env('payByLinkQueryWired') ? describe : describe.skip;
-
 function interceptPayByLinkOrder(response) {
   cy.intercept('**/graphql*', (req) => {
     const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
@@ -32,7 +30,7 @@ function assertApiErrorCard(state, { expectCta = true } = {}) {
   }
 }
 
-runner('Pay By Link — API-driven error states', () => {
+describe('Pay By Link — API-driven error states', () => {
   // 64-char lowercase hex — required for the block to attempt the query at all.
   const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -1,38 +1,67 @@
 const PAY_PATH = '/drafts/aries/pay';
+const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 
 function stubPayByLinkOrder(body) {
   cy.intercept('POST', '**/graphql*', (req) => {
     const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
     if (query.includes('PAY_BY_LINK_ORDER')) {
-      req.reply({ body });
+      const responseBody = typeof body === 'function' ? body(req) : body;
+      req.reply({ body: responseBody });
       return;
     }
     req.continue();
   }).as('payByLinkOrder');
 }
 
-function assertApiErrorCard(state, { expectCta = true } = {}) {
+function assertErrorCard(state, { cta = 'contactSupport' } = {}) {
   cy.get(`.pay-by-link.pay-by-link--error[data-state="${state}"]`).should('be.visible');
   cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
   cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
 
   cy.get('.pay-by-link__error-title')
-    .should('be.visible')
-    .should('have.attr', 'tabindex', '-1')
-    .invoke('text')
-    .should('match', /\S/);
+    .should('exist')
+    .should('have.attr', 'tabindex', '-1');
 
-  cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+  cy.get('.pay-by-link__error-body').should('exist');
 
-  if (expectCta) {
-    cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
-  } else {
+  if (cta === 'none') {
     cy.get('[data-testid="pay-by-link-error-cta"]').should('not.exist');
+    return;
+  }
+
+  cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
+
+  if (cta === 'contactSupport') {
+    cy.get('[data-testid="pay-by-link-error-cta"]').then(($el) => {
+      const hasHref = $el.is('a[href]') || $el.find('a[href]').length > 0;
+      expect(hasHref, 'contact support CTA should link to support').to.be.true;
+    });
+    return;
+  }
+
+  if (cta === 'tryAgain') {
+    cy.get('[data-testid="pay-by-link-error-cta"]').then(($el) => {
+      const isButton = $el.is('button') || $el.find('button').length > 0;
+      expect(isButton, 'try again CTA should be a button').to.be.true;
+    });
   }
 }
 
 describe('Pay By Link — API-driven error states', () => {
-  const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
+  it('renders the not-found token error state', () => {
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{
+        message: 'Pay By Link token was not found.',
+        extensions: { code: 'TOKEN_NOT_FOUND', category: 'graphql-input' },
+      }],
+    });
+
+    cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+    cy.wait('@payByLinkOrder');
+
+    assertErrorCard('not-found', { cta: 'contactSupport' });
+  });
 
   it('renders the expired token error state', () => {
     stubPayByLinkOrder({
@@ -46,7 +75,7 @@ describe('Pay By Link — API-driven error states', () => {
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
     cy.wait('@payByLinkOrder');
 
-    assertApiErrorCard('expired');
+    assertErrorCard('expired', { cta: 'contactSupport' });
   });
 
   it('renders the already-completed token error state', () => {
@@ -61,7 +90,7 @@ describe('Pay By Link — API-driven error states', () => {
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
     cy.wait('@payByLinkOrder');
 
-    assertApiErrorCard('already-completed', { expectCta: false });
+    assertErrorCard('already-completed', { cta: 'none' });
   });
 
   it('renders the generic / unexpected error state', () => {
@@ -73,6 +102,34 @@ describe('Pay By Link — API-driven error states', () => {
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
     cy.wait('@payByLinkOrder');
 
-    assertApiErrorCard('generic');
+    assertErrorCard('generic', { cta: 'tryAgain' });
+  });
+
+  it('retries the payByLinkOrder query when Try again is clicked on generic error', () => {
+    cy.fixture('payByLinkOrder').then((fixture) => {
+      let callCount = 0;
+
+      stubPayByLinkOrder(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            data: { payByLinkOrder: null },
+            errors: [{ message: 'internal error' }],
+          };
+        }
+        return fixture;
+      });
+
+      cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
+      cy.wait('@payByLinkOrder');
+      assertErrorCard('generic', { cta: 'tryAgain' });
+
+      cy.get('[data-testid="pay-by-link-error-cta"]').click();
+      cy.wait('@payByLinkOrder');
+
+      cy.get('.pay-by-link--error').should('not.exist');
+      cy.get('.pay-by-link__order-summary').should('be.visible');
+      cy.then(() => expect(callCount).to.eq(2));
+    });
   });
 });

--- a/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkErrorStates.spec.js
@@ -1,10 +1,10 @@
 const PAY_PATH = '/drafts/aries/pay';
 
-function interceptPayByLinkOrder(response) {
-  cy.intercept('**/graphql*', (req) => {
-    const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
-    if (body.includes('payByLinkOrder')) {
-      req.reply(response);
+function stubPayByLinkOrder(body) {
+  cy.intercept('POST', '**/graphql*', (req) => {
+    const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+    if (query.includes('PAY_BY_LINK_ORDER')) {
+      req.reply({ body });
     }
   }).as('payByLinkOrder');
 }
@@ -31,17 +31,15 @@ function assertApiErrorCard(state, { expectCta = true } = {}) {
 }
 
 describe('Pay By Link — API-driven error states', () => {
-  // 64-char lowercase hex — required for the block to attempt the query at all.
   const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 
   it('renders the expired token error state', () => {
-    // Backend codes mirror BACKEND_CODE_TO_STATE in errors/error-states.js.
-    interceptPayByLinkOrder({
-      statusCode: 200,
-      body: {
-        errors: [{ message: 'token expired', extensions: { code: 'PAY_BY_LINK_TOKEN_EXPIRED' } }],
-        data: { payByLinkOrder: null },
-      },
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{
+        message: 'Pay By Link token has expired.',
+        extensions: { code: 'TOKEN_EXPIRED', category: 'graphql-input' },
+      }],
     });
 
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
@@ -51,12 +49,12 @@ describe('Pay By Link — API-driven error states', () => {
   });
 
   it('renders the already-completed token error state', () => {
-    interceptPayByLinkOrder({
-      statusCode: 200,
-      body: {
-        errors: [{ message: 'already completed', extensions: { code: 'PAY_BY_LINK_ALREADY_COMPLETED' } }],
-        data: { payByLinkOrder: null },
-      },
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{
+        message: 'Order has already been paid.',
+        extensions: { code: 'ORDER_ALREADY_PAID', category: 'graphql-input' },
+      }],
     });
 
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
@@ -66,11 +64,9 @@ describe('Pay By Link — API-driven error states', () => {
   });
 
   it('renders the generic / unexpected error state', () => {
-    interceptPayByLinkOrder({
-      statusCode: 500,
-      body: {
-        errors: [{ message: 'internal error' }],
-      },
+    stubPayByLinkOrder({
+      data: { payByLinkOrder: null },
+      errors: [{ message: 'internal error' }],
     });
 
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);

--- a/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
@@ -5,18 +5,38 @@ const PAY_PATH = '/drafts/aries/pay';
 // Structurally-valid 64-char hex token used across all tests.
 const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 
-describe('Pay By Link — Order Summary (ACCS-873)', () => {
-  function stubPayByLinkOrder(body) {
-    cy.intercept('POST', '**/graphql*', (req) => {
-      const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
-      if (query.includes('PAY_BY_LINK_ORDER')) {
-        req.reply({ body });
-        return;
-      }
-      req.continue();
-    }).as('payByLinkOrder');
-  }
+function stubPayByLinkOrder(body) {
+  cy.intercept('POST', '**/graphql*', (req) => {
+    const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+    if (query.includes('PAY_BY_LINK_ORDER')) {
+      const responseBody = typeof body === 'function' ? body(req) : body;
+      req.reply({ body: responseBody });
+      return;
+    }
+    req.continue();
+  }).as('payByLinkOrder');
+}
 
+function assertErrorCard(state, { expectCta = true } = {}) {
+  cy.get(`.pay-by-link.pay-by-link--error[data-state="${state}"]`).should('be.visible');
+  cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
+  cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
+
+  cy.get('.pay-by-link__error-title')
+    .should('have.attr', 'tabindex', '-1')
+    .invoke('text')
+    .should('match', /\S/);
+
+  cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+
+  if (expectCta) {
+    cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
+  } else {
+    cy.get('[data-testid="pay-by-link-error-cta"]').should('not.exist');
+  }
+}
+
+describe('Pay By Link — Order Summary (ACCS-873)', () => {
   it('renders the order summary for a valid token (happy path)', () => {
     cy.fixture('payByLinkOrder').then((fixture) => {
       stubPayByLinkOrder(fixture);
@@ -59,15 +79,7 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
     cy.wait('@payByLinkOrder');
 
-    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
-    cy.get('.pay-by-link__error-card[role="alert"]')
-      .should('be.visible')
-      .should('have.attr', 'aria-live', 'assertive');
-    cy.get('.pay-by-link__error-title')
-      .should('have.attr', 'tabindex', '-1')
-      .invoke('text')
-      .should('match', /\S/);
-    cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+    assertErrorCard('expired');
   });
 
   it('renders the already-paid error state', () => {
@@ -81,9 +93,7 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
     cy.wait('@payByLinkOrder');
 
-    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
-    cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
-    cy.get('.pay-by-link__error-title').invoke('text').should('match', /\S/);
+    assertErrorCard('already-completed', { expectCta: false });
   });
 
   it('renders the cancelled-order error state', () => {
@@ -97,15 +107,13 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
     cy.wait('@payByLinkOrder');
 
-    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
-    cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
-    cy.get('.pay-by-link__error-title').invoke('text').should('match', /\S/);
+    assertErrorCard('cancelled');
   });
 
   it('shows the loading skeleton while the query is in flight and removes it after', () => {
     cy.fixture('payByLinkOrder').then((fixture) => {
       cy.intercept('POST', '**/graphql*', (req) => {
-        const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+        const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || {});
         if (query.includes('PAY_BY_LINK_ORDER')) {
           req.reply({ body: fixture, delay: 2000 });
           return;

--- a/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
@@ -11,7 +11,9 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
       const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
       if (query.includes('PAY_BY_LINK_ORDER')) {
         req.reply({ body });
+        return;
       }
+      req.continue();
     }).as('payByLinkOrder');
   }
 
@@ -102,23 +104,17 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
 
   it('shows the loading skeleton while the query is in flight and removes it after', () => {
     cy.fixture('payByLinkOrder').then((fixture) => {
-      let resolveQuery;
-
       cy.intercept('POST', '**/graphql*', (req) => {
         const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
         if (query.includes('PAY_BY_LINK_ORDER')) {
-          return new Promise((resolve) => {
-            resolveQuery = () => {
-              req.reply({ body: fixture });
-              resolve();
-            };
-          });
+          req.reply({ body: fixture, delay: 2000 });
+          return;
         }
+        req.continue();
       }).as('payByLinkOrder');
 
       cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);
       cy.get('.pay-by-link__skeleton').should('exist');
-      cy.then(() => resolveQuery?.());
       cy.wait('@payByLinkOrder');
       cy.get('.pay-by-link__skeleton').should('not.exist');
     });

--- a/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
@@ -13,7 +13,8 @@ function stubPayByLinkOrder(body) {
       req.reply({ body: responseBody });
       return;
     }
-    req.continue();
+    // Other dropins (e.g. personalization) also call GraphQL on page load.
+    req.reply({ body: { data: {} } });
   }).as('payByLinkOrder');
 }
 
@@ -23,11 +24,10 @@ function assertErrorCard(state, { expectCta = true } = {}) {
   cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
 
   cy.get('.pay-by-link__error-title')
-    .should('have.attr', 'tabindex', '-1')
-    .invoke('text')
-    .should('match', /\S/);
+    .should('exist')
+    .should('have.attr', 'tabindex', '-1');
 
-  cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+  cy.get('.pay-by-link__error-body').should('exist');
 
   if (expectCta) {
     cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
@@ -118,7 +118,7 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
           req.reply({ body: fixture, delay: 2000 });
           return;
         }
-        req.continue();
+        req.reply({ body: { data: {} } });
       }).as('payByLinkOrder');
 
       cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);

--- a/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkOrderSummary.spec.js
@@ -5,16 +5,34 @@ const PAY_PATH = '/drafts/aries/pay';
 // Structurally-valid 64-char hex token used across all tests.
 const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 
+function stubNonPayByLinkGraphql() {
+  cy.intercept('GET', '**/graphql*', {
+    body: {
+      data: {
+        storeConfig: {
+          share_active_segments: false,
+          graphql_share_customer_group: false,
+          share_applied_cart_rule: false,
+        },
+      },
+    },
+  });
+  cy.intercept('POST', '**/graphql*', (req) => {
+    const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+    if (!query.includes('PAY_BY_LINK_ORDER')) {
+      req.reply({ body: { data: {} } });
+    }
+  });
+}
+
 function stubPayByLinkOrder(body) {
+  stubNonPayByLinkGraphql();
   cy.intercept('POST', '**/graphql*', (req) => {
     const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
     if (query.includes('PAY_BY_LINK_ORDER')) {
       const responseBody = typeof body === 'function' ? body(req) : body;
       req.reply({ body: responseBody });
-      return;
     }
-    // Other dropins (e.g. personalization) also call GraphQL on page load.
-    req.reply({ body: { data: {} } });
   }).as('payByLinkOrder');
 }
 
@@ -112,13 +130,12 @@ describe('Pay By Link — Order Summary (ACCS-873)', () => {
 
   it('shows the loading skeleton while the query is in flight and removes it after', () => {
     cy.fixture('payByLinkOrder').then((fixture) => {
+      stubNonPayByLinkGraphql();
       cy.intercept('POST', '**/graphql*', (req) => {
         const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || {});
         if (query.includes('PAY_BY_LINK_ORDER')) {
           req.reply({ body: fixture, delay: 2000 });
-          return;
         }
-        req.reply({ body: { data: {} } });
       }).as('payByLinkOrder');
 
       cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);

--- a/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
@@ -9,12 +9,10 @@ function assertErrorCard(state) {
   cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
 
   cy.get('.pay-by-link__error-title')
-    .should('be.visible')
-    .should('have.attr', 'tabindex', '-1')
-    .invoke('text')
-    .should('match', /\S/);
+    .should('exist')
+    .should('have.attr', 'tabindex', '-1');
 
-  cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+  cy.get('.pay-by-link__error-body').should('exist');
   cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
 }
 
@@ -51,7 +49,9 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
       const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
       if (body.includes('PAY_BY_LINK_ORDER')) {
         req.reply({ fixture: 'payByLinkOrder' });
+        return;
       }
+      req.reply({ body: { data: {} } });
     }).as('payByLinkOrder');
 
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);

--- a/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
@@ -1,11 +1,24 @@
 // Path of the authored Pay By Link page in DA. Lives under /drafts/aries/ during
 // the ACCS-869 demo phase; update to /pay when the document graduates out of drafts.
 const PAY_PATH = '/drafts/aries/pay';
+const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
+
+function assertErrorCard(state) {
+  cy.get(`.pay-by-link.pay-by-link--error[data-state="${state}"]`).should('be.visible');
+  cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
+  cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
+
+  cy.get('.pay-by-link__error-title')
+    .should('be.visible')
+    .should('have.attr', 'tabindex', '-1')
+    .invoke('text')
+    .should('match', /\S/);
+
+  cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
+  cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
+}
 
 describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
-  // 64-char lowercase hex matches the HLD §5.A token spec.
-  const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
-
   // Tracks GraphQL requests whose body references the payByLinkOrder operation.
   // Other commerce dropins (cart, auth) issue unrelated GraphQL calls on every
   // page load; those are out of scope for this assertion.
@@ -22,30 +35,14 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
   it('renders the missing-token error state when /pay has no token', () => {
     cy.visit(PAY_PATH);
 
-    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
-    cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
-    cy.get('.pay-by-link__error-card').should('have.attr', 'aria-live', 'assertive');
-
-    cy.get('.pay-by-link__error-title')
-      .should('be.visible')
-      .should('have.attr', 'tabindex', '-1')
-      .invoke('text')
-      .should('match', /\S/);
-
-    cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
-    cy.get('[data-testid="pay-by-link-error-cta"]').should('be.visible');
-
+    assertErrorCard('missing');
     cy.then(() => expect(payByLinkOrderCalls).to.have.length(0));
   });
 
   it('renders the malformed-token error state when /pay has an invalid token', () => {
     cy.visit(`${PAY_PATH}?token=garbage`);
 
-    cy.get('.pay-by-link.pay-by-link--error').should('be.visible');
-    cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
-    cy.get('.pay-by-link__error-title').invoke('text').should('match', /\S/);
-    cy.get('.pay-by-link__error-body').invoke('text').should('match', /\S/);
-
+    assertErrorCard('malformed');
     cy.then(() => expect(payByLinkOrderCalls).to.have.length(0));
   });
 

--- a/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
+++ b/cypress/src/tests/e2eTests/verifyPayByLinkPageShell.spec.js
@@ -3,6 +3,26 @@
 const PAY_PATH = '/drafts/aries/pay';
 const VALID_TOKEN = '4d6b20e9f8ed98dcb4287ad80b2e82206c71e4abe0bc3e04015c9ca5ec629d59';
 
+function stubNonPayByLinkGraphql() {
+  cy.intercept('GET', '**/graphql*', {
+    body: {
+      data: {
+        storeConfig: {
+          share_active_segments: false,
+          graphql_share_customer_group: false,
+          share_applied_cart_rule: false,
+        },
+      },
+    },
+  });
+  cy.intercept('POST', '**/graphql*', (req) => {
+    const query = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
+    if (!query.includes('PAY_BY_LINK_ORDER')) {
+      req.reply({ body: { data: {} } });
+    }
+  });
+}
+
 function assertErrorCard(state) {
   cy.get(`.pay-by-link.pay-by-link--error[data-state="${state}"]`).should('be.visible');
   cy.get('.pay-by-link__error-card[role="alert"]').should('be.visible');
@@ -24,7 +44,8 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
 
   beforeEach(() => {
     payByLinkOrderCalls = [];
-    cy.intercept('**/graphql*', (req) => {
+    stubNonPayByLinkGraphql();
+    cy.intercept('POST', '**/graphql*', (req) => {
       const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
       if (body.includes('payByLinkOrder')) payByLinkOrderCalls.push(req);
     });
@@ -49,9 +70,7 @@ describe('Pay By Link — /pay route & page shell (ACCS-869)', () => {
       const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body || '');
       if (body.includes('PAY_BY_LINK_ORDER')) {
         req.reply({ fixture: 'payByLinkOrder' });
-        return;
       }
-      req.reply({ body: { data: {} } });
     }).as('payByLinkOrder');
 
     cy.visit(`${PAY_PATH}?token=${VALID_TOKEN}`);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://ACCS-871--aem-boilerplate-commerce--hlxsites.aem.live/

Ticket:
https://jira.corp.adobe.com/browse/ACCS-871

**Changes**

Shared error modules in `blocks/commerce-pay-by-link/errors/`:
  - `error-states.js` — 9 states, backend code + HTTP status mapping (`404`/`409`/`410`), `resolveOnRetry()`
  - `error-card.js` — accessible error UI (`role="alert"`, focus management, Elsie Button CTAs), plus `renderMappedError()` for API failures
- Block integration:
  - Pre-flight errors (missing/malformed token) → `renderErrorCard()`
  - `payByLinkOrder` failures → `renderMappedError()` with automatic retry for generic errors
- i18n via `PayByLink.*` da.live placeholders (including `ErrorGenericTitle` / `ErrorGenericBody` / `ErrorTryAgainLabel`)
- Cypress E2E: `verifyPayByLinkPageShell`, `verifyPayByLinkOrderSummary`, `verifyPayByLinkErrorStates` (not-found, expired, already-completed, generic + retry)
- Block README documenting states, exports, and i18n keys

<img width="1427" height="858" alt="PaymentLink Missing" src="https://github.com/user-attachments/assets/0256c106-d3aa-4ebf-8d13-2059ab0d1f1b" />
<img width="1427" height="852" alt="PaymentLink Not Valid" src="https://github.com/user-attachments/assets/f919b1a4-d9ce-42fc-a1b1-088294f806c8" />
<img width="1414" height="853" alt="Payment Not Found" src="https://github.com/user-attachments/assets/465e3513-4535-4f64-9058-2b8ba9be3c1e" />

