### PR TITLE
USF-3082 accessible names for product image links and Add to Cart buttons

### DIFF
--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -102,9 +102,13 @@ export default async function decorate(block) {
     || product.attributes?.some((attr) => attr.name === 'ac_giftcard');
 
   const getAddToCartButton = (product) => {
+    const productName = product.name || product.sku;
+    const addToCartLabel = `${labels.Global?.AddProductToCart} ${productName}`;
+
     if (requiresPdpConfiguration(product)) {
       const button = document.createElement('div');
       UI.render(Button, {
+        'aria-label': addToCartLabel,
         children: labels.Global?.AddProductToCart,
         icon: Icon({ source: 'Cart' }),
         href: getProductLink(product.urlKey, product.sku),
@@ -114,6 +118,7 @@ export default async function decorate(block) {
     }
     const button = document.createElement('div');
     UI.render(Button, {
+      'aria-label': addToCartLabel,
       children: labels.Global?.AddProductToCart,
       icon: Icon({ source: 'Cart' }),
       onClick: () => cartApi.addProductsToCart([{ sku: product.sku, quantity: 1 }]),
@@ -155,6 +160,7 @@ export default async function decorate(block) {
           const { product, defaultImageProps } = ctx;
           const anchorWrapper = document.createElement('a');
           anchorWrapper.href = getProductLink(product.urlKey, product.sku);
+          anchorWrapper.setAttribute('aria-label', product.name || product.sku);
 
           tryRenderAemAssetsImage(ctx, {
             alias: product.sku,


### PR DESCRIPTION
## Summary

Fixes accessibility issues in the product list page where interactive elements lacked proper accessible names, preventing screen reader users from understanding their purpose:

- "Add to cart" buttons now include the product name so screen readers can distinguish between buttons for different products
- Product image links now include the product name so their destination is clear without visual context

Tickets: [USF-3090](https://jira.corp.adobe.com/browse/USF-3090) · [USF-3092](https://jira.corp.adobe.com/browse/USF-3092) · [USF-3098](https://jira.corp.adobe.com/browse/USF-3098) · [USF-3102](https://jira.corp.adobe.com/browse/USF-3102)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-3082--aem-boilerplate-commerce--hlxsites.aem.page/
