### PR TITLE
hotfix: update @dropins/tools to revert reCAPTCHA COMPANY_CREATE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@dropins/storefront-product-discovery": "3.1.1",
         "@dropins/storefront-recommendations": "4.0.4",
         "@dropins/storefront-wishlist": "3.4.0",
-        "@dropins/tools": "2.0.0"
+        "@dropins/tools": "2.0.1-alpha-20260806134012"
       },
       "devDependencies": {
         "@adobe/aem-cli": "16.17.1",
@@ -2133,9 +2133,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/tools": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dropins/tools/-/tools-2.0.0.tgz",
-      "integrity": "sha512-YrC+O2Thhf6v7B7NgNa9dUEY0TrJ3nbAZm+AoGYs+Z57AruEgZ14W/Bb+H3sNRgSfPh7hJp5XferXOVO2MGpFg==",
+      "version": "2.0.1-alpha-20260806134012",
+      "resolved": "https://registry.npmjs.org/@dropins/tools/-/tools-2.0.1-alpha-20260806134012.tgz",
+      "integrity": "sha512-7/FMYf/A9vWdQHiHfUxRpVsFpbfV3ASa5juy+SVHccDh5suBSkRzTVSsfhrJ4pyPyfd9DyHpPBNCDJCHIFmSrQ==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@dropins/storefront-product-discovery": "3.1.1",
     "@dropins/storefront-recommendations": "4.0.4",
     "@dropins/storefront-wishlist": "3.4.0",
-    "@dropins/tools": "2.0.0"
+    "@dropins/tools": "2.0.1-alpha-20260806134012"
   },
   "overrides": {
     "@adobe/alloy": {


### PR DESCRIPTION
Updates `@dropins/tools` to `2.0.1-alpha-20260806134012` which reverts the reCAPTCHA `COMPANY_CREATE` form entry that was causing issues for merchants not using SCP-B2B.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://hotfix-revert-recaptcha-main--aem-boilerplate-commerce--hlxsites.aem.live/