### PR TITLE
USF-4155 Automate dropin health checks via GitHub Actions

### DIFF
--- a/.github/workflows/dropin-health.yml
+++ b/.github/workflows/dropin-health.yml
@@ -1,0 +1,92 @@
+name: Dropin Health Check
+
+# This workflow does NOT validate individual feature PRs.
+# It validates that the release candidate (release/* branches) remains healthy
+# against the latest dropin registry from @dropins/mcp.
+
+on:
+  pull_request:
+    branches: [main, b2b]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'blocks/**'
+      - 'scripts/initializers/**'
+      - 'package.json'
+  push:
+    branches: [main, b2b]
+    paths:
+      - 'blocks/**'
+      - 'scripts/initializers/**'
+      - 'package.json'
+  schedule:
+    # Weekly Monday 8:00 UTC — detect drift from new dropin releases
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      startsWith(github.head_ref, 'release/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run dropin block health check
+        id: health
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          npx --yes @dropins/mcp@latest check-health --fix --fail-on error --json | tee health.json
+
+      - name: Print findings
+        if: always()
+        run: |
+          if [ -f health.json ]; then
+            node -e "
+              const r = JSON.parse(require('fs').readFileSync('health.json','utf8'));
+              const icon = s => s === 'error' ? '❌' : '⚠️';
+              const fmt = (prefix, f) => '  ' + icon(f.severity) + ' [' + f.severity + '] ' + prefix + ': ' + f.detail + (f.fix?.hint ? ' → ' + f.fix.hint : '');
+              console.log(r.message);
+              (r.data?.blocks || []).filter(b => !b.healthy).forEach(b => {
+                b.findings.forEach(f => console.log(fmt(b.block, f)));
+              });
+              (r.data?.initializers?.findings || []).forEach(f => {
+                console.log(fmt('initializer', f));
+              });
+              (r.data?.findings || []).forEach(f => {
+                console.log(fmt(r.data.block || 'block', f));
+              });
+            "
+          fi
+
+      - name: Post job summary
+        if: always()
+        run: |
+          if [ -f health.json ]; then
+            echo "## Dropin Health Check" >> $GITHUB_STEP_SUMMARY
+            node -e "
+              const r = JSON.parse(require('fs').readFileSync('health.json','utf8'));
+              const icon = s => s === 'error' ? '❌' : '⚠️';
+              const fmt = (prefix, f) => '- ' + icon(f.severity) + ' **' + prefix + '** [' + f.severity + ']: ' + f.detail;
+              console.log(r.message);
+              console.log('');
+              (r.data?.blocks || []).filter(b => !b.healthy).forEach(b => {
+                b.findings.forEach(f => console.log(fmt(b.block, f)));
+              });
+              (r.data?.initializers?.findings || []).forEach(f => {
+                console.log(fmt('initializer', f));
+              });
+              (r.data?.findings || []).forEach(f => {
+                console.log(fmt(r.data.block || 'block', f));
+              });
+            " >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Fail if unhealthy
+        if: steps.health.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/dropin-health.yml
+++ b/.github/workflows/dropin-health.yml
@@ -1,22 +1,10 @@
 name: Dropin Health Check
 
-# Monitors the health of blocks and initializers against the published dropin
-# registry. Runs after changes land on main/b2b, on a weekly schedule to detect
-# silent drift from new dropin releases, and on demand.
-#
-# Not used as a PR gate: the MCP registry is updated after each dropin release,
-# so checking during a release PR would use stale registry data.
+# Validates block and initializer health against the published dropin registry.
+# Run manually after each dropin release, once the MCP registry has been updated,
+# to confirm main is in sync with the latest published API surface.
 
 on:
-  push:
-    branches: [main, b2b]
-    paths:
-      - 'blocks/**'
-      - 'scripts/initializers/**'
-      - 'package.json'
-  schedule:
-    # Weekly Monday 8:00 UTC — detect drift from new dropin releases
-    - cron: '0 8 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dropin-health.yml
+++ b/.github/workflows/dropin-health.yml
@@ -1,17 +1,13 @@
 name: Dropin Health Check
 
-# This workflow does NOT validate individual feature PRs.
-# It validates that the release candidate (release/* branches) remains healthy
-# against the latest dropin registry from @dropins/mcp.
+# Monitors the health of blocks and initializers against the published dropin
+# registry. Runs after changes land on main/b2b, on a weekly schedule to detect
+# silent drift from new dropin releases, and on demand.
+#
+# Not used as a PR gate: the MCP registry is updated after each dropin release,
+# so checking during a release PR would use stale registry data.
 
 on:
-  pull_request:
-    branches: [main, b2b]
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'blocks/**'
-      - 'scripts/initializers/**'
-      - 'package.json'
   push:
     branches: [main, b2b]
     paths:
@@ -26,9 +22,6 @@ on:
 jobs:
   health-check:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request' ||
-      startsWith(github.head_ref, 'release/')
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
**Description** 
There is no automated way to detect when the project's blocks and initializers fall out of sync with the latest dropin releases. Manual discovery of these issues is slow and typically surfaces only after integration problems appear in production or staging.

**Goal** 
Introduce a manual workflow that validates dropin health on demand, after each dropin release, once the MCP registry has been updated. Findings surface clearly in the CI job summary. The workflow is intentionally manual-only — event-driven triggers (PR, push, schedule) are unreliable because the MCP registry is updated after each dropin release, not before, so any automated trigger risks running against stale registry data.

**Ticket**
[USF-4155](https://jira.corp.adobe.com/browse/USF-4155)

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-4155--aem-boilerplate-commerce--hlxsites.aem.page/