### PR TITLE
Lazyload Mini-Cart Containers (port to b2b-integration)

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -347,7 +347,6 @@ export default async function decorate(block) {
   let previousCartQuantity;
 
   events.on('cart/data', (data) => {
-
     const totalQuantity = data?.totalQuantity ?? 0;
 
     if (totalQuantity) {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -347,8 +347,6 @@ export default async function decorate(block) {
   let previousCartQuantity;
 
   events.on('cart/data', (data) => {
-    // preload mini cart fragment if user has a cart
-    if (data) loadMiniCartFragment();
 
     const totalQuantity = data?.totalQuantity ?? 0;
 

--- a/cypress/src/tests/b2c/events/add-to-cart.spec.js
+++ b/cypress/src/tests/b2c/events/add-to-cart.spec.js
@@ -13,6 +13,7 @@ it("is sent on add to cart button click", () => {
   cy.get(".product-details__buttons__add-to-cart button")
     .should("be.visible")
     .click();
+  cy.get(".minicart-wrapper").click();
   cy.get(".minicart-panel[data-loaded='true']").should('exist');
   cy.get(".minicart-panel").should("not.be.empty");
 

--- a/cypress/src/tests/b2c/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js
+++ b/cypress/src/tests/b2c/verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js
@@ -38,9 +38,9 @@ describe("Verify price summary on cart", () => {
     cy.get(".product-details__buttons__add-to-cart button")
       .should("be.visible")
       .click();
+    cy.get(".minicart-wrapper").click();
     cy.get(".minicart-panel[data-loaded='true']").should('exist');
     cy.get(".minicart-panel").should("not.be.empty");
-    cy.get(".minicart-wrapper").click();
     assertCartSummaryProduct(
       'Configurable product',
       'CYPRESS456',


### PR DESCRIPTION
## Problem

Same issue as #1387, ported to `b2b-integration`. On every page load, the `cart/data` event handler in `blocks/header/header.js` called `loadMiniCartFragment()` immediately when cart data existed:

```js
events.on('cart/data', (data) => {
  if (data) loadMiniCartFragment(); // triggered on every page load for users with cart items
  ...
});
```

This eagerly fetched the mini-cart fragment and decorated the `commerce-mini-cart` block for any user with an active cart, even if they never opened the cart panel, contributing to 429 Too Many Requests errors from EDS rate limits.

## Fix

Cherry-picked the fix from `lazyminicart` (merged via #1387):
- Removed the preload call — the mini-cart fragment now loads only on the user's first click of the cart button.
- Updated the two Cypress specs that asserted `.minicart-panel[data-loaded='true']` right after "Add to cart" without opening the cart panel first (`events/add-to-cart.spec.js`, `verifyZeroTotalCheckoutWithGiftCardAndGiftOptions.spec.js`) to click `.minicart-wrapper` before asserting, matching the pattern already used by the other passing specs.

## Impact

Same as #1387 — dropin/block requests deferred from initial page load to first user interaction with the mini-cart. No functionality or accessibility regressions.

## Test URLs

- Feature Preview: https://b2b-lazycart--aem-boilerplate-commerce--hlxsites.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)