### PR TITLE
USF-3217 make sign-in dropdown scrollable to fix WCAG 1.4.10 reflow

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -514,6 +514,12 @@ header .nav-search-input .search_autocomplete .popover-container {
   font: var(--type-body-1-default-font) !important;
   letter-spacing: var(--type-body-1-default-letter-spacing) !important;
   width: 100%;
+  max-height: calc(100vh - var(--nav-height));
+  overflow-y: auto;
+
+  @supports (height: 100dvh) {
+    max-height: calc(100dvh - var(--nav-height));
+  }
 }
 
 @media (min-width: 1024px) {
@@ -856,4 +862,3 @@ body:has(.seller-assisted-buying-banner) {
     display: inline-block;
   }
 }
-


### PR DESCRIPTION
At 320px width equivalent, the password error message, "Forgot password?" and "Sign in" buttons were unreachable inside the sign-in dropdown. The panel now scrolls within itself when the viewport is small.

[USF-3217](https://jira.corp.adobe.com/browse/USF-3217)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-3217--aem-boilerplate-commerce--hlxsites.aem.page/
