### PR TITLE
USF-3175 (b2b-int): visually hide add-to-cart status region on PDP

### DIFF
--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -106,7 +106,7 @@
     display: block;
     grid-column: 1 / span 6;
   }
-  
+
   .product-details__right-column {
     grid-column: 7 / span 5;
     padding-top: var(--spacing-medium);
@@ -133,4 +133,16 @@
   .product-details__quantity {
     grid-column: 1 / span 2;
   }
+}
+
+.product-details__add-to-cart-status {
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Cherry-pick of #1378 into `b2b-integration` branch to include the fix in the existing release tag without requiring a new one.
This visually hides the add-to-cart status region on PDP while keeping it accessible for screen readers.
## Test URLs:
- **Before:** https://b2b-integration--aem-boilerplate-commerce--hlxsites.aem.page/
- **After:** https://fix-usf3175-b2b-int--aem-boilerplate-commerce--hlxsites.aem.page/