### PR TITLE
USF-4180 Gift cards fail silently when added to cart from PLP

### DIFF
--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -98,8 +98,11 @@ export default async function decorate(block) {
     });
   }
 
+  const requiresPdpConfiguration = (product) => product.typename === 'ComplexProductView'
+    || product.attributes?.some((attr) => attr.name === 'ac_giftcard');
+
   const getAddToCartButton = (product) => {
-    if (product.typename === 'ComplexProductView') {
+    if (requiresPdpConfiguration(product)) {
       const button = document.createElement('div');
       UI.render(Button, {
         children: labels.Global?.AddProductToCart,


### PR DESCRIPTION
Ticket: https://jira.corp.adobe.com/browse/USF-4180

Gift card products require sender/recipient info that can only be entered on the PDP. The PLP was calling `addProductsToCart` directly for them, which silently failed.

This redirects gift card products to the PDP instead, the same way bundle/configurable products already work, using the `ac_giftcard` product attribute to detect them.

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://usf-4180--aem-boilerplate-commerce--hlxsites.aem.page/
