### PR TITLE
USF-4266: Hardcoded status/label strings not translatable

### DIFF
--- a/blocks/commerce-checkout/utils.js
+++ b/blocks/commerce-checkout/utils.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved */
 import { ProgressSpinner, provider as UI } from '@dropins/tools/components.js';
 import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
-import { ORDER_DETAILS_PATH, rootLink } from '../../scripts/commerce.js';
+import { fetchPlaceholders, ORDER_DETAILS_PATH, rootLink } from '../../scripts/commerce.js';
 import { getUserTokenCookie } from '../../scripts/initializers/index.js';
 import createModal from '../modal/modal.js';
 
@@ -15,7 +15,10 @@ export const displayOverlaySpinner = async (loaderRef, $loader, $loaderStatus) =
   // Kept as a separate, persistently mounted live region so the
   // announcement isn't missed when the spinner mounts and unmounts
   // together with the live region attached to it.
-  if ($loaderStatus) $loaderStatus.textContent = 'Placing your order…';
+  if ($loaderStatus) {
+    const placeholders = await fetchPlaceholders('placeholders/checkout.json');
+    $loaderStatus.textContent = placeholders?.Checkout?.Loader?.placingOrder ?? 'Placing your order…';
+  }
 
   if (loaderRef.current) return;
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -94,7 +94,10 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
   document.body.style.overflowY = expanded || isDesktop.matches ? '' : 'hidden';
   nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
   toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
-  button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');
+  button.setAttribute(
+    'aria-label',
+    expanded ? (labels.Global?.OpenNavigation ?? 'Open navigation') : (labels.Global?.CloseNavigation ?? 'Close navigation'),
+  );
   // enable nav dropdown keyboard accessibility
   if (navSections) {
     const navDrops = navSections.querySelectorAll('.nav-drop');
@@ -128,7 +131,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 
 const subMenuHeader = document.createElement('div');
 subMenuHeader.classList.add('submenu-header');
-subMenuHeader.innerHTML = '<h5 class="back-link">All Categories</h5><hr />';
+subMenuHeader.innerHTML = `<h5 class="back-link">${labels.Global?.AllCategories ?? 'All Categories'}</h5><hr />`;
 
 /**
  * Sets up the submenu
@@ -225,7 +228,7 @@ export default async function decorate(block) {
   /** Wishlist */
   const wishlist = document.createRange().createContextualFragment(`
      <div class="wishlist-wrapper nav-tools-wrapper">
-       <button type="button" class="nav-wishlist-button" aria-label="Wishlist"></button>
+       <button type="button" class="nav-wishlist-button" aria-label="${labels.Global?.Wishlist ?? 'Wishlist'}"></button>
        <div class="wishlist-panel nav-tools-panel"></div>
      </div>
    `);
@@ -246,7 +249,7 @@ export default async function decorate(block) {
 
   const minicart = document.createRange().createContextualFragment(`
      <div class="minicart-wrapper nav-tools-wrapper">
-       <button type="button" class="nav-cart-button" aria-label="Cart" aria-haspopup="dialog" aria-expanded="false" aria-controls="minicart-panel"></button>
+       <button type="button" class="nav-cart-button" aria-label="${labels.Global?.Cart ?? 'Cart'}" aria-haspopup="dialog" aria-expanded="false" aria-controls="minicart-panel"></button>
        <div class="minicart-panel nav-tools-panel" id="minicart-panel"></div>
        <div class="nav-cart-status" role="status" aria-live="polite"></div>
      </div>
@@ -361,9 +364,15 @@ export default async function decorate(block) {
     // reader users aren't told about the cart contents before they've
     // interacted with it; only announce actual changes.
     if (previousCartQuantity !== undefined && previousCartQuantity !== totalQuantity) {
-      cartStatus.textContent = totalQuantity
-        ? `Cart updated, ${totalQuantity} item${totalQuantity === 1 ? '' : 's'} in cart`
-        : 'Cart updated, cart is empty';
+      if (totalQuantity) {
+        cartStatus.textContent = totalQuantity === 1
+          ? (labels.Global?.CartUpdatedWithItem?.replace('{count}', totalQuantity)
+            ?? `Cart updated, ${totalQuantity} item in cart`)
+          : (labels.Global?.CartUpdatedWithItems?.replace('{count}', totalQuantity)
+            ?? `Cart updated, ${totalQuantity} items in cart`);
+      } else {
+        cartStatus.textContent = labels.Global?.CartUpdatedEmpty ?? 'Cart updated, cart is empty';
+      }
     }
 
     previousCartQuantity = totalQuantity;
@@ -372,7 +381,7 @@ export default async function decorate(block) {
   /** Search */
   const searchFragment = document.createRange().createContextualFragment(`
   <div class="search-wrapper nav-tools-wrapper">
-    <button type="button" class="nav-search-button">Search</button>
+    <button type="button" class="nav-search-button">${labels.Global?.Search ?? 'Search'}</button>
     <div class="nav-search-input nav-search-panel nav-tools-panel">
       <form id="search-bar-form"></form>
       <div class="search-bar-result" style="display: none;"></div>
@@ -546,7 +555,7 @@ export default async function decorate(block) {
   // hamburger for mobile
   const hamburger = document.createElement('div');
   hamburger.classList.add('nav-hamburger');
-  hamburger.innerHTML = `<button type="button" aria-controls="nav" aria-label="Open navigation">
+  hamburger.innerHTML = `<button type="button" aria-controls="nav" aria-label="${labels.Global?.OpenNavigation ?? 'Open navigation'}">
       <span class="nav-hamburger-icon"></span>
     </button>`;
   hamburger.addEventListener('click', () => {


### PR DESCRIPTION
Some status messages and aria-labels in the boilerplate are hardcoded in English instead of being sourced from placeholders, so screen reader users on non-English storefronts still hear English announcements. These strings should be made translatable, following the existing placeholders pattern used elsewhere in the codebase.

[USF-4266](https://jira.corp.adobe.com/browse/USF-4266)

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-4266--aem-boilerplate-commerce--hlxsites.aem.page/
