### PR TITLE
fix(header): keep search popover reachable at reduced viewport height (USF-3083)

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -385,6 +385,9 @@ header nav .nav-tools button.nav-search-button {
 
 header .nav-search-panel {
   padding: var(--spacing-small);
+  box-sizing: border-box;
+  max-height: 760px;
+  overflow-y: auto;
 }
 
 header .nav-search-panel input {
@@ -444,6 +447,10 @@ header .nav-search-panel .search-bar-result .product-discovery-product-list__foo
   }
 
   .cart-mini-cart:has(.cart-empty-cart) {
+    max-height: calc(100vh - var(--nav-height));
+  }
+
+  header .nav-search-panel {
     max-height: calc(100vh - var(--nav-height));
   }
 }


### PR DESCRIPTION
## Summary
- Fixes USF-3083: the header search popover (results list + "View all" button) had no `max-height`/`overflow-y`, so at a 320px-width-equivalent viewport (WCAG 1.4.10 Reflow test) its content rendered outside the visible viewport with no way to scroll to it, since the popover is an absolutely-positioned child of the fixed header.
- Bounds `.nav-search-panel` height and makes it scroll internally, mirroring the mini-cart panel fix already shipped for USF-3133 (`.cart-mini-cart` max-height/overflow-y pattern), including the same `@media (max-height: 819px)` short-viewport override.

Fix issue: [USF-3083](https://jira.corp.adobe.com/browse/USF-3083)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://usf-3083--aem-boilerplate-commerce--hlxsites.aem.page/

## Test plan
- [ ] Open the preview URL, resize viewport to 320x256 (or 640x512 @200%, or use browser dev tools device toolbar), tab to the Search button, expand it, and type a query with results.
- [ ] Confirm all result cards and the "View all" button are reachable by scrolling within the popover.
- [ ] Confirm desktop (>=1024px) search popover still looks/behaves as before.
- [x] `npm run lint` passes.