### PR TITLE
Lazyload Mini-Cart Containers

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -349,7 +349,6 @@ export default async function decorate(block) {
   let previousCartQuantity;
 
   events.on('cart/data', (data) => {
-
     const totalQuantity = data?.totalQuantity ?? 0;
 
     if (totalQuantity) {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -349,8 +349,6 @@ export default async function decorate(block) {
   let previousCartQuantity;
 
   events.on('cart/data', (data) => {
-    // preload mini cart fragment if user has a cart
-    if (data) loadMiniCartFragment();
 
     const totalQuantity = data?.totalQuantity ?? 0;
 

--- a/cypress/src/tests/b2c/events/add-to-cart.spec.js
+++ b/cypress/src/tests/b2c/events/add-to-cart.spec.js
@@ -13,6 +13,7 @@ it("is sent on add to cart button click", () => {
   cy.get(".product-details__buttons__add-to-cart button")
     .should("be.visible")
     .click();
+  cy.get(".minicart-wrapper").click();
   cy.get(".minicart-panel[data-loaded='true']").should('exist');
   cy.get(".minicart-panel").should("not.be.empty");
 

--- a/cypress/src/tests/b2c/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js
+++ b/cypress/src/tests/b2c/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js
@@ -38,9 +38,9 @@ describe("Verify price summary on cart", () => {
     cy.get(".product-details__buttons__add-to-cart button")
       .should("be.visible")
       .click();
+    cy.get(".minicart-wrapper").click();
     cy.get(".minicart-panel[data-loaded='true']").should('exist');
     cy.get(".minicart-panel").should("not.be.empty");
-    cy.get(".minicart-wrapper").click();
     assertCartSummaryProduct(
       'Configurable product',
       'CYPRESS456',


### PR DESCRIPTION
## Problem

On every page load, the `cart/data` event handler in `blocks/header/header.js` called `loadMiniCartFragment()` immediately when cart data existed:

```js
events.on('cart/data', (data) => {
  if (data) loadMiniCartFragment(); // triggered on every page load for users with cart items
  ...
});
```

This eagerly fetched the mini-cart fragment and decorated the `commerce-mini-cart` block for any user with an active cart, even if they never opened the cart panel. The block decoration chain loads ~25 additional requests:

- `commerce-mini-cart.js` + `commerce-mini-cart.css`
- `storefront-cart/render.js`, `fragments.js`, `chunks/components.js`
- 11 cart dropin containers (MiniCart, EstimateShipping, CartSummaryGrid, CartSummaryList, CartSummaryTable, Coupons, EmptyCart, GiftCards, GiftOptions, OrderSummary, OrderSummaryLine)
- `commerce-mini-pdp.js`, `cart-product-card.js`
- `storefront-pdp/render.js`, `api.js`, `fragments.js`, `chunks/components.js`
- ProductPrice, ProductOptions, ProductQuantity containers

This contributed to 429 Too Many Requests errors caused by EDS rate limits (100 req/sec per IP on `.aem.live`). A single homepage load was generating ~163 same-origin requests within the first 500ms.

## Fix

Removed the preload call. The mini-cart fragment now loads only on the user's first click of the cart button — the interaction-driven path via `toggleMiniCart()` was already in place and working correctly.

The cart item count badge is driven by `data.totalQuantity` and a CSS `data-count` attribute, so it continues to update without requiring the fragment to be loaded. The `withLoadingState()` function already sets `aria-busy` on the cart button during the first-click fetch, so the loading UX is handled.

## Impact

~25 dropin and block requests deferred from initial page load to first user interaction with the mini-cart. No functionality or accessibility regressions.

## Test URLs

- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://lazyminicart--aem-boilerplate-commerce--hlxsites.aem.live/