### PR TITLE
USF-3078 My Account button doesn't announce expanded state to screen readers

### DIFF
--- a/blocks/header/renderAuthDropdown.js
+++ b/blocks/header/renderAuthDropdown.js
@@ -68,6 +68,7 @@ export function renderAuthDropdown(navTools) {
     authDropDownPanel.setAttribute('aria-hidden', 'false');
     authDropDownPanel.setAttribute('aria-labelledby', 'modal-title');
     authDropDownPanel.setAttribute('aria-describedby', 'modal-description');
+    loginButton.setAttribute('aria-expanded', show ? 'true' : 'false');
     authDropDownPanel.focus();
   }
 


### PR DESCRIPTION
When a user relying on a screen reader (such as NVDA) opens the "My Account" menu in the header, the screen reader kept announcing the button as "collapsed" even after it had actually been opened. This could confuse people with visual impairments, since they had no way of knowing whether the menu had actually expanded.

This change fixes that behavior so the screen reader correctly announces when the menu is open or closed, improving the site's accessibility and its compliance with WCAG guidelines.

Related to: [USF-3078](https://jira.corp.adobe.com/browse/USF-3078)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-3078--aem-boilerplate-commerce--hlxsites.aem.page/