### PR TITLE
fix(a11y): give checkout Edit-cart link an accessible name

### DIFF
--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -508,6 +508,7 @@ export const renderCartSummaryList = async (container) => renderContainer(
           editCartLink.href = rootLink('/cart');
           editCartLink.rel = 'noreferrer';
           editCartLink.innerText = placeholders?.Checkout?.Summary?.Edit;
+          editCartLink.setAttribute('aria-label', `${placeholders?.Checkout?.Summary?.Edit} cart`);
 
           cartSummaryListHeading.appendChild(cartSummaryListHeadingText);
           cartSummaryListHeading.appendChild(editCartLink);


### PR DESCRIPTION
Fixes:
[USF-3234](https://jira.corp.adobe.com/browse/USF-3234)
[USF-3184](https://jira.corp.adobe.com/browse/USF-3184)

## Summary
- The checkout cart-summary "Edit" link only announced the bare word "Edit" to screen readers, with no indication of what it edits — WCAG 2.4.4 (Link Purpose). Added an `aria-label` ("Edit cart") built from the existing placeholder text.
- Same code path renders for both guest and signed-in checkout, so this single fix closes both tickets.

## Test plan
- [x] `npm run lint` — clean.
- [x] Verified the diff applies cleanly onto the latest `integration`.
- [ ] Manual verification with NVDA + Chrome against the ticket repro steps once deployed.

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://usf-3234--aem-boilerplate-commerce--hlxsites.aem.page/