### PR TITLE
fix: ignore prerender-only productContext push in view history tracking

### DIFF
--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -729,7 +729,10 @@ function trackHistory() {
   if (storeIdentifier) {
     window.adobeDataLayer.push((dl) => {
       dl.addEventListener('adobeDataLayer:change', (event) => {
-        if (!event.productContext || !event.productContext.sku) {
+        // Speculation Rules prerendering pushes productContext once immediately and
+        // again on activation. Ignore the prerender-only push so hovering a link
+        // doesn't record a view that never actually happened.
+        if (document.prerendering || !event.productContext || !event.productContext.sku) {
           return;
         }
         const key = `${storeIdentifier}:productViewHistory`;


### PR DESCRIPTION
## Summary
- Speculation Rules `prerender` (`head.html`) fully runs the PDP page in the background when a user hovers a product link, which pushes `productContext` onto `adobeDataLayer` before the page is ever actually activated/visited.
- `trackHistory()` had no prerender awareness, so it wrote that premature push straight to `localStorage`, polluting `productViewHistory` with SKUs the user never actually visited (just hovered).
- Fix: skip the write while `document.prerendering` is true. The dropin re-pushes `productContext` for real on activation (`prerenderingchange`), so genuine visits are still recorded — this follows the same prerender-gating pattern already used elsewhere in the codebase (`scripts/delayed.js`, `scripts/initializers/index.js`).

## Test plan
- [x] Reproduced the exact repro from the Jira ticket in Chrome: hovered two PDP links (~5s each) on the apparel listing, confirmed no `productViewHistory` entry was created
- [x] Verified actually navigating to a PDP still correctly records `productViewHistory`
- [x] `npm run lint` passes

## Test URLS
- https://usf-4233-pdp-preload--aem-boilerplate-commerce--hlxsites.aem.page/apparel?page=1&sort=&filter=