### PR TITLE
Fix tests not executed

### DIFF
--- a/.github/workflows/run-e2e-tests-aco.yaml
+++ b/.github/workflows/run-e2e-tests-aco.yaml
@@ -48,7 +48,7 @@ jobs:
           # "Specs found" list in CI (never run) despite no skip tag and no
           # errors. This traces @cypress/grep's spec discovery/filtering.
           # Remove once root-caused.
-          DEBUG: "@cypress/grep,find-test-names*"
+          DEBUG: "cypress:server:specs,cypress:server:project,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-aco.yaml
+++ b/.github/workflows/run-e2e-tests-aco.yaml
@@ -48,7 +48,7 @@ jobs:
           # "Specs found" list in CI (never run) despite no skip tag and no
           # errors. This traces @cypress/grep's spec discovery/filtering.
           # Remove once root-caused.
-          DEBUG: "cypress:server:specs,cypress:server:project,cypress:cli:*"
+          DEBUG: "cypress:server:*,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-aco.yaml
+++ b/.github/workflows/run-e2e-tests-aco.yaml
@@ -44,6 +44,11 @@ jobs:
           CYPRESS_API_ENDPOINT: ${{ secrets.CYPRESS_API_ENDPOINT_ACO }}
           CYPRESS_COMMERCE_ADMIN_USERNAME: ${{ secrets.CYPRESS_COMMERCE_ADMIN_USERNAME_ACO }}
           CYPRESS_COMMERCE_ADMIN_PASSWORD: ${{ secrets.CYPRESS_COMMERCE_ADMIN_PASSWORD_ACO }}
+          # TEMP diagnostic: some spec files are silently missing from the
+          # "Specs found" list in CI (never run) despite no skip tag and no
+          # errors. This traces @cypress/grep's spec discovery/filtering.
+          # Remove once root-caused.
+          DEBUG: "@cypress/grep,find-test-names*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-aco.yaml
+++ b/.github/workflows/run-e2e-tests-aco.yaml
@@ -39,16 +39,15 @@ jobs:
         with:
           working-directory: cypress
           wait-on: 'http://localhost:3000'
-          command: npm run cypress:aco:run -- --spec "${{ matrix.spec }}"
+          # No quotes around matrix.spec: the comma-separated list has no
+          # spaces, and quoting it here caused cypress-io/github-action's
+          # command execution to leave stray literal `"` characters glued to
+          # the first/last spec paths, silently dropping them from every run.
+          command: npm run cypress:aco:run -- --spec ${{ matrix.spec }}
         env:
           CYPRESS_API_ENDPOINT: ${{ secrets.CYPRESS_API_ENDPOINT_ACO }}
           CYPRESS_COMMERCE_ADMIN_USERNAME: ${{ secrets.CYPRESS_COMMERCE_ADMIN_USERNAME_ACO }}
           CYPRESS_COMMERCE_ADMIN_PASSWORD: ${{ secrets.CYPRESS_COMMERCE_ADMIN_PASSWORD_ACO }}
-          # TEMP diagnostic: some spec files are silently missing from the
-          # "Specs found" list in CI (never run) despite no skip tag and no
-          # errors. This traces @cypress/grep's spec discovery/filtering.
-          # Remove once root-caused.
-          DEBUG: "cypress:server:*,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -54,6 +54,11 @@ jobs:
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}
+          # TEMP diagnostic: some spec files are silently missing from the
+          # "Specs found" list in CI (never run) despite no skip tag and no
+          # errors. This traces @cypress/grep's spec discovery/filtering.
+          # Remove once root-caused.
+          DEBUG: "@cypress/grep,find-test-names*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -58,7 +58,7 @@ jobs:
           # "Specs found" list in CI (never run) despite no skip tag and no
           # errors. This traces @cypress/grep's spec discovery/filtering.
           # Remove once root-caused.
-          DEBUG: "@cypress/grep,find-test-names*"
+          DEBUG: "cypress:server:specs,cypress:server:project,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -58,7 +58,7 @@ jobs:
           # "Specs found" list in CI (never run) despite no skip tag and no
           # errors. This traces @cypress/grep's spec discovery/filtering.
           # Remove once root-caused.
-          DEBUG: "cypress:server:specs,cypress:server:project,cypress:cli:*"
+          DEBUG: "cypress:server:*,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests-saas.yaml
+++ b/.github/workflows/run-e2e-tests-saas.yaml
@@ -47,18 +47,17 @@ jobs:
         with:
           working-directory: cypress
           wait-on: 'http://localhost:3000'
-          command: npm run cypress:saas:run -- --spec "${{ matrix.spec }}"
+          # No quotes around matrix.spec: the comma-separated list has no
+          # spaces, and quoting it here caused cypress-io/github-action's
+          # command execution to leave stray literal `"` characters glued to
+          # the first/last spec paths, silently dropping them from every run.
+          command: npm run cypress:saas:run -- --spec ${{ matrix.spec }}
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
           CYPRESS_API_ENDPOINT: ${{ secrets.CYPRESS_API_ENDPOINT }}
           CYPRESS_IMS_CLIENT_ID: ${{ secrets.CYPRESS_IMS_CLIENT_ID }}
           CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
           CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}
-          # TEMP diagnostic: some spec files are silently missing from the
-          # "Specs found" list in CI (never run) despite no skip tag and no
-          # errors. This traces @cypress/grep's spec discovery/filtering.
-          # Remove once root-caused.
-          DEBUG: "cypress:server:*,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -47,16 +47,15 @@ jobs:
         with:
           working-directory: cypress
           wait-on: 'http://localhost:3000'
-          command: npm run cypress:run -- --spec "${{ matrix.spec }}"
+          # No quotes around matrix.spec: the comma-separated list has no
+          # spaces, and quoting it here caused cypress-io/github-action's
+          # command execution to leave stray literal `"` characters glued to
+          # the first/last spec paths, silently dropping them from every run.
+          command: npm run cypress:run -- --spec ${{ matrix.spec }}
         env:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
           CYPRESS_COMMERCE_ADMIN_USERNAME: ${{ secrets.CYPRESS_COMMERCE_ADMIN_USERNAME }}
           CYPRESS_COMMERCE_ADMIN_PASSWORD: ${{ secrets.CYPRESS_COMMERCE_ADMIN_PASSWORD }}
-          # TEMP diagnostic: some spec files are silently missing from the
-          # "Specs found" list in CI (never run) despite no skip tag and no
-          # errors. This traces @cypress/grep's spec discovery/filtering.
-          # Remove once root-caused.
-          DEBUG: "cypress:server:*,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -56,7 +56,7 @@ jobs:
           # "Specs found" list in CI (never run) despite no skip tag and no
           # errors. This traces @cypress/grep's spec discovery/filtering.
           # Remove once root-caused.
-          DEBUG: "cypress:server:specs,cypress:server:project,cypress:cli:*"
+          DEBUG: "cypress:server:*,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -52,6 +52,11 @@ jobs:
           AEM_ASSETS_PRIVATE_USER: ${{ secrets.AEM_ASSETS_PRIVATE_USER }}
           CYPRESS_COMMERCE_ADMIN_USERNAME: ${{ secrets.CYPRESS_COMMERCE_ADMIN_USERNAME }}
           CYPRESS_COMMERCE_ADMIN_PASSWORD: ${{ secrets.CYPRESS_COMMERCE_ADMIN_PASSWORD }}
+          # TEMP diagnostic: some spec files are silently missing from the
+          # "Specs found" list in CI (never run) despite no skip tag and no
+          # errors. This traces @cypress/grep's spec discovery/filtering.
+          # Remove once root-caused.
+          DEBUG: "@cypress/grep,find-test-names*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -56,7 +56,7 @@ jobs:
           # "Specs found" list in CI (never run) despite no skip tag and no
           # errors. This traces @cypress/grep's spec discovery/filtering.
           # Remove once root-caused.
-          DEBUG: "@cypress/grep,find-test-names*"
+          DEBUG: "cypress:server:specs,cypress:server:project,cypress:cli:*"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -4,13 +4,13 @@
   "description": "Boilerplate E2E tests",
   "scripts": {
     "cypress:open": "cypress open --browser chrome --config-file cypress.paas.config.js",
-    "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas,grepFilterSpecs=true,grepOmitFiltered=true",
+    "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas",
     "cypress:percy": "percy exec -- cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas+@snapPercy",
     "cypress:saas:open": "cypress open --browser chrome --config-file cypress.saas.config.js",
-    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=true,grepOmitFiltered=true",
+    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas",
     "check:shards": "node scripts/check-shard-coverage.js",
     "cypress:aco:open": "cypress open --browser chrome --config-file cypress.aco.config.js",
-    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco,grepFilterSpecs=true,grepOmitFiltered=true"
+    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco"
   },
   "author": "Adobe Commerce",
   "license": "Apache License 2.0",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -4,13 +4,13 @@
   "description": "Boilerplate E2E tests",
   "scripts": {
     "cypress:open": "cypress open --browser chrome --config-file cypress.paas.config.js",
-    "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas,grepFilterSpecs=true,grepOmitFiltered=true",
+    "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas,grepFilterSpecs=false,grepOmitFiltered=false",
     "cypress:percy": "percy exec -- cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas+@snapPercy",
     "cypress:saas:open": "cypress open --browser chrome --config-file cypress.saas.config.js",
-    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=true,grepOmitFiltered=true",
+    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=false,grepOmitFiltered=false",
     "check:shards": "node scripts/check-shard-coverage.js",
     "cypress:aco:open": "cypress open --browser chrome --config-file cypress.aco.config.js",
-    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco,grepFilterSpecs=true,grepOmitFiltered=true"
+    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco,grepFilterSpecs=false,grepOmitFiltered=false"
   },
   "author": "Adobe Commerce",
   "license": "Apache License 2.0",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -4,13 +4,13 @@
   "description": "Boilerplate E2E tests",
   "scripts": {
     "cypress:open": "cypress open --browser chrome --config-file cypress.paas.config.js",
-    "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas",
+    "cypress:run": "cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas,grepFilterSpecs=true,grepOmitFiltered=true",
     "cypress:percy": "percy exec -- cypress run --config-file cypress.paas.config.js --env grepTags=-@skipPaas+@snapPercy",
     "cypress:saas:open": "cypress open --browser chrome --config-file cypress.saas.config.js",
-    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas",
+    "cypress:saas:run": "cypress run --config-file cypress.saas.config.js --env grepTags=-@skipSaas,grepFilterSpecs=true,grepOmitFiltered=true",
     "check:shards": "node scripts/check-shard-coverage.js",
     "cypress:aco:open": "cypress open --browser chrome --config-file cypress.aco.config.js",
-    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco"
+    "cypress:aco:run": "cypress run --config-file cypress.aco.config.js --env grepTags=-@skipAco,grepFilterSpecs=true,grepOmitFiltered=true"
   },
   "author": "Adobe Commerce",
   "license": "Apache License 2.0",

--- a/cypress/src/tests/e2eTests/verifyAuthUserCheckout.spec.js
+++ b/cypress/src/tests/e2eTests/verifyAuthUserCheckout.spec.js
@@ -111,10 +111,18 @@ describe("Verify auth user can place order", () => {
     )('.cart-mini-cart');
     assertProductImage(Cypress.env('productImageNameConfigurable'))('.cart-mini-cart');
     cy.visit("/products/youth-tee/adb150");
+    // Button can be visible before the product form finishes hydrating;
+    // clicking while still disabled registers in the UI but never reaches
+    // the cart model (see the same pattern guarded against above).
     cy.get(".product-details__buttons__add-to-cart button")
       .should("be.visible")
+      .and("not.be.disabled")
       .click();
     cy.get(".minicart-wrapper").click();
+    // Panel re-fetches/re-renders cart contents on open; wait for the
+    // loaded flag like the first add-to-cart above, otherwise the
+    // assertion below can run against the stale (pre-add) cart state.
+    cy.get('.minicart-panel[data-loaded="true"]').should('exist');
     assertCartSummaryProduct(
       "Youth tee",
       "ADB150",


### PR DESCRIPTION
In every e2e CI shard (ACO/PaaS/SaaS), the first and last spec file in each shard's comma-separated list would silently never run — no error, no failure, just missing from Cypress's "Specs found" count.

**Reason:**
The double quotes around ${{ matrix.spec }} are supposed to be consumed by the shell before Node ever sees the string. But cypress-io/github-action@v6's command execution doesn't strip them cleanly — it leaves a literal " character glued onto the first comma-separated path and another " glued onto the last one. 

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://cg-spec-debug--aem-boilerplate-commerce--hlxsites.aem.live/