### PR TITLE
USF-2894: Non-company storefront users see B2B company menu items on "My Account" page

### DIFF
--- a/blocks/commerce-account-nav/README.md
+++ b/blocks/commerce-account-nav/README.md
@@ -30,6 +30,7 @@ The block expects a tabular structure with a header row defining column names an
 ```
 
 The block processes:
+
 - **Header Row**: Defines column structure (label, icon, permission)
 - **Data Rows**: Each row creates a navigation item
 - **Title**: From the `<a>` element within the label column
@@ -41,6 +42,8 @@ The block processes:
 ### Permission System
 
 The block uses the event bus to retrieve user permissions via `'auth/permissions'` event (emitted by auth dropin). The permission system implements a three-state permission model to handle enabled, disabled, and missing permissions.
+
+In addition to the permissions emitted on `'auth/permissions'`, the block merges in a synthetic `hasCompany` flag, computed via `isCompanyUser()` from `@dropins/storefront-company-management`. Unlike the B2B role/ACL permissions (e.g. `Magento_PurchaseOrder::*`), `hasCompany` reflects only whether the customer belongs to a company, independent of company feature flags (e.g. Purchase Orders) or the granularity of their assigned role. Use `hasCompany` for nav items that should be visible to any company member (e.g. "My Company"), rather than reusing a role-specific ACL permission that may be `false`/`undefined` for company members with a restricted role.
 
 #### Permission Logic
 

--- a/blocks/commerce-account-nav/commerce-account-nav.js
+++ b/blocks/commerce-account-nav/commerce-account-nav.js
@@ -1,9 +1,14 @@
 import { provider as UI, Icon } from '@dropins/tools/components.js';
 import { events } from '@dropins/tools/event-bus.js';
+import { isCompanyUser } from '@dropins/storefront-company-management/api.js';
 
 import '../../scripts/initializers/auth.js';
+import '../../scripts/initializers/company.js';
 
 export default async function decorate(block) {
+  /** Whether the current customer belongs to a company (independent of B2B role/PO permissions) */
+  const hasCompanyPromise = isCompanyUser().catch(() => false);
+
   /** Get rows data */
   const [keys, ...$items] = [...block.children].map((child, index) => {
     if (index === 0) return [...child.children].map((c) => c.textContent.trim());
@@ -22,7 +27,10 @@ export default async function decorate(block) {
   };
 
   /** Get permissions */
-  events.on('auth/permissions', (permissions) => {
+  events.on('auth/permissions', async (basePermissions) => {
+    const hasCompany = await hasCompanyPromise;
+    const permissions = { ...basePermissions, hasCompany };
+
     /** Clear nav */
     $nav.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- Non-company storefront users saw "My Company" / "Company Structure" / "Company Users" / "Company Credit" in the account nav, which redirected back to My Account when clicked (dead-end links) — see USF-2894.
- Root cause: these items are configured with `permission: all` in the `/customer/nav` DA fragment, so `commerce-account-nav` renders them for every customer regardless of company membership.
- Fix: merge a `hasCompany` flag (via `isCompanyUser()` from `@dropins/storefront-company-management`) into the nav's permission check, so DA content can gate on real company membership instead of reusing a Purchase-Order-specific ACL bit (which would incorrectly hide these items for company users whose role lacks that specific PO permission).

## Follow-up required (separate from this PR)
The DA content fragment at `/customer/nav` still needs its `permission` column changed from `all` to `hasCompany` for the affected rows — this code change alone does not alter production behavior until that content edit is made by an author.

## Test plan
- [ ] On this PR's preview environment, confirm the account nav still renders correctly with the existing (unchanged) DA content — no regressions to decoration.
- [ ] Once the DA fragment's `permission` column is updated to `hasCompany` for Company Profile/Structure/Users/Credit (in a sandbox/preview copy), confirm:
  - [ ] Non-company customer: those items are hidden.
  - [ ] Company customer: those items still show and link correctly, including for roles without granular Purchase Order permissions.
- [ ] `Roles and Permissions` (already gated on `Magento_Company::roles_view`) is unaffected.

## Test URLs:
- Before: https://b2b-integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://USF-2894--boilerplate-b2b-accs--adobe-commerce.aem.page/