### PR TITLE
PAY-6081: Upgrade payment-services dropin to v4.1.0

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -304,7 +304,7 @@ export default async function decorate(block) {
   }
 
   const EXPRESS_PAYMENT_METHODS = [
-    PaymentMethodCode.SMART_BUTTONS,
+    PaymentMethodCode.PAYPAL_BUTTONS,
     PaymentMethodCode.APPLE_PAY,
     PaymentMethodCode.GOOGLE_PAY,
   ];

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -438,9 +438,7 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
                   showPaymentSheet();
                 }
               },
-              onSuccess: ({ cartId }) => {
-                orderApi.placeOrder(cartId);
-              },
+              onSuccess: ({ cartId }) => orderApi.placeOrder(cartId),
               onError: (localizedError) => {
                 events.emit('checkout/error', {
                   message: localizedError.message,

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -43,6 +43,7 @@ import { PaymentMethodCode, PaymentLocation } from '@dropins/storefront-payment-
 import ApplePay from '@dropins/storefront-payment-services/containers/ApplePay.js';
 import CreditCard from '@dropins/storefront-payment-services/containers/CreditCard.js';
 import GooglePay from '@dropins/storefront-payment-services/containers/GooglePay.js';
+import PayPalButtons from '@dropins/storefront-payment-services/containers/PayPalButtons.js';
 import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
 
 // Order Dropin
@@ -366,7 +367,27 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
         [PaymentMethodCode.FASTLANE]: {
           enabled: false,
         },
-        [PaymentMethodCode.SMART_BUTTONS]: {
+        [PaymentMethodCode.PAYPAL_BUTTONS]: {
+          render: (ctx) => {
+            const $paypalButtons = document.createElement('div');
+
+            PaymentServices.render(PayPalButtons, {
+              onButtonClick: (showPaymentSheet) => {
+                if (validateCheckoutForms()) {
+                  showPaymentSheet();
+                }
+              },
+              onSuccess: ({ cartId }) => {
+                orderApi.placeOrder(cartId);
+              },
+              onError: (localizedError) => {
+                events.emit('checkout/error', {
+                  message: localizedError.message,
+                });
+              },
+            })($paypalButtons);
+            ctx.replaceHTML($paypalButtons);
+          },
           enabled: false,
         },
         [PaymentMethodCode.APPLE_PAY]: {
@@ -417,7 +438,10 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
                   showPaymentSheet();
                 }
               },
-              onSuccess: ({ cartId }) => orderApi.placeOrder(cartId),
+              onSuccess: ({ cartId }) => {
+                throw new Error('Something went wrong');
+                // orderApi.placeOrder(cartId);
+              },
               onError: (localizedError) => {
                 events.emit('checkout/error', {
                   message: localizedError.message,

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -439,8 +439,7 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
                 }
               },
               onSuccess: ({ cartId }) => {
-                throw new Error('Something went wrong');
-                // orderApi.placeOrder(cartId);
+                orderApi.placeOrder(cartId);
               },
               onError: (localizedError) => {
                 events.emit('checkout/error', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dropins/storefront-cart": "^3.3.0",
         "@dropins/storefront-checkout": "^3.3.0",
         "@dropins/storefront-order": "^4.0.0",
-        "@dropins/storefront-payment-services": "^4.0.0",
+        "@dropins/storefront-payment-services": "^4.1.0-beta1",
         "@dropins/storefront-pdp": "^3.2.0",
         "@dropins/storefront-personalization": "^3.2.0",
         "@dropins/storefront-product-discovery": "^3.1.1",
@@ -2649,9 +2649,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-payment-services": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.0.0.tgz",
-      "integrity": "sha512-YUiAm9D2LNg85zGni8zZUuv0tVW1d3ZtFw0buz6fW4GAkX0JgVOu14gfkPBIqzLs0Rx7pS+Tq0W4OIDpKR/d9A==",
+      "version": "4.1.0-beta1",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.1.0-beta1.tgz",
+      "integrity": "sha512-4r3j+VjOEYizZBfJtO8wCM/455zFOayOVBuQa6dLEzeBVDdGlfb7NcGqdhsVFFOC/H2DSiDT2veZiFY3WHSwpg==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-pdp": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "^3.3.0",
     "@dropins/storefront-checkout": "^3.3.0",
     "@dropins/storefront-order": "^4.0.0",
-    "@dropins/storefront-payment-services": "^5.0.0",
+    "@dropins/storefront-payment-services": "^4.1.0",
     "@dropins/storefront-pdp": "^3.2.0",
     "@dropins/storefront-personalization": "^3.2.0",
     "@dropins/storefront-product-discovery": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "^3.3.0",
     "@dropins/storefront-checkout": "^3.3.0",
     "@dropins/storefront-order": "^4.0.0",
-    "@dropins/storefront-payment-services": "^4.0.0",
+    "@dropins/storefront-payment-services": "^5.0.0",
     "@dropins/storefront-pdp": "^3.2.0",
     "@dropins/storefront-personalization": "^3.2.0",
     "@dropins/storefront-product-discovery": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "^3.3.0",
     "@dropins/storefront-checkout": "^3.3.0",
     "@dropins/storefront-order": "^4.0.0",
-    "@dropins/storefront-payment-services": "^4.1.0",
+    "@dropins/storefront-payment-services": "^4.1.0-beta1",
     "@dropins/storefront-pdp": "^3.2.0",
     "@dropins/storefront-personalization": "^3.2.0",
     "@dropins/storefront-product-discovery": "^3.1.1",


### PR DESCRIPTION
Update storefront-payment-services to version v4.1.0

Test URLs:

Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
After: https://pay-6080--aem-boilerplate-commerce--hlxsites.aem.live/
