### PR TITLE
fix: actually invoke isAemAssetsEnabled() in PDP image preload

### DIFF
--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -124,7 +124,7 @@ async function preloadImageMiddleware(data) {
     let imageParams = {
       ...IMAGES_SIZES,
     };
-    if (isAemAssetsEnabled) {
+    if (isAemAssetsEnabled()) {
       url = tryGenerateAemAssetsOptimizedUrl(image, data.sku, {});
       imageParams = {
         ...imageParams,


### PR DESCRIPTION
## Summary
- `scripts/initializers/pdp.js`'s `preloadImageMiddleware` checked `isAemAssetsEnabled` (the function reference, always truthy) instead of calling it, so the AEM Assets optimized-URL branch always ran regardless of the actual config flag.
- Now correctly calls `isAemAssetsEnabled()`.
- No behavior change today: `tryGenerateAemAssetsOptimizedUrl()` already re-checks the flag internally and no-ops when AEM Assets is disabled, so this only removes a redundant/misleading dead check — it's a correctness fix, not a functional one.

## Test plan
- [ ] Verify PDP image preload still resolves the optimized URL when `commerce-assets-enabled: true`
- [ ] Verify PDP image preload uses the original image URL when `commerce-assets-enabled` is false/unset

## Test URLS
- https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/adobe-pattern-hoodie/adb127
- https://fix-pdp-aem-assets-enabled-check--aem-boilerplate-commerce--hlxsites.aem.live/products/adobe-pattern-hoodie/adb127