### PR TITLE
feat: Quick Edit / Experience Workspace support

### DIFF
--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -51,6 +51,10 @@ export const CS_FETCH_GRAPHQL = new FetchGraphQL();
 // Environment checks
 export const IS_UE = window.location.hostname.includes('ue.da.live');
 export const IS_DA = new URL(window.location.href).searchParams.has('dapreview');
+// Quick Edit / Experience Workspace also author/preview a page in place (see
+// tools/quick-edit/quick-edit.js); treat that the same as IS_UE/IS_DA
+// wherever a template page needs to render a default product for editing.
+export const IS_QUICK_EDIT = new URL(window.location.href).searchParams.has('quick-edit');
 
 /**
  * Product template paths - pages that are templates and should use
@@ -682,7 +686,7 @@ export function getProductLink(urlKey, sku) {
  * @returns {string|null} The SKU from metadata or URL, or null if not found
  */
 export function getProductSku() {
-  if (isProductTemplate() && (IS_UE || IS_DA)) {
+  if (isProductTemplate() && (IS_UE || IS_DA || IS_QUICK_EDIT)) {
     return getDefaultSkuFromBlock();
   }
 

--- a/scripts/initializers/pdp.js
+++ b/scripts/initializers/pdp.js
@@ -9,6 +9,8 @@ import {
   getOptionsUIDsFromUrl,
   getProductSku,
   IS_UE,
+  IS_DA,
+  IS_QUICK_EDIT,
   loadErrorPage,
   preloadFile,
 } from '../commerce.js';
@@ -83,8 +85,10 @@ await initializeDropin(async () => {
   const sku = getProductSku();
   const optionsUIDs = getOptionsUIDsFromUrl();
 
-  // If we cannot find a sku, and we are not in UE, there's a problem.
-  if (!sku && !IS_UE) {
+  // If we cannot find a sku, and we are not authoring/previewing this page
+  // (Universal Editor, Document Authoring preview, or Quick Edit /
+  // Experience Workspace), there's a problem.
+  if (!sku && !IS_UE && !IS_DA && !IS_QUICK_EDIT) {
     return loadErrorPage();
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -193,6 +193,41 @@ export function decorateMain(main) {
   decorateButtons(main);
 }
 
+let quickEditLoadPromise = null;
+
+/**
+ * Dynamically loads the Quick Edit plugin (da.live). Also used by
+ * Experience Workspace, which drives the same plugin as a parent controller
+ * over postMessage rather than embedding its own iframe.
+ * @param {...*} args forwarded to quick-edit init (Sidekick payload or URL deep-link).
+ */
+async function loadQuickEdit(...args) {
+  if (quickEditLoadPromise) return quickEditLoadPromise;
+
+  quickEditLoadPromise = (async () => {
+    // eslint-disable-next-line import/no-cycle
+    const { default: initQuickEdit } = await import('../tools/quick-edit/quick-edit.js');
+    initQuickEdit(...args);
+  })();
+
+  return quickEditLoadPromise;
+}
+
+function registerQuickEditSidekick() {
+  const addSidekickListeners = (sk) => {
+    sk.addEventListener('custom:quick-edit', loadQuickEdit);
+  };
+
+  const sk = document.querySelector('aem-sidekick');
+  if (sk) {
+    addSidekickListeners(sk);
+  } else {
+    document.addEventListener('sidekick-ready', () => {
+      addSidekickListeners(document.querySelector('aem-sidekick'));
+    }, { once: true });
+  }
+}
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
@@ -213,7 +248,10 @@ async function loadEager(doc) {
       loadErrorPage(418);
     }
     document.body.classList.add('appear');
-    await loadSection(main.querySelector('.section'), waitForFirstImage);
+    await loadSection(main.querySelector('.section'), (section) => {
+      if (document.body.classList.contains('quick-edit')) return Promise.resolve();
+      return waitForFirstImage(section);
+    });
   }
 
   try {
@@ -246,6 +284,8 @@ async function loadLazy(doc) {
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
+
+  registerQuickEditSidekick();
 }
 
 /**
@@ -257,7 +297,7 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
-async function loadPage() {
+export async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();
@@ -276,3 +316,11 @@ loadPage();
   // eslint-disable-next-line import/no-unresolved
   import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
 }());
+
+// Experience Workspace / Quick Edit deep-link: da.live opens this page with a
+// `quick-edit` query param (directly, or as the parent-controlled iframe inside
+// Experience Workspace) instead of waiting for a Sidekick button click.
+(() => {
+  const hasQE = new URL(window.location.href).searchParams.has('quick-edit');
+  if (hasQE) import('../tools/quick-edit/quick-edit.js').then((mod) => mod.default());
+})();

--- a/tools/quick-edit/quick-edit.js
+++ b/tools/quick-edit/quick-edit.js
@@ -1,0 +1,52 @@
+// eslint-disable-next-line import/no-cycle
+import { loadPage } from '../../scripts/scripts.js';
+
+const importMap = {
+  imports: {
+    'da-lit': 'https://da.live/deps/lit/dist/index.js',
+    'da-y-wrapper': 'https://da.live/deps/da-y-wrapper/dist/index.js',
+  },
+};
+
+function addImportmap() {
+  const importmapEl = document.createElement('script');
+  importmapEl.type = 'importmap';
+  importmapEl.textContent = JSON.stringify(importMap);
+  document.head.appendChild(importmapEl);
+}
+
+async function loadModule(origin, payload) {
+  const { default: loadQuickEdit } = await import(`${origin}/nx/public/plugins/quick-edit/quick-edit.js`);
+  loadQuickEdit(payload, loadPage);
+}
+
+function generateSidekickPayload() {
+  let { hostname } = window.location;
+  if (hostname === 'localhost') {
+    hostname = document.querySelector('meta[property="hlx:proxyUrl"]').content;
+  }
+  const parts = hostname.split('.')[0].split('--');
+  const [, repo, owner] = parts;
+
+  return {
+    detail: {
+      config: {
+        mountpoint: `https://content.da.live/${owner}/${repo}/`,
+      },
+      location: {
+        pathname: window.location.pathname,
+      },
+    },
+  };
+}
+
+export default function init(payload) {
+  const { search } = window.location;
+  const ref = new URLSearchParams(search).get('quick-edit');
+  let origin;
+  if (ref === 'on' || !ref) origin = 'https://da.live';
+  if (ref === 'local') origin = 'http://localhost:6456';
+  if (!origin) origin = `https://${ref}--da-nx--adobe.aem.live`;
+  addImportmap();
+  loadModule(origin, payload || generateSidekickPayload());
+}


### PR DESCRIPTION
## Summary
- Adds Quick Edit sidekick + deep-link hooks (`scripts/scripts.js`, `tools/quick-edit/quick-edit.js`) so pages can be authored in place from da.live.
- Adds `IS_QUICK_EDIT` and checks it alongside `IS_UE`/`IS_DA` so product template pages render a default product when authored via Quick Edit or Experience Workspace.

Companion PRs (Site Creator OOTB support / docs):
- storefront-tools: https://github.com/adobe-commerce/storefront-tools/pull/98
- microsite-commerce-storefront: https://github.com/commerce-docs/microsite-commerce-storefront/pull/966

## Test plan
- [ ] Manually verify Quick Edit sidekick button launches editing on a page
- [ ] Manually verify Experience Workspace canvas can drive this page via postMessage
- [ ] Verify product template page renders a default product when authored via Quick Edit/EW

## Test URLS
- https://feat-experience-workspace-ootb--aem-boilerplate-commerce.aem.live