### PR TITLE
USF-4125: Cypress tests to use ACCS Sandbox in case it is not a release branch

### DIFF
--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -36,7 +36,7 @@ jobs:
           command: npm run cypress:saas:run
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
-          CYPRESS_API_ENDPOINT: ${{ secrets.CYPRESS_API_ENDPOINT }}
+          CYPRESS_API_ENDPOINT: ${{ github.base_ref == 'main' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -1,5 +1,5 @@
 name: Cypress E2E SaaS Tests
-on: push
+on: pull_request
 jobs:
   cypress-saas-run:
     # If you want this job to run on your fork, remove the below "if" line.
@@ -9,12 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set storefront config
+        id: config
+        run: |
+          BASE_REF="${{ github.base_ref }}"
+          if [[ "$BASE_REF" == "main" ]]; then
+            echo "aem_url=https://main--boilerplate-accs-prod--adobe-commerce.aem.live/" >> "$GITHUB_OUTPUT"
+            echo "graphql_endpoint=https://na1.api.commerce.adobe.com/MYAtJvyuQfnr4nW37jbfp1/graphql" >> "$GITHUB_OUTPUT"
+          else
+            echo "aem_url=https://main--boilerplate-accs--adobe-commerce.aem.live/" >> "$GITHUB_OUTPUT"
+            echo "graphql_endpoint=https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install root dependencies
         run: npm ci
       - name: Install adobe aem cli dependencies
         run: npm install -g @adobe/aem-cli
       - name: Start server in the background
-        run: aem up --url https://main--boilerplate-accs--adobe-commerce.aem.live/ &
+        run: aem up --url ${{ steps.config.outputs.aem_url }} &
       - name: Install Cypress and run tests
         uses: cypress-io/github-action@v6
         with:
@@ -27,6 +38,7 @@ jobs:
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}
+          CYPRESS_GRAPHQL_ENDPOINT: ${{ steps.config.outputs.graphql_endpoint }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -1,5 +1,7 @@
 name: Cypress E2E SaaS Tests
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 jobs:
   cypress-saas-run:
     # If you want this job to run on your fork, remove the below "if" line.

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -10,7 +10,7 @@ module.exports = defineConfig({
   ...baseConfig,
   env: {
     ...baseConfig.env,
-    graphqlEndPoint: "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
+    graphqlEndPoint: process.env.CYPRESS_GRAPHQL_ENDPOINT ?? "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
     API_ENDPOINT: process.env.CYPRESS_API_ENDPOINT,
     IMS_CLIENT_ID: process.env.CYPRESS_IMS_CLIENT_ID,
     IMS_CLIENT_SECRET: process.env.CYPRESS_IMS_CLIENT_SECRET,


### PR DESCRIPTION
Adapted the run-e2e-tests-saas workflow to use the ACCS Sandbox or Prod instance depending on the base reference branch for a PR: if the PR is open against main, it will execute the Cypress tests using ACCS Prod, otherwise Sandbox.

Fix #[USF-4125](https://jira.corp.adobe.com/browse/USF-4125)

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://USF-4125--aem-boilerplate-commerce--hlxsites.aem.live/
