### PR TITLE
fix: remove require-trusted-types-for directive to unblock Credit Card checkout

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,6 +1,6 @@
 <meta
   http-equiv="Content-Security-Policy"
-  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none'; frame-src 'self' https:; require-trusted-types-for 'script';"
+  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none'; frame-src 'self' https:;"
   move-to-http-header="true"
 />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -22,6 +22,35 @@ import {
   IS_DA,
 } from './commerce.js';
 
+/*
+ * Trusted Types default policy.
+ *
+ * This policy is defined but NOT currently enforced: the
+ * `require-trusted-types-for 'script'` CSP directive that activates it has been
+ * removed from the Content-Security-Policy meta in head.html. The policy is kept
+ * here so enforcement can be turned back on without re-authoring it.
+ *
+ * Why the directive was removed: with it enforced, payment SDKs that build a
+ * same-origin iframe and synchronously inject a <script> into it fail to render.
+ * The Credit Card checkout flow hits this because its hosted-fields SDK does
+ * exactly that. Trusted Types policies are scoped per document/realm, so the
+ * child iframe inherits the CSP directive but not this default policy; the SDK's
+ * `script.src` assignment in that realm then throws "This document requires
+ * 'TrustedScriptURL' assignment" and the card fields never mount. Any dependency
+ * that injects scripts into a same-origin iframe realm hits the same wall.
+ *
+ * To re-enable enforcement: add `require-trusted-types-for 'script';` back to the
+ * `Content-Security-Policy` meta in head.html. Before doing so, note that the
+ * policy below is a passthrough (createScriptURL/createScript return their input
+ * unchanged), so enforcing it satisfies the API without adding real containment;
+ * hardening it into an allowlist is the useful next step. Enforcement will also
+ * re-break any same-origin-iframe SDK unless that SDK installs its own policy in
+ * the iframe realm (the correct long-term fix).
+ *
+ * References:
+ * - Directive introduced upstream: https://github.com/adobe/aem-boilerplate/pull/641
+ * - Trusted Types API: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
+ */
 if (window.trustedTypes && window.trustedTypes.createPolicy) {
   const innerTT = window.trustedTypes.createPolicy('tt-inner', {
     createHTML: (s) => s, // avoid stack overflow


### PR DESCRIPTION
## What

Removes the enforcing `require-trusted-types-for 'script'` directive from the `Content-Security-Policy` meta in `head.html`. `frame-src 'self' https:` stays enforcing. The Trusted Types default policy in `scripts.js` is left in place, with a comment explaining why it is no longer enforced, how to re-enable it, and the caveats.

## Why

With the directive enforced, the Credit Card checkout flow does not render. The hosted-fields payment SDK builds a same-origin iframe and synchronously injects a `<script>` into it. Trusted Types policies are scoped per document/realm, so that child iframe inherits the CSP directive but not the default policy registered in the top document. The SDK's `script.src` assignment in the iframe realm then throws `This document requires 'TrustedScriptURL' assignment` and the card fields never mount. Any dependency that injects scripts into a same-origin iframe realm hits the same wall.

The directive was introduced upstream in adobe/aem-boilerplate#641. The default policy it enforces is a passthrough (`createScriptURL`/`createScript` return input unchanged), so enforcing it satisfies the Trusted Types API without adding meaningful containment. The long-term fix belongs in the payment SDK (installing its own policy in the iframe realm); hardening the default policy into an allowlist is the useful next step before re-enabling enforcement.

## Verification

- Built and served the branch; confirmed the edge delivers an enforcing `content-security-policy` header with `frame-src` retained and the Trusted Types directive gone.
- Drove a full guest checkout end to end (add to cart, checkout, select Credit Card). The hosted-fields iframes (card number, expiration, CVV) render real inputs and the console is free of any `TrustedScriptURL` / Trusted Types error.

## References

- Directive introduced upstream: https://github.com/adobe/aem-boilerplate/pull/641
- Trusted Types API: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API

## Test URLS 

- https://fix-remove-tt-directive--aem-boilerplate-commerce--hlxsites.aem.page/ 

(cannot link to /checkout due to redirect occurring which breaks the PSI check for the path)