### PR TITLE
USF-1562 [Accessibility] Screen Reader - Mini Cart button improvements

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -246,8 +246,8 @@ export default async function decorate(block) {
 
   const minicart = document.createRange().createContextualFragment(`
      <div class="minicart-wrapper nav-tools-wrapper">
-       <button type="button" class="nav-cart-button" aria-label="Cart"></button>
-       <div class="minicart-panel nav-tools-panel"></div>
+       <button type="button" class="nav-cart-button" aria-label="Cart" aria-haspopup="dialog" aria-expanded="false" aria-controls="minicart-panel"></button>
+       <div class="minicart-panel nav-tools-panel" id="minicart-panel"></div>
      </div>
    `);
 
@@ -328,6 +328,10 @@ export default async function decorate(block) {
     }
 
     togglePanel(minicartPanel, state);
+    cartButton.setAttribute(
+      'aria-expanded',
+      minicartPanel.classList.contains('nav-tools-panel--show') ? 'true' : 'false',
+    );
   }
 
   cartButton.addEventListener('click', () => toggleMiniCart(!minicartPanel.classList.contains('nav-tools-panel--show')));


### PR DESCRIPTION
## Summary
- Fixes WCAG 4.1.2 (Name, Role, Value): the Mini Cart trigger button had no `aria-expanded`/`aria-haspopup` state, so screen readers never announced whether it was collapsed or expanded, especially noticeable with an empty cart.
- Adds `aria-haspopup="dialog" aria-expanded="false" aria-controls="minicart-panel"` to the button and syncs `aria-expanded` on every toggle, mirroring the existing pattern in `renderAuthDropdown.js`.
- Companion fix in `storefront-cart` (PR adobe-commerce/storefront-cart#164) adds an `aria-live` region so the empty-cart message itself gets announced.

Ticket: https://jira.corp.adobe.com/browse/USF-1562

## Test URLs
Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
After: https://USF-1562--aem-boilerplate-commerce--hlxsites.aem.page/