### PR TITLE
USF-4125: Cypress SaaS tests to use ACCS Prod storefront for release PRs to main

### DIFF
--- a/.github/workflows/run-e2e-tests-aco.yaml
+++ b/.github/workflows/run-e2e-tests-aco.yaml
@@ -26,6 +26,8 @@ jobs:
           - "src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js"
           # Shard 4 — Discovery & search (verifyAemAssets and verifyRecsDisplay are @skipAco)
           - "src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js"
+          # Shard 5 — ACCS Prod specific tests without using Payment Services
+          - "src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js,src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js"
     steps:
       - uses: actions/checkout@v4
       - name: Install root dependencies

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -42,7 +42,7 @@ jobs:
         id: config
         run: |
           BASE_REF="${{ github.base_ref }}"
-          if [[ "$BASE_REF" == "main" ]]; then
+          if [[ "$BASE_REF" == "integration" ]]; then
             echo "aem_url=https://main--boilerplate-accs-prod--adobe-commerce.aem.live/" >> "$GITHUB_OUTPUT"
             echo "graphql_endpoint=https://na1.api.commerce.adobe.com/MYAtJvyuQfnr4nW37jbfp1/graphql" >> "$GITHUB_OUTPUT"
           else
@@ -63,7 +63,7 @@ jobs:
           command: npm run cypress:saas:run -- --spec "${{ matrix.spec }}"
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
-          CYPRESS_API_ENDPOINT: ${{ github.base_ref == 'main' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}
+          CYPRESS_API_ENDPOINT: ${{ github.base_ref == 'integration' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -1,5 +1,7 @@
 name: Cypress E2E SaaS Tests
-on: push
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 jobs:
   cypress-saas-run:
     # If you want this job to run on your fork, remove the below "if" line.
@@ -36,12 +38,23 @@ jobs:
           - "src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js"
     steps:
       - uses: actions/checkout@v4
+      - name: Set storefront config
+        id: config
+        run: |
+          BASE_REF="${{ github.base_ref }}"
+          if [[ "$BASE_REF" == "main" ]]; then
+            echo "aem_url=https://main--boilerplate-accs-prod--adobe-commerce.aem.live/" >> "$GITHUB_OUTPUT"
+            echo "graphql_endpoint=https://na1.api.commerce.adobe.com/MYAtJvyuQfnr4nW37jbfp1/graphql" >> "$GITHUB_OUTPUT"
+          else
+            echo "aem_url=https://main--boilerplate-accs--adobe-commerce.aem.live/" >> "$GITHUB_OUTPUT"
+            echo "graphql_endpoint=https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install root dependencies
         run: npm ci
       - name: Install adobe aem cli dependencies
         run: npm install -g @adobe/aem-cli
       - name: Start server in the background
-        run: aem up --url https://main--boilerplate-accs--adobe-commerce.aem.live/ &
+        run: aem up --url ${{ steps.config.outputs.aem_url }} &
       - name: Install Cypress and run tests
         uses: cypress-io/github-action@v6
         with:
@@ -50,10 +63,11 @@ jobs:
           command: npm run cypress:saas:run -- --spec "${{ matrix.spec }}"
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
-          CYPRESS_API_ENDPOINT: ${{ secrets.CYPRESS_API_ENDPOINT }}
+          CYPRESS_API_ENDPOINT: ${{ github.base_ref == 'main' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}
+          CYPRESS_GRAPHQL_ENDPOINT: ${{ steps.config.outputs.graphql_endpoint }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -9,6 +9,8 @@ jobs:
     # demo backend.
     if: github.repository == 'hlxsites/aem-boilerplate-commerce'
     runs-on: ubuntu-latest
+    env:
+      IS_PROD_RELEASE: ${{ github.base_ref == 'main' }}
     strategy:
       # Run all shards even if one fails, so a single flaky shard doesn't hide
       # results from the others.
@@ -41,8 +43,7 @@ jobs:
       - name: Set storefront config
         id: config
         run: |
-          BASE_REF="${{ github.base_ref }}"
-          if [[ "$BASE_REF" == "integration" ]]; then
+          if [[ "$IS_PROD_RELEASE" == "true" ]]; then
             echo "aem_url=https://main--boilerplate-accs-prod--adobe-commerce.aem.live/" >> "$GITHUB_OUTPUT"
             echo "graphql_endpoint=https://na1.api.commerce.adobe.com/MYAtJvyuQfnr4nW37jbfp1/graphql" >> "$GITHUB_OUTPUT"
           else
@@ -67,7 +68,7 @@ jobs:
           command: npm run cypress:saas:run -- --spec ${{ matrix.spec }}
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
-          CYPRESS_API_ENDPOINT: ${{ github.base_ref == 'integration' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}
+          CYPRESS_API_ENDPOINT: ${{ env.IS_PROD_RELEASE == 'true' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'hlxsites/aem-boilerplate-commerce'
     runs-on: ubuntu-latest
     env:
-      IS_PROD_RELEASE: ${{ github.base_ref == 'main' }}
+      IS_PROD_RELEASE: ${{ github.base_ref == 'integration' }}
     strategy:
       # Run all shards even if one fails, so a single flaky shard doesn't hide
       # results from the others.

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -24,18 +24,18 @@ jobs:
           # Shard 1 — Auth & account flows
           # Add here if: spec tests sign-in/sign-out, account management pages,
           # authenticated-user wishlist, or event SDK initialization.
-          - "src/tests/e2eTests/verifyAuthUserCheckout.spec.js,src/tests/e2eTests/verifyUserAccount.spec.js,src/tests/e2eTests/verifyAuthUserWishlistFeature.spec.js,src/tests/e2eTests/events/auth.spec.js,src/tests/e2eTests/events/product-page-view.spec.js,src/tests/e2eTests/events/initialization.spec.js"
+          - src/tests/e2eTests/verifyAuthUserCheckout.spec.js,src/tests/e2eTests/verifyUserAccount.spec.js,src/tests/e2eTests/verifyAuthUserWishlistFeature.spec.js,src/tests/e2eTests/events/auth.spec.js,src/tests/e2eTests/events/product-page-view.spec.js,src/tests/e2eTests/events/initialization.spec.js
           # Shard 2 — Guest checkout flows
           # Add here if: spec tests guest checkout (including virtual products),
           # guest wishlist, or event SDK calls fired during cart/checkout/order flows.
-          - "src/tests/e2eTests/verifyGuestUserCheckout.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckout.spec.js,src/tests/e2eTests/verifyGuestUserWishlistFeature.spec.js,src/tests/e2eTests/events/add-to-cart.spec.js,src/tests/e2eTests/events/initiate-checkout.spec.js,src/tests/e2eTests/events/place-order.spec.js,src/tests/e2eTests/events/shopping-cart-view.spec.js"
+          - src/tests/e2eTests/verifyGuestUserCheckout.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckout.spec.js,src/tests/e2eTests/verifyGuestUserWishlistFeature.spec.js,src/tests/e2eTests/events/add-to-cart.spec.js,src/tests/e2eTests/events/initiate-checkout.spec.js,src/tests/e2eTests/events/place-order.spec.js,src/tests/e2eTests/events/shopping-cart-view.spec.js
           # Shard 3 — Cart features + B2B (verifySellerAssistedBuying last so cart is warm)
           # Add here if: spec tests cart manipulation (undo, stock messages, gift cards,
           # store switcher) or B2B seller-assisted buying. Keep ordering-dependent
           # specs last — verifySellerAssistedBuying relies on a warm cart state.
-          - "src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js"
+          - src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js
           # Shard 4 — Discovery & search (events/recs and verifyAemAssets are skipped)
-          - "src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js"
+          - src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js
     steps:
       - uses: actions/checkout@v4
       - name: Set storefront config

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -38,6 +38,8 @@ jobs:
           - "src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js"
           # Shard 4 — Discovery & search (events/recs and verifyAemAssets are skipped)
           - "src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js"
+          # Shard 5 — ACCS Prod specific tests without using Payment Services
+          - "src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js,src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js"
     steps:
       - uses: actions/checkout@v4
       - name: Set storefront config
@@ -65,7 +67,7 @@ jobs:
           # spaces, and quoting it here caused cypress-io/github-action's
           # command execution to leave stray literal `"` characters glued to
           # the first/last spec paths, silently dropping them from every run.
-          command: npm run cypress:saas:run -- --spec ${{ matrix.spec }}
+          command: ${{ env.IS_PROD_RELEASE == 'true' && 'npm run cypress:saas-prod:run' || 'npm run cypress:saas:run' }} -- --spec ${{ matrix.spec }}
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
           CYPRESS_API_ENDPOINT: ${{ env.IS_PROD_RELEASE == 'true' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -24,18 +24,18 @@ jobs:
           # Shard 1 — Auth & account flows
           # Add here if: spec tests sign-in/sign-out, account management pages,
           # authenticated-user wishlist, or event SDK initialization.
-          - src/tests/e2eTests/verifyAuthUserCheckout.spec.js,src/tests/e2eTests/verifyUserAccount.spec.js,src/tests/e2eTests/verifyAuthUserWishlistFeature.spec.js,src/tests/e2eTests/events/auth.spec.js,src/tests/e2eTests/events/product-page-view.spec.js,src/tests/e2eTests/events/initialization.spec.js
+          - "src/tests/e2eTests/verifyAuthUserCheckout.spec.js,src/tests/e2eTests/verifyUserAccount.spec.js,src/tests/e2eTests/verifyAuthUserWishlistFeature.spec.js,src/tests/e2eTests/events/auth.spec.js,src/tests/e2eTests/events/product-page-view.spec.js,src/tests/e2eTests/events/initialization.spec.js"
           # Shard 2 — Guest checkout flows
           # Add here if: spec tests guest checkout (including virtual products),
           # guest wishlist, or event SDK calls fired during cart/checkout/order flows.
-          - src/tests/e2eTests/verifyGuestUserCheckout.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckout.spec.js,src/tests/e2eTests/verifyGuestUserWishlistFeature.spec.js,src/tests/e2eTests/events/add-to-cart.spec.js,src/tests/e2eTests/events/initiate-checkout.spec.js,src/tests/e2eTests/events/place-order.spec.js,src/tests/e2eTests/events/shopping-cart-view.spec.js
+          - "src/tests/e2eTests/verifyGuestUserCheckout.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckout.spec.js,src/tests/e2eTests/verifyGuestUserWishlistFeature.spec.js,src/tests/e2eTests/events/add-to-cart.spec.js,src/tests/e2eTests/events/initiate-checkout.spec.js,src/tests/e2eTests/events/place-order.spec.js,src/tests/e2eTests/events/shopping-cart-view.spec.js"
           # Shard 3 — Cart features + B2B (verifySellerAssistedBuying last so cart is warm)
           # Add here if: spec tests cart manipulation (undo, stock messages, gift cards,
           # store switcher) or B2B seller-assisted buying. Keep ordering-dependent
           # specs last — verifySellerAssistedBuying relies on a warm cart state.
-          - src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js
+          - "src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js"
           # Shard 4 — Discovery & search (events/recs and verifyAemAssets are skipped)
-          - src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js
+          - "src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js"
     steps:
       - uses: actions/checkout@v4
       - name: Set storefront config
@@ -60,7 +60,7 @@ jobs:
         with:
           working-directory: cypress
           wait-on: 'http://localhost:3000'
-          command: npm run cypress:saas:run -- --spec "${{ matrix.spec }}"
+          command: npm run cypress:saas:run -- --spec ${{ matrix.spec }}
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
           CYPRESS_API_ENDPOINT: ${{ github.base_ref == 'integration' && secrets.CYPRESS_API_ENDPOINT_PROD || secrets.CYPRESS_API_ENDPOINT }}

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'hlxsites/aem-boilerplate-commerce'
     runs-on: ubuntu-latest
     env:
-      IS_PROD_RELEASE: ${{ github.base_ref == 'integration' }}
+      IS_PROD_RELEASE: ${{ github.base_ref == 'main' }}
     strategy:
       # Run all shards even if one fails, so a single flaky shard doesn't hide
       # results from the others.

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -34,6 +34,8 @@ jobs:
           - "src/tests/e2eTests/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js,src/tests/e2eTests/verifyCartUndo.spec.js,src/tests/e2eTests/verifyLowStockInfoMessage.spec.js,src/tests/e2eTests/verifyStoreSwitcher.spec.js,src/tests/e2eTests/verifySellerAssistedBuying.spec.js"
           # Shard 4 — Discovery & search (events/recs and verifyAemAssets are skipped)
           - "src/tests/e2eTests/verifyProductSearch.spec.js,src/tests/e2eTests/verifyProductListPage.spec.js,src/tests/e2eTests/verifyRecsDisplay.spec.js,src/tests/e2eTests/verifyAemAssets.spec.js,src/tests/e2eTests/events/recs.spec.js,src/tests/e2eTests/events/search-product-click.spec.js,src/tests/e2eTests/events/search-request-sent.spec.js,src/tests/e2eTests/events/search-results-view.spec.js"
+          # Shard 5 — ACCS Prod specific tests without using Payment Services
+          - "src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js,src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js,src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js"
     steps:
       - uses: actions/checkout@v4
       - name: Install root dependencies

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -25,6 +25,8 @@ All commands use a base config defined in `cypress.base.config.js`, extended by 
 For various reasons, certain tests fail against certain environments. Eventually these issues will be fixed. But for now, if a test is _expected_ to fail on a specific environment, you can assign a tag to it.
 
 - `{ tags: '@skipSaas' }` skips the test when run with `cypress:saas:run`
+- `{ tags: '@skipSaasProd' }` skips the test when run with `cypress:saas-prod:run` in a Production environment
+- `{ tags: '@skipSaasNoProd' }` skips the test when run with `cypress:saas:run` in a non-Production environment
 - `{ tags: '@skipPaas' }` skips the test when run with `cypress:run`
 - `{ tags: '@skipAco' }` skips the test when run with `cypress:aco:run`
 
@@ -37,6 +39,9 @@ For various reasons, certain tests fail against certain environments. Eventually
 | `search-results-view.spec` | SaaS | Epic <https://jira.corp.adobe.com/browse/COMOPT-81> |
 | `verifyAemAssets.spec` | SaaS, PaaS, ACO | AEM Assets not configured on ACO |
 | `verifyRecsDisplay.spec` | SaaS, PaaS, ACO | Recommendations not configured on ACO |
+| `verifyAuthUserCheckout.spec` | SaaSProd | Payment Services not configured on ACCS Prod |
+| `verifyGuestUserCheckout.spec` | SaaSProd | Payment Services not configured on ACCS Prod |
+| `verifyGuestUserVirtualCheckout.spec` | SaaSProd | Payment Services not configured on ACCS Prod |
 
 ## Metadata/SKUs in Tests
 

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -3,19 +3,22 @@ const baseConfig = require("./cypress.base.config");
 
 // A private user used with AEM Assets testing suite.
 const AEM_ASSETS_PRIVATE_USER = JSON.parse(
-  process.env.AEM_ASSETS_PRIVATE_USER ?? "{}"
+  process.env.AEM_ASSETS_PRIVATE_USER ?? "{}",
 );
 
 module.exports = defineConfig({
   ...baseConfig,
   env: {
     ...baseConfig.env,
-    graphqlEndPoint: process.env.CYPRESS_GRAPHQL_ENDPOINT ?? "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
+    graphqlEndPoint:
+      process.env.CYPRESS_GRAPHQL_ENDPOINT ??
+      "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
     API_ENDPOINT: process.env.CYPRESS_API_ENDPOINT,
     IMS_CLIENT_ID: process.env.CYPRESS_IMS_CLIENT_ID,
     IMS_CLIENT_SECRET: process.env.CYPRESS_IMS_CLIENT_SECRET,
     IMS_ORG_ID: process.env.CYPRESS_IMS_ORG_ID,
-    giftCardA: "00419VQ5C341",
+    giftCardA:
+      process.env.IS_PROD_RELEASE === "true" ? "01J2UN97NBO0" : "00419VQ5C341",
     productUrlWithOptions:
       "/products/cypress-configurable-product-latest/cypress456?optionsUIDs=Y29uZmlndXJhYmxlLzkzLzEz",
     stateShippingId: "TX,57",
@@ -26,8 +29,10 @@ module.exports = defineConfig({
 
     aemAssetsConfig: {
       commerceConfig: {
-        coreEndpoint: "https://na1-sandbox.api.commerce.adobe.com/QhUjcEq9dMrdCF7h8a4e5g/graphql",
-        endpoint: "https://na1-sandbox.api.commerce.adobe.com/QhUjcEq9dMrdCF7h8a4e5g/graphql",
+        coreEndpoint:
+          "https://na1-sandbox.api.commerce.adobe.com/QhUjcEq9dMrdCF7h8a4e5g/graphql",
+        endpoint:
+          "https://na1-sandbox.api.commerce.adobe.com/QhUjcEq9dMrdCF7h8a4e5g/graphql",
       },
 
       author: {

--- a/cypress/cypress.saas.config.js
+++ b/cypress/cypress.saas.config.js
@@ -10,7 +10,7 @@ module.exports = defineConfig({
   ...baseConfig,
   env: {
     ...baseConfig.env,
-    graphqlEndPoint: "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
+    graphqlEndPoint: process.env.CYPRESS_GRAPHQL_ENDPOINT ?? "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
     API_ENDPOINT: process.env.CYPRESS_API_ENDPOINT,
     IMS_CLIENT_ID: process.env.CYPRESS_IMS_CLIENT_ID,
     IMS_CLIENT_SECRET: process.env.CYPRESS_IMS_CLIENT_SECRET,

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -7,7 +7,7 @@
     "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas,grepFilterSpecs=true,grepOmitFiltered=true",
     "cypress:percy": "percy exec -- cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas+@snapPercy",
     "cypress:saas:open": "cypress open --browser chrome --config-file cypress.saas.config.js",
-    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=true,grepOmitFiltered=true",
+    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=false,grepOmitFiltered=false",
     "check:shards": "node scripts/check-shard-coverage.js",
     "cypress:aco:open": "cypress open --browser chrome --config-file cypress.aco.config.js",
     "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco,grepFilterSpecs=true,grepOmitFiltered=true"

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -7,7 +7,8 @@
     "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas,grepFilterSpecs=false,grepOmitFiltered=false",
     "cypress:percy": "percy exec -- cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas+@snapPercy",
     "cypress:saas:open": "cypress open --browser chrome --config-file cypress.saas.config.js",
-    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=false,grepOmitFiltered=false",
+    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas+-@skipSaasNoProd,grepFilterSpecs=false,grepOmitFiltered=false",
+    "cypress:saas-prod:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas+-@skipSaasProd,grepFilterSpecs=false,grepOmitFiltered=false",
     "check:shards": "node scripts/check-shard-coverage.js",
     "cypress:aco:open": "cypress open --browser chrome --config-file cypress.aco.config.js",
     "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco,grepFilterSpecs=false,grepOmitFiltered=false"

--- a/cypress/src/tests/e2eTests/verifyAuthUserCheckout.spec.js
+++ b/cypress/src/tests/e2eTests/verifyAuthUserCheckout.spec.js
@@ -33,7 +33,7 @@ import {
 } from "../../fixtures/index";
 import * as fields from "../../fields";
 
-describe("Verify auth user can place order", () => {
+describe("Verify auth user can place order", { tags: "@skipSaasProd" }, () => {
   it("Verify auth user can place order", { tags: "@snapPercy" }, () => {
     // TODO: replace with single "test" product shared between all tests (not this vs products.configurable.urlPathWithOptions).
     cy.visit(products.configurable.urlPathWithOptions);

--- a/cypress/src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js
@@ -1,0 +1,298 @@
+import {
+  setGuestShippingAddress,
+  setGuestBillingAddress,
+  placeOrder,
+  signUpUser,
+  uncheckBillToShippingAddress,
+  checkTermsAndConditions,
+  editProductOptions,
+} from "../../actions";
+import {
+  assertCartSummaryProduct,
+  assertCartSummaryProductsOnCheckout,
+  assertTitleHasLink,
+  assertProductImage,
+  assertCartSummaryMisc,
+  assertOrderSummaryMisc,
+  assertOrderConfirmationCommonDetails,
+  assertOrderConfirmationShippingDetails,
+  assertOrderConfirmationBillingDetails,
+  assertOrderConfirmationShippingMethod,
+  assertSelectedPaymentMethod,
+  assertAuthUser,
+  assertOrderImageDisplay,
+  assertOrderCommentsVisible,
+} from "../../assertions";
+import {
+  customerShippingAddress,
+  customerBillingAddress,
+  checkMoneyOrder,
+  products,
+} from "../../fixtures/index";
+import * as fields from "../../fields";
+
+describe(
+  "Verify auth user can place order",
+  { tags: "@skipSaasNoProd" },
+  () => {
+    it("Verify auth user can place order", { tags: "@snapPercy" }, () => {
+      // TODO: replace with single "test" product shared between all tests (not this vs products.configurable.urlPathWithOptions).
+      cy.visit(products.configurable.urlPathWithOptions);
+      // Wait for the configurable product form to hydrate before adding to cart.
+      cy.contains("Add to Cart").should("be.visible").and("not.be.disabled");
+      cy.get(".minicart-panel").should("be.empty");
+      cy.contains("Add to Cart").click();
+      cy.get(".minicart-wrapper").click();
+      cy.get('.minicart-panel[data-loaded="true"]').should("exist");
+      cy.get(".minicart-panel").should("not.be.empty");
+      assertCartSummaryProduct(
+        "Configurable product",
+        "CYPRESS456",
+        "1",
+        "$60.00",
+        "$60.00",
+        "0",
+      )(".cart-mini-cart");
+      assertTitleHasLink(
+        "Configurable product",
+        "/products/cypress-configurable-product-latest/cypress456",
+      )(".cart-mini-cart");
+      assertProductImage(Cypress.env("productImageNameConfigurable"))(
+        ".cart-mini-cart",
+      );
+      editProductOptions("red", "green");
+      cy.get(".minicart-wrapper").click();
+      cy.get('.minicart-panel[data-loaded="true"]').should("exist");
+      cy.get(".minicart-panel").should("not.be.empty");
+      cy.contains("CYPRESS456-green").should("be.visible");
+      cy.contains("View Cart").click();
+      cy.contains("Shopping Cart (2)").should("be.visible");
+      cy.contains("CYPRESS456-green").should("be.visible");
+
+      // Edit product in Overlay
+      cy.contains("Edit").click();
+      cy.get(".modal-content").should("be.visible");
+      cy.get(".modal-content").assertSelectedProductOption("color", "green");
+      cy.get(".modal-content")
+        .find(".dropin-incrementer__decrease-button")
+        .click();
+      cy.get(".modal-content")
+        .find(".dropin-incrementer__input")
+        .should("have.value", "1");
+      cy.get(".modal-content").selectProductOption("color", "red");
+      cy.get(".modal-content").assertSelectedProductOption("color", "red");
+      cy.percyTakeSnapshot("Cart Edit Overlay");
+      cy.contains("Update in Cart").should("be.visible").click();
+
+      assertCartSummaryProduct(
+        "Configurable product",
+        "CYPRESS456",
+        "1",
+        "$60.00",
+        "$60.00",
+        "0",
+      )(".commerce-cart-wrapper");
+      assertTitleHasLink(
+        "Configurable product",
+        "/products/cypress-configurable-product-latest/cypress456",
+      )(".commerce-cart-wrapper");
+      cy.visit("/customer/create");
+      cy.get(".minicart-wrapper").should("be.visible");
+      cy.fixture("userInfo").then(({ sign_up }) => {
+        signUpUser(sign_up);
+        assertAuthUser(sign_up);
+      });
+      cy.get(".minicart-wrapper").click();
+      cy.get('.minicart-panel[data-loaded="true"]').should("exist");
+      assertCartSummaryProduct(
+        "Configurable product",
+        "CYPRESS456",
+        "1",
+        "$60.00",
+        "$60.00",
+        "0",
+      )(".cart-mini-cart");
+      assertTitleHasLink(
+        "Configurable product",
+        "/products/cypress-configurable-product-latest/cypress456",
+      )(".cart-mini-cart");
+      assertProductImage(Cypress.env("productImageNameConfigurable"))(
+        ".cart-mini-cart",
+      );
+      cy.visit("/products/youth-tee/adb150");
+      // Button can be visible before the product form finishes hydrating;
+      // clicking while still disabled registers in the UI but never reaches
+      // the cart model (see the same pattern guarded against above).
+      cy.get(".product-details__buttons__add-to-cart button")
+        .should("be.visible")
+        .and("not.be.disabled")
+        .click();
+      cy.get(".minicart-wrapper").click();
+      // Panel re-fetches/re-renders cart contents on open; wait for the
+      // loaded flag like the first add-to-cart above, otherwise the
+      // assertion below can run against the stale (pre-add) cart state.
+      cy.get('.minicart-panel[data-loaded="true"]').should("exist");
+      assertCartSummaryProduct(
+        "Youth tee",
+        "ADB150",
+        "1",
+        "$10.00",
+        "$10.00",
+        "0",
+      )(".cart-mini-cart");
+      assertTitleHasLink(
+        "Youth tee",
+        "/products/youth-tee/adb150",
+      )(".cart-mini-cart");
+      assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
+      assertCartSummaryProduct(
+        "Configurable product",
+        "CYPRESS456",
+        "1",
+        "$60.00",
+        "$60.00",
+        "1",
+      )(".cart-mini-cart");
+      assertTitleHasLink(
+        "Configurable product",
+        "/products/cypress-configurable-product-latest/cypress456",
+      )(".cart-mini-cart");
+      assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
+      cy.visit("/cart");
+      assertCartSummaryProduct(
+        "Youth tee",
+        "ADB150",
+        "1",
+        "$10.00",
+        "$10.00",
+        "0",
+      )(".commerce-cart-wrapper");
+      assertTitleHasLink(
+        "Youth tee",
+        "/products/youth-tee/adb150",
+      )(".commerce-cart-wrapper");
+      assertProductImage(Cypress.env("productImageName"))(
+        ".commerce-cart-wrapper",
+      );
+
+      assertCartSummaryProduct(
+        "Configurable product",
+        "CYPRESS456",
+        "1",
+        "$60.00",
+        "$60.00",
+        "1",
+      )(".commerce-cart-wrapper");
+      assertTitleHasLink(
+        "Configurable product",
+        "/products/cypress-configurable-product-latest/cypress456",
+      )(".commerce-cart-wrapper");
+      assertProductImage(Cypress.env("productImageNameConfigurable"))(
+        ".commerce-cart-wrapper",
+      );
+      cy.contains("Estimated Shipping").should("be.visible");
+      cy.percyTakeSnapshot("Cart page");
+      cy.get(".dropin-button.dropin-button--medium.dropin-button--primary")
+        .contains("Checkout")
+        .click({ force: true });
+      assertCartSummaryMisc(2);
+      assertCartSummaryProductsOnCheckout(
+        "Youth tee",
+        "ADB150",
+        "1",
+        "$10.00",
+        "$10.00",
+        "0",
+      );
+      assertCartSummaryProductsOnCheckout(
+        "Configurable product",
+        "CYPRESS456",
+        "1",
+        "$60.00",
+        "$60.00",
+        "1",
+      );
+      setGuestShippingAddress(customerShippingAddress, true);
+      uncheckBillToShippingAddress();
+      setGuestBillingAddress(customerBillingAddress, true);
+      assertOrderSummaryMisc("$70.00", "$10.00", "$80.00");
+      assertSelectedPaymentMethod(checkMoneyOrder.code, 0);
+      checkTermsAndConditions();
+      cy.percyTakeSnapshot("Checkout Page");
+      placeOrder();
+      assertOrderConfirmationCommonDetails(
+        customerBillingAddress,
+        checkMoneyOrder,
+      );
+      assertOrderConfirmationShippingDetails(customerShippingAddress);
+      assertOrderConfirmationBillingDetails(customerBillingAddress);
+      assertOrderConfirmationShippingMethod(customerShippingAddress);
+      cy.percyTakeSnapshot("Order Confirmation");
+
+      /**
+       * TODO - when /customer/order-details page will be ready
+       * Redirect to /order-details?orderRef={ORDER_TOKEN}
+       * Confirm that elements similar to orderConfirmation page present (not exactly the same, separate assert needed)
+       */
+      /**
+       * TODO - when /customer/account page will be ready
+       * Redirect to /customer/account
+       * Confirm that new order is visible in Recent Orders section of account dashboard
+       */
+      /**
+       * TODO - when /customer/orders page will be ready
+       * Redirect to /customer/orders
+       * Confirm that new order is visible on Orders page
+       */
+
+      // Obtain order reference from URL and visit order details page
+
+      cy.url().then((url) => {
+        const orderRef = url.split("?")[1];
+        cy.visit("/order-details?" + orderRef);
+      });
+
+      // ORDER COMMENTS
+      assertOrderCommentsVisible();
+
+      // CANCEL ORDER
+      cy.get(fields.cancelButton).should("exist");
+      cy.percyTakeSnapshot("Order Details");
+      cy.get(fields.cancelButton).click();
+
+      cy.get(fields.cancellationReasonsSelector).select("1");
+      cy.contains("Submit Cancellation").should("be.visible");
+      cy.get(fields.cancellationReasonsSelector).should("have.value", "1");
+      cy.percyTakeSnapshot("Cancel Order");
+      cy.get(fields.submitCancelOrderButton).click();
+
+      cy.get(".dropin-header-container__title", { timeout: 3000 })
+        .should("exist")
+        .and("be.visible")
+        .and("contain.text", "Canceled");
+
+      cy.get(fields.cancellationReasonsModal).should("not.exist");
+
+      cy.get(".order-order-status-content__wrapper-description p")
+        .should("exist")
+        .and("be.visible")
+        .and(
+          "contain.text",
+          "This order was cancelled by you. You should see a refund to your original payment method with 5-7 business days.",
+        );
+
+      cy.get(fields.cancelButton).should("not.exist");
+
+      cy.visit("/customer/orders");
+      assertOrderImageDisplay();
+      cy.waitForLoadingSkeletonToDisappear();
+      cy.percyTakeSnapshot("My Account Order");
+
+      cy.visit("/customer/account");
+      assertOrderImageDisplay();
+      cy.waitForLoadingSkeletonToDisappear();
+      cy.contains("No returns").should("be.visible");
+      cy.percyTakeSnapshot("My Account");
+    });
+  },
+);

--- a/cypress/src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/e2eTests/verifyAuthUserCheckoutWithoutPaymentServices.spec.js
@@ -33,7 +33,7 @@ import * as fields from "../../fields";
 
 describe(
   "Verify auth user can place order",
-  { tags: "@skipSaasNoProd" },
+  { tags: ["@skipSaasNoProd", "@skipPaas", "@skipAco"] },
   () => {
     it("Verify auth user can place order", { tags: "@snapPercy" }, () => {
       // TODO: replace with single "test" product shared between all tests (not this vs products.configurable.urlPathWithOptions).

--- a/cypress/src/tests/e2eTests/verifyGuestUserCheckout.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserCheckout.spec.js
@@ -27,7 +27,7 @@ import {
 } from "../../fixtures/index";
 import * as fields from "../../fields";
 
-describe("Verify guest user can place order", () => {
+describe("Verify guest user can place order", { tags: "@skipSaasProd" }, () => {
   it("Verify guest user can place order", () => {
     cy.visit("");
     // Navigate to PDP

--- a/cypress/src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js
@@ -27,7 +27,7 @@ import * as fields from "../../fields";
 
 describe(
   "Verify guest user can place order",
-  { tags: "@skipSaasNoProd" },
+  { tags: ["@skipSaasNoProd", "@skipPaas", "@skipAco"] },
   () => {
     it("Verify guest user can place order", () => {
       cy.visit("");

--- a/cypress/src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserCheckoutWithoutPaymentServices.spec.js
@@ -1,0 +1,160 @@
+import {
+  setGuestEmail,
+  setGuestShippingAddress,
+  placeOrder,
+  checkTermsAndConditions,
+} from "../../actions";
+import {
+  assertCartSummaryProduct,
+  assertCartSummaryProductsOnCheckout,
+  assertTitleHasLink,
+  assertProductImage,
+  assertCartSummaryMisc,
+  assertOrderSummaryMisc,
+  assertOrderConfirmationCommonDetails,
+  assertOrderConfirmationShippingDetails,
+  assertOrderConfirmationBillingDetails,
+  assertOrderConfirmationShippingMethod,
+  assertSelectedPaymentMethod,
+  assertOrderCommentsVisible,
+} from "../../assertions";
+import {
+  customerShippingAddress,
+  checkMoneyOrder,
+  products,
+} from "../../fixtures/index";
+import * as fields from "../../fields";
+
+describe(
+  "Verify guest user can place order",
+  { tags: "@skipSaasNoProd" },
+  () => {
+    it("Verify guest user can place order", () => {
+      cy.visit("");
+      // Navigate to PDP
+      cy.visit(products.simple.urlPath);
+      // Wait for the product form to hydrate (Add to Cart enabled) before touching
+      // the incrementer; clicking too early registers in the UI but not the cart
+      // model, leaving quantity at 1.
+      cy.contains("Add to Cart").should("be.visible").and("not.be.disabled");
+      cy.get(".dropin-incrementer__increase-button").click();
+      cy.get(".dropin-incrementer__input").should("have.value", "2");
+      // The incrementer dropin re-renders shortly after the click and can revert
+      // the quantity in the cart model; there is no DOM signal for "committed", so
+      // a short settle is intentionally kept here to avoid adding quantity 1.
+      cy.wait(1000);
+      cy.get(".minicart-panel").should("be.empty");
+      cy.contains("Add to Cart").click();
+      cy.get(".minicart-wrapper").click();
+      cy.get(".minicart-panel[data-loaded='true']").should("exist");
+      cy.get(".minicart-panel").should("not.be.empty");
+      assertCartSummaryProduct(
+        "Youth tee",
+        "ADB150",
+        "2",
+        "$10.00",
+        "$20.00",
+        "0",
+      )(".cart-mini-cart");
+      assertTitleHasLink(
+        "Youth tee",
+        "/products/youth-tee/adb150",
+      )(".cart-mini-cart");
+      assertProductImage(Cypress.env("productImageName"))(".cart-mini-cart");
+      cy.contains("View Cart").click();
+      assertCartSummaryProduct(
+        "Youth tee",
+        "ADB150",
+        "2",
+        "$10.00",
+        "$20.00",
+        "0",
+      )(".commerce-cart-wrapper");
+      assertTitleHasLink(
+        "Youth tee",
+        "/products/youth-tee/adb150",
+      )(".commerce-cart-wrapper");
+      assertProductImage(Cypress.env("productImageName"))(
+        ".commerce-cart-wrapper",
+      );
+      cy.contains("Estimated Shipping").should("be.visible");
+      cy.get(".dropin-button--primary").contains("Checkout").click();
+      assertCartSummaryMisc(2);
+      assertCartSummaryProductsOnCheckout(
+        "Youth tee",
+        "ADB150",
+        "2",
+        "$10.00",
+        "$20.00",
+        "0",
+      );
+      cy.contains("Estimated Shipping").should("be.visible");
+      const apiMethod = "setGuestEmailOnCart";
+      const urlTest = Cypress.env("graphqlEndPoint");
+      cy.intercept("POST", urlTest, (req) => {
+        let data = req.body.query;
+        if (data && typeof data == "string") {
+          if (data.includes(apiMethod)) {
+            req.alias = "setEmailOnCart";
+          }
+        }
+      });
+      setGuestEmail(customerShippingAddress.email);
+      cy.wait("@setEmailOnCart");
+
+      setGuestShippingAddress(customerShippingAddress, true);
+      assertOrderSummaryMisc("$20.00", "$10.00", "$86.00");
+
+      assertSelectedPaymentMethod(checkMoneyOrder.code, 0);
+
+      checkTermsAndConditions();
+      placeOrder();
+
+      assertOrderConfirmationCommonDetails(
+        customerShippingAddress,
+        checkMoneyOrder,
+      );
+      assertOrderConfirmationShippingDetails(customerShippingAddress);
+      assertOrderConfirmationBillingDetails(customerShippingAddress);
+      assertOrderConfirmationShippingMethod(customerShippingAddress);
+
+      /**
+       * TODO - when /order-details page will be ready
+       * Redirect to /order-details?orderRef={ORDER_TOKEN}
+       * Confirm that elements similar to orderConfirmation page present (not exactly the same, separate assert needed)
+       */
+
+      // Obtain order reference from URL and visit order details page
+      cy.url().then((url) => {
+        const orderRef = url.split("?")[1];
+        cy.visit("/order-details?" + orderRef);
+      });
+
+      // ORDER COMMENTS
+      assertOrderCommentsVisible();
+
+      // CANCEL ORDER
+      cy.get(fields.cancelButton).should("exist");
+      cy.get(fields.cancelButton).click();
+
+      cy.get(fields.cancellationReasonsSelector).select("1");
+      cy.get(fields.cancellationReasonsSelector).should("have.value", "1");
+
+      cy.get(fields.submitCancelOrderButton).click();
+
+      // Wait for the modal to close before asserting the updated order status
+      cy.get(fields.cancellationReasonsModal).should("not.exist");
+
+      cy.get(".dropin-header-container__title")
+        .should("exist")
+        .and("be.visible")
+        .and("contain.text", "Cancellation requested");
+
+      cy.get(".order-order-status-content__wrapper-description p")
+        .should("exist")
+        .and("be.visible")
+        .and("contain.text", "The cancellation has been requested")
+        .and("contain.text", "Check your email for further instructions.");
+    });
+  },
+);

--- a/cypress/src/tests/e2eTests/verifyGuestUserVirtualCheckout.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserVirtualCheckout.spec.js
@@ -24,7 +24,7 @@ import {
 } from "../../fixtures/index";
 import * as fields from "../../fields";
 
-describe("Verify guest user can place order with virtual product", () => {
+describe("Verify guest user can place order with virtual product", { tags: "@skipSaasProd" }, () => {
   it("Verify guest user can place order with virtual product", { tags: "@snapPercy" }, () => {
     cy.visit(products.virtualGiftCard.urlPath);
     cy.get('select')

--- a/cypress/src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js
@@ -24,7 +24,7 @@ import * as fields from "../../fields";
 
 describe(
   "Verify guest user can place order with virtual product",
-  { tags: "@skipSaasNoProd" },
+  { tags: ["@skipSaasNoProd", "@skipPaas", "@skipAco"] },
   () => {
     it(
       "Verify guest user can place order with virtual product",

--- a/cypress/src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js
+++ b/cypress/src/tests/e2eTests/verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js
@@ -1,0 +1,203 @@
+import {
+  setGuestEmail,
+  placeOrder,
+  checkTermsAndConditions,
+  setGuestBillingAddress,
+  typeInFieldBasedOnText,
+} from "../../actions";
+import {
+  assertCartSummaryProduct,
+  assertCartSummaryProductsOnCheckout,
+  assertTitleHasLink,
+  assertCartSummaryMisc,
+  assertOrderSummaryMisc,
+  assertOrderConfirmationCommonDetails,
+  assertOrderConfirmationBillingDetails,
+  assertSelectedPaymentMethod,
+} from "../../assertions";
+import {
+  checkMoneyOrder,
+  customerBillingAddress,
+  products,
+} from "../../fixtures/index";
+import * as fields from "../../fields";
+
+describe(
+  "Verify guest user can place order with virtual product",
+  { tags: "@skipSaasNoProd" },
+  () => {
+    it(
+      "Verify guest user can place order with virtual product",
+      { tags: "@snapPercy" },
+      () => {
+        cy.visit(products.virtualGiftCard.urlPath);
+        cy.get("select")
+          .find("option:selected")
+          .should("have.text", "Choose amount");
+        cy.get("select").select("150");
+        cy.get("select").find("option:selected").should("have.text", "150");
+        typeInFieldBasedOnText("Sender Name", "John Doe");
+        typeInFieldBasedOnText("Sender Email", "test@example.com");
+        typeInFieldBasedOnText("Recipient Name", "Jane Smith");
+        typeInFieldBasedOnText("Recipient Email", "jane20@example.com");
+        cy.get(".dropin-textarea")
+          .clear()
+          .type("Lorem ipsum dolor sit amet, consectetur adipiscing elit :)");
+        cy.contains("Add to Cart").click();
+        cy.get(".minicart-wrapper").click();
+        cy.get(".minicart-panel[data-loaded='true']").should("exist");
+        cy.get(".minicart-panel").should("not.be.empty");
+        assertCartSummaryProduct(
+          "Gift Card (Virtual)",
+          "gift-card-virtual",
+          "1",
+          "$150.00",
+          "$150.00",
+          "0",
+        )(".cart-mini-cart");
+
+        assertTitleHasLink(
+          "Gift Card (Virtual)",
+          "/products/gift-card-virtual/gift-card-virtual",
+        )(".cart-mini-cart");
+        cy.get(".dropin-cart-list__item").within(() => {
+          cy.contains("Jane Smith (jane20@example.com)").should("be.visible");
+          cy.contains("John Doe (test@example.com)").should("be.visible");
+          cy.contains(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit :)",
+          ).should("be.visible");
+        });
+        cy.visit(products.virtual.urlPath);
+
+        cy.get(".dropin-incrementer__input").should("have.value", "1");
+        cy.get(".minicart-panel").should("not.be.empty");
+        cy.contains("Add to Cart").click();
+        cy.get(".minicart-wrapper").click();
+        cy.get(".minicart-panel[data-loaded='true']").should("exist");
+        cy.get(".minicart-panel").should("not.be.empty");
+
+        assertCartSummaryProduct(
+          "Virtual Product",
+          "VIRTUAL123",
+          "1",
+          "$100.00",
+          "$100.00",
+          "0",
+        )(".cart-mini-cart");
+
+        assertTitleHasLink(
+          "Virtual Product",
+          "/products/virtual-product/virtual123",
+        )(".cart-mini-cart");
+        cy.contains("View Cart").click();
+
+        assertCartSummaryProduct(
+          "Virtual Product",
+          "VIRTUAL123",
+          "1",
+          "$100.00",
+          "$100.00",
+          "0",
+        )(".commerce-cart-wrapper");
+
+        assertTitleHasLink(
+          "Virtual Product",
+          "/products/virtual-product/virtual123",
+        )(".commerce-cart-wrapper");
+
+        assertCartSummaryProduct(
+          "Gift Card (Virtual)",
+          "gift-card-virtual",
+          "1",
+          "$150.00",
+          "$150.00",
+          "1",
+        )(".commerce-cart-wrapper");
+
+        assertTitleHasLink(
+          "Gift Card (Virtual)",
+          "/products/gift-card-virtual/gift-card-virtual",
+        )(".commerce-cart-wrapper");
+        cy.get(".cart-cart-summary-list__content").within(() => {
+          cy.contains("Jane Smith (jane20@example.com)").should("be.visible");
+          cy.contains("John Doe (test@example.com)").should("be.visible");
+          cy.contains(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit :)",
+          ).should("be.visible");
+        });
+
+        cy.get(".dropin-button--primary").contains("Checkout").click();
+
+        assertCartSummaryMisc(2);
+        assertCartSummaryProductsOnCheckout(
+          "Virtual Product",
+          "VIRTUAL123",
+          "1",
+          "$100.00",
+          "$100.00",
+          "0",
+        );
+
+        const apiMethod = "setGuestEmailOnCart";
+        const urlTest = Cypress.env("graphqlEndPoint");
+        cy.intercept("POST", urlTest, (req) => {
+          let data = req.body.query;
+          if (data && typeof data == "string") {
+            if (data.includes(apiMethod)) {
+              req.alias = "setEmailOnCart";
+            }
+          }
+        });
+        setGuestEmail(customerBillingAddress.email);
+        cy.wait("@setEmailOnCart");
+
+        // Assert that shipping form is not present for Virtual Products
+        cy.get(".checkout__shipping-form").should("not.be.visible");
+
+        assertOrderSummaryMisc("$250.00", null, "$250.00");
+
+        assertSelectedPaymentMethod(checkMoneyOrder.code, 0);
+
+        setGuestBillingAddress(customerBillingAddress, true);
+
+        checkTermsAndConditions();
+        cy.percyTakeSnapshot("Checkout with virtual product");
+        placeOrder();
+
+        assertOrderConfirmationCommonDetails(
+          customerBillingAddress,
+          checkMoneyOrder,
+        );
+        assertOrderConfirmationBillingDetails(customerBillingAddress);
+
+        // Obtain order reference from URL and visit order details page
+        cy.url().then((url) => {
+          const orderRef = url.split("?")[1];
+          cy.visit("/order-details?" + orderRef);
+        });
+
+        // CANCEL ORDER
+        cy.get(fields.cancelButton).should("exist");
+        cy.get(fields.cancelButton).click();
+
+        cy.get(fields.cancellationReasonsSelector).select("1");
+        cy.get(fields.cancellationReasonsSelector).should("have.value", "1");
+
+        cy.get(fields.submitCancelOrderButton).click();
+
+        cy.get(".dropin-header-container__title", { timeout: 3000 })
+          .should("exist")
+          .and("be.visible")
+          .and("contain.text", "Cancellation requested");
+
+        cy.get(fields.cancellationReasonsModal).should("not.exist");
+
+        cy.get(".order-order-status-content__wrapper-description p")
+          .should("exist")
+          .and("be.visible")
+          .and("contain.text", "The cancellation has been requested")
+          .and("contain.text", "Check your email for further instructions.");
+      },
+    );
+  },
+);


### PR DESCRIPTION
Fix #USF-4125

## Summary

Configures the `cypress-saas-run` CI check to automatically use the **ACCS Prod** storefront and API endpoint when a PR targets `main`, and **ACCS Sandbox** otherwise. A new parallel set of checkout tests is also introduced for the prod environment, which does not have Payment Services configured.

### Workflow changes (`.github/workflows/run-e2e-tests-saas.yaml`)

* Switches trigger from `on: push` to `on: pull_request` (types: `opened`, `synchronize`, `reopened`, `edited`) so `github.base_ref` is always available to detect the target branch.
* Adds a job-level `IS_PROD_RELEASE` env var (`${{ github.base_ref == 'main' }}`), used throughout the job and inherited by the Cypress process.
* Adds a **"Set storefront config"** step that selects the correct AEM storefront URL and GraphQL endpoint based on `IS_PROD_RELEASE`:
  * `IS_PROD_RELEASE=true` (PR → `main`): uses **ACCS Prod** (`boilerplate-accs-prod`, `na1.api.commerce.adobe.com`)
  * `IS_PROD_RELEASE=false` (PR → any other branch): uses **ACCS Sandbox** (`boilerplate-accs`, `na1-sandbox.api.commerce.adobe.com`)
* `CYPRESS_API_ENDPOINT` switches dynamically to `CYPRESS_API_ENDPOINT_PROD` for PRs targeting `main`.
* The `command` now picks the right npm script based on `IS_PROD_RELEASE` (see below).
* The sharding matrix is extended from 4 to **5 shards** to include the new `WithoutPaymentServices` specs.

### Cypress config changes (`cypress/cypress.saas.config.js`)

* `graphqlEndPoint` now reads from the `CYPRESS_GRAPHQL_ENDPOINT` env var (sandbox URL as fallback), keeping local development working without any env var set.
* `giftCardA` is now selected dynamically based on `IS_PROD_RELEASE` (different gift card SKU for prod vs sandbox).

### npm script changes (`cypress/package.json`)

Two separate scripts control which tests are executed depending on the environment:

| Script | `grepTags` | Used when |
|---|---|---|
| `cypress:saas:run` | `-@skipSaas+-@skipSaasNoProd` | PR targets any branch other than `main` |
| `cypress:saas-prod:run` | `-@skipSaas+-@skipSaasProd` | PR targets `main` |

### New Cypress tags

| Tag | Excluded by | Meaning |
|---|---|---|
| `@skipSaas` | Both scripts | Test incompatible with any SaaS environment |
| `@skipSaasProd` | `cypress:saas-prod:run` | Test requires Payment Services (sandbox only) |
| `@skipSaasNoProd` | `cypress:saas:run` | Test designed for prod (no Payment Services) |

### New spec files (Shard 5)

Three new spec files mirror the original checkout flows but use the default Magento payment method (Check / Money Order) instead of Payment Services:

* `verifyAuthUserCheckoutWithoutPaymentServices.spec.js`
* `verifyGuestUserCheckoutWithoutPaymentServices.spec.js`
* `verifyGuestUserVirtualCheckoutWithoutPaymentServices.spec.js`

These specs are tagged `["@skipSaasNoProd", "@skipPaas", "@skipAco"]` so they **only execute** during a SaaS prod release. The original checkout specs are tagged `@skipSaasProd` and are skipped during a prod release. The two sets are mutually exclusive — they never run simultaneously.

The Shard 5 entry has been added to all three workflow files (`run-e2e-tests.yaml`, `run-e2e-tests-saas.yaml`, `run-e2e-tests-aco.yaml`) to satisfy the `check-shard-coverage` CI check.

## Test URLs

Before: <https://integration--aem-boilerplate-commerce--hlxsites.aem.live/>  
After: <https://usf-4125-integration--aem-boilerplate-commerce--hlxsites.aem.live/>
