### PR TITLE
fix: Trusted Types breaks Credit Card checkout (Braintree iframe realm)

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -22,12 +22,13 @@ import {
   IS_DA,
 } from './commerce.js';
 
-if (window.trustedTypes && window.trustedTypes.createPolicy) {
-  const innerTT = window.trustedTypes.createPolicy('tt-inner', {
+function installDefaultPolicy(tt) {
+  if (!tt || !tt.createPolicy || tt.defaultPolicy) return;
+  const innerTT = tt.createPolicy('tt-inner', {
     createHTML: (s) => s, // avoid stack overflow
   });
 
-  window.trustedTypes.createPolicy('default', {
+  tt.createPolicy('default', {
     createHTML: (input, type, sink) => {
       let processedInput = input;
       if (/srcdoc\s*=/i.test(processedInput)) {
@@ -44,6 +45,29 @@ if (window.trustedTypes && window.trustedTypes.createPolicy) {
     },
     createScriptURL: (input) => input,
     createScript: (input) => input,
+  });
+}
+
+installDefaultPolicy(window.trustedTypes);
+
+if (window.trustedTypes) {
+  const { get } = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
+  Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+    configurable: true,
+    get() {
+      const win = get.call(this);
+      try {
+        installDefaultPolicy(win.trustedTypes);
+      } catch (e) {
+        // cross-origin iframes throw a SecurityError here - expected, their
+        // CSP isn't ours to satisfy. Anything else means this genuinely
+        // failed to install and is worth knowing about.
+        if (e.name !== 'SecurityError') {
+          console.warn('Failed to install Trusted Types policy in iframe realm', e);
+        }
+      }
+      return win;
+    },
   });
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -51,24 +51,30 @@ function installDefaultPolicy(tt) {
 installDefaultPolicy(window.trustedTypes);
 
 if (window.trustedTypes) {
-  const { get } = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
-  Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
-    configurable: true,
-    get() {
-      const win = get.call(this);
-      try {
-        installDefaultPolicy(win.trustedTypes);
-      } catch (e) {
-        // cross-origin iframes throw a SecurityError here - expected, their
-        // CSP isn't ours to satisfy. Anything else means this genuinely
-        // failed to install and is worth knowing about.
-        if (e.name !== 'SecurityError') {
-          console.warn('Failed to install Trusted Types policy in iframe realm', e);
+  try {
+    const { get } = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+      configurable: true,
+      get() {
+        const win = get.call(this);
+        try {
+          installDefaultPolicy(win.trustedTypes);
+        } catch (e) {
+          // cross-origin iframes throw a SecurityError here - expected, their
+          // CSP isn't ours to satisfy. Anything else means this genuinely
+          // failed to install and is worth knowing about.
+          if (e.name !== 'SecurityError') {
+            console.warn('Failed to install Trusted Types policy in iframe realm', e);
+          }
         }
-      }
-      return win;
-    },
-  });
+        return win;
+      },
+    });
+  } catch (e) {
+    // e.g. contentWindow was made non-configurable by other code - the
+    // top-level policy above still applies, iframes just won't get one.
+    console.warn('Failed to patch HTMLIFrameElement.prototype.contentWindow for Trusted Types', e);
+  }
 }
 
 /**


### PR DESCRIPTION
## Context

Follow-up to the blocker raised in [this thread](https://magento.slack.com/archives/C03J16UAEHZ/p1784561961990899?thread_ts=1784556389.996259&cid=C03J16UAEHZ): upstream's `require-trusted-types-for 'script'` (added [in aem-boilerplate](https://github.com/adobe/aem-boilerplate/pull/641/changes), carried by this sync PR) breaks Credit Card checkout and the Cypress order tests.

**Root cause, confirmed by live reproduction (not guesswork):** selecting Credit Card renders `@dropins/storefront-payment-services`'s `CreditCard.tsx` → `@adobe-commerce/payment-services-sdk` → **Braintree's Hosted Fields SDK**. Braintree creates a same-origin `about:blank` iframe and, in the same synchronous tick, injects a `<script>` into *that iframe's own document*. Chromium inherits our CSP into that iframe (so `require-trusted-types-for` applies there too), but Trusted Types policies are scoped per-Document — the `default` policy `scripts.js` registers for the top-level document never exists in that iframe's realm. Verified directly: inside the iframe, `trustedTypes` exists but `trustedTypes.defaultPolicy` is `undefined`, and the browser throws `Failed to set the 'src' property on 'HTMLScriptElement': This document requires 'TrustedScriptURL' assignment.`

A `MutationObserver`-based fix would be too late — iframe creation and the script injection happen in the same synchronous call stack, before any microtask fires.

*(Note: this PR replaces #1345, which was opened from `fix/trusted-types-iframe-realms` — that branch name produces a preview-URL DNS label over 63 characters and doesn't publish via AEM Code Sync. Same change, from the shorter `fix/tt-iframe-policy`, plus the `defineProperty` guard called out below is now fixed.)*

## Two ways to unblock this - opening this PR to get input on which to take

**Option A — drop/flag off `require-trusted-types-for 'script'` for now** (as originally proposed in the thread: gate it behind an `if (ttEnabled && ...)` condition, disabled by default, resolved via a later ticket). Fast, zero risk, doesn't touch third-party SDK behavior. Gives up the DOM-XSS mitigation this directive is meant to add, and every future upstream sync would need to keep re-applying the same carve-out until it's actually resolved.

**Option B — this PR's change:** patch `HTMLIFrameElement.prototype.contentWindow`'s getter so the same `default` policy is installed into any same-origin iframe's realm the instant something reads that property — synchronously, before the caller's next line (the script injection) runs. Verified end-to-end: real Braintree checkout now renders actual card-number/expiration/CVV input fields with no console errors, tested both with and without also patching `contentDocument` (Braintree only ever goes through `contentWindow`, so that half was dropped from the diff — smaller patch, same effect).

## Considerations with Option B, if we go this route

These are trade-offs, not blockers, but worth the team's eyes before merging:

- **It widens what the permissive `default` policy covers, permanently, site-wide.** The existing top-level `default` policy is already a full passthrough (doesn't sanitize scripts, just satisfies the API). This patch extends that same no-real-protection passthrough into *every* same-origin iframe the site or any dependency ever creates in the future — not just Braintree's. If this site ever gets a genuine DOM-XSS bug that reaches a same-origin iframe, this is the mechanism that quietly removes `require-trusted-types-for`'s backstop there too.
- **It's coupled to an undocumented Braintree implementation detail, not a stable contract.** Nothing in Braintree's public API promises "same-origin `about:blank` iframe, reached via `contentWindow`." If a future Braintree SDK version does this differently, the fix silently stops protecting checkout with no code-level signal - the bug just reappears.
- **Monkey-patching a native accessor on a payment page carries a specific irony risk.** Fraud-detection/device-fingerprinting scripts (Braintree's own, or another vendor's, on the same checkout page) sometimes probe `Function.prototype.toString` on common DOM accessors as a tamper signal. Patching `HTMLIFrameElement.prototype.contentWindow` is exactly that kind of change, on exactly the page where it's most likely to matter.
- Mitigated in this diff: errors other than the expected cross-origin `SecurityError` are now surfaced via `console.warn` instead of being silently swallowed, so a future regression here is at least visible instead of invisible. The `Object.defineProperty` call itself is now also guarded — if `contentWindow` were ever non-configurable (a frozen prototype from some other library, or a future browser/extension behavior), that's caught and warned on instead of throwing uncaught at module top level and potentially halting the rest of `scripts.js`.

## Verification

- `npm run lint:js` — clean.
- Manual repro against the real backend (`mcstaging.aemshop.net`, same one Cypress uses): added item to cart, reached checkout, selected Credit Card. Before this patch: `TrustedScriptURL` console error, no card fields render. After: no errors, and the Braintree hosted-fields iframes (card number, expiration, CVV) render real inputs.
- Confirmed the added `console.warn` doesn't fire for the legitimate cross-origin Braintree iframes (hosted-fields-input-frame, tokenization-frame) — only for the same-origin `about:blank` sandbox frames, and only on genuine failures.

## Test URLs

- https://fix-tt-iframe-policy--aem-boilerplate-commerce--hlxsites.aem.live/checkout