### PR TITLE
USF-3133 make empty-cart mini-cart panel scrollable to fix WCAG 1.4.10 reflow

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -432,9 +432,18 @@ header .nav-search-panel .search-bar-result .product-discovery-product-list__foo
   min-height: 360px;
 }
 
+.cart-mini-cart:has(.cart-empty-cart) {
+  max-height: 760px;
+  overflow-y: auto;
+}
+
 /* If viewport height is below max, set max height to 90% of viewport */
 @media (max-height: 819px) {
   .cart-mini-cart:not(:has(.cart-empty-cart)) {
+    max-height: calc(100vh - var(--nav-height));
+  }
+
+  .cart-mini-cart:has(.cart-empty-cart) {
     max-height: calc(100vh - var(--nav-height));
   }
 }


### PR DESCRIPTION
### Description

The mini-cart's viewport-relative max-height constraint explicitly excluded the empty-cart state (:not(:has(.cart-empty-cart))), so it had no height cap and overflow stayed visible. At a 320x256-equivalent viewport, the "Start shopping" button was pushed below the visible area with no way to scroll to it. Add the same max-height constraint plus overflow-y:auto for the empty-cart case, matching the non-empty state.

Fix issue: [USF-3133](https://jira.corp.adobe.com/browse/USF-3133)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://usf-3133--aem-boilerplate-commerce--hlxsites.aem.page/
- 
Replaces #1313, which was inadvertently closed when its branch was renamed to shorten the DNS label used for the feature-preview URL (the original branch name made the PSI check fail).
