### PR TITLE
PAY: Upgrade payment-services dropin to ^4.1.0 stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dropins/storefront-cart": "^3.3.0",
         "@dropins/storefront-checkout": "^3.3.0",
         "@dropins/storefront-order": "^4.0.0",
-        "@dropins/storefront-payment-services": "^4.1.0-beta1",
+        "@dropins/storefront-payment-services": "^4.1.0",
         "@dropins/storefront-pdp": "^3.2.0",
         "@dropins/storefront-personalization": "^3.2.0",
         "@dropins/storefront-product-discovery": "^3.1.1",
@@ -2649,9 +2649,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-payment-services": {
-      "version": "4.1.0-beta1",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.1.0-beta1.tgz",
-      "integrity": "sha512-4r3j+VjOEYizZBfJtO8wCM/455zFOayOVBuQa6dLEzeBVDdGlfb7NcGqdhsVFFOC/H2DSiDT2veZiFY3WHSwpg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.1.0.tgz",
+      "integrity": "sha512-scRGwIFUbQ/Bj9NHrFLvndD0CoxClZfAnUAVBR3ayTPUQpLm0TXEJukuCJeF0QJh1mLISV/mcNFdTbjndTMn2w==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-pdp": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "^3.3.0",
     "@dropins/storefront-checkout": "^3.3.0",
     "@dropins/storefront-order": "^4.0.0",
-    "@dropins/storefront-payment-services": "^4.1.0-beta1",
+    "@dropins/storefront-payment-services": "^4.1.0",
     "@dropins/storefront-pdp": "^3.2.0",
     "@dropins/storefront-personalization": "^3.2.0",
     "@dropins/storefront-product-discovery": "^3.1.1",


### PR DESCRIPTION
This pull request bumps the payment services dropin from v2 to v3. The only change is the revisited license agreement. See release notes: https://github.com/adobe-commerce/storefront-payment-services/releases/tag/v4.1.0

Test URLs:

- Before: https://payments-4-1-0-stable--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
