### PR TITLE
.gitattributes: mark dropins and lockfiles as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+# Hide generated/vendored files from GitHub diffs and language stats
 scripts/__dropins__/** linguist-generated=true
 package-lock.json linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+scripts/__dropins__/** linguist-generated=true
+package-lock.json linguist-generated=true


### PR DESCRIPTION
## Summary
Adds `.gitattributes` so GitHub collapses diffs/stats for generated files:
- `scripts/__dropins__/**`
- `package-lock.json` (root, `cypress/`, `tools/pdp-metadata/`)

## Test URLs
- https://gitattributes-lock-dropins--aem-boilerplate-commerce--hlxsites.aem.page