### PR TITLE
USF-3175-fix: visually hide add-to-cart status region on PDP

### DIFF
--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -87,7 +87,7 @@
     display: block;
     grid-column: 1 / span 6;
   }
-  
+
   .product-details__right-column {
     grid-column: 7 / span 5;
     padding-top: var(--spacing-medium);
@@ -114,4 +114,16 @@
   .product-details__quantity {
     grid-column: 1 / span 2;
   }
+}
+
+.product-details__add-to-cart-status {
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Description
The aria-live status region added in [#1344](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1344) for the PDP "Adding to Cart" announcement is missing its `visually-hidden` CSS. This causes the text to render visibly below the button. 

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://fix-USF-3175-pdp-status--aem-boilerplate-commerce--hlxsites.aem.page/
