### PR TITLE
PAY-6731: Upgrade payment-services dropin to v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dropins/storefront-cart": "^3.2.0",
         "@dropins/storefront-checkout": "^3.2.1",
         "@dropins/storefront-order": "^3.3.0",
-        "@dropins/storefront-payment-services": "^4.0.0-beta2",
+        "@dropins/storefront-payment-services": "^4.0.0",
         "@dropins/storefront-pdp": "3.0.4-beta2",
         "@dropins/storefront-personalization": "^3.1.1",
         "@dropins/storefront-product-discovery": "3.1.1-beta2",
@@ -1830,9 +1830,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-payment-services": {
-      "version": "4.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.0.0-beta2.tgz",
-      "integrity": "sha512-vn8SLaWY/7bgI81jsuZkg/bzDeFNJkEqq/tJdFBoOXl9fwSTKYy/wMtLC2aZXJbdlvnC76Rq/EknCIWfB4qb+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.0.0.tgz",
+      "integrity": "sha512-YUiAm9D2LNg85zGni8zZUuv0tVW1d3ZtFw0buz6fW4GAkX0JgVOu14gfkPBIqzLs0Rx7pS+Tq0W4OIDpKR/d9A==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-pdp": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "^3.2.0",
     "@dropins/storefront-checkout": "^3.2.1",
     "@dropins/storefront-order": "^3.3.0",
-    "@dropins/storefront-payment-services": "^4.0.0-beta2",
+    "@dropins/storefront-payment-services": "^4.0.0",
     "@dropins/storefront-pdp": "3.0.4-beta2",
     "@dropins/storefront-personalization": "^3.1.1",
     "@dropins/storefront-product-discovery": "3.1.1-beta2",


### PR DESCRIPTION
Update storefront-payment-services to version 4.0.0

Test URLs:
- Before: https://pay-6731--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
