### PR TITLE
PAY-6967: Relocate APS payment buttons to bottom of checkout

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.css
+++ b/blocks/commerce-checkout/commerce-checkout.css
@@ -238,6 +238,14 @@
 
     .checkout__place-order {
         order: 4;
+        background-color: var(--color-neutral-200);
+        padding: 0 var(--spacing-medium) var(--spacing-big) var(--spacing-medium);
+    }
+
+    /* Neutralize the checkout dropin's own background/padding so it doesn't stack with the rule above */
+    .checkout__place-order .checkout-place-order {
+        background-color: transparent;
+        padding: 0;
     }
 }
 

--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -34,6 +34,7 @@ import {
 
 // Container functions
 import {
+  isPlaceOrderRendered,
   renderAddressForm,
   renderBillingAddressFormSkeleton,
   renderBillToShippingAddress,
@@ -318,7 +319,7 @@ export default async function decorate(block) {
     $billingForm.style.display = isBillToShipping ? 'none' : 'block';
 
     if (!isExpressPaymentMethod(selectedPaymentMethod)
-        && !$placeOrder.querySelector('.checkout-place-order')) {
+        && !isPlaceOrderRendered($placeOrder)) {
       // Express payment methods replace the place order button; restore it for non-express methods
       renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
     }

--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -178,7 +178,7 @@ export default async function decorate(block) {
   };
 
   // First, render the place order component
-  const placeOrder = await renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
+  await renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
 
   // Render the remaining containers
   const [
@@ -213,7 +213,7 @@ export default async function decorate(block) {
 
     renderShippingMethods($delivery),
 
-    renderPaymentMethods($paymentMethods, creditCardFormRef, handleValidation),
+    renderPaymentMethods($paymentMethods, $placeOrder, creditCardFormRef, handleValidation),
 
     renderBillingAddressFormSkeleton($billingForm),
 
@@ -316,11 +316,11 @@ export default async function decorate(block) {
   function handleCheckoutValues(payload) {
     const { isBillToShipping, selectedPaymentMethod } = payload;
     $billingForm.style.display = isBillToShipping ? 'none' : 'block';
-    if (isExpressPaymentMethod(selectedPaymentMethod)) {
-      // Express payment methods take over the responsibility of placing the order
-      placeOrder.setProps((prev) => ({ ...prev, active: false }));
-    } else {
-      placeOrder.setProps((prev) => ({ ...prev, active: true }));
+
+    if (!isExpressPaymentMethod(selectedPaymentMethod)
+        && !$placeOrder.querySelector('.checkout-place-order')) {
+      // Express payment methods replace the place order button; restore it for non-express methods
+      renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
     }
   }
 

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -472,7 +472,6 @@ export const renderPaymentMethods = async (
  */
 const createExpressPaymentNotice = (label) => {
   const $notice = document.createElement('p');
-  $notice.className = 'checkout-payment-methods__express-notice';
   $notice.textContent = `Complete your purchase using the ${label} button below.`;
   return $notice;
 };

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -700,6 +700,14 @@ export const renderPlaceOrder = async (container, options = {}) => mountPlaceOrd
 );
 
 /**
+ * Checks whether the standard Place Order button currently occupies the Place Order slot,
+ * as opposed to an express payment method's own button (or nothing, if unmounted).
+ * @param {HTMLElement} container - The Place Order slot element.
+ * @returns {boolean}
+ */
+export const isPlaceOrderRendered = (container) => !!container.querySelector('.checkout-place-order');
+
+/**
  * Renders customer shipping addresses selector/form for authenticated users - original regular checkout functionality
  * @param {HTMLElement} container - DOM element to render shipping addresses in
  * @param {Object} formRef - React-style ref for form reference

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -340,12 +340,19 @@ export const renderShippingMethods = async (container) => renderContainer(
 
 /**
  * Renders payment methods with credit card integration - original regular checkout functionality
- * @param {HTMLElement} container - DOM element to render payment methods in
+ * @param {HTMLElement} paymentMethodsContainer - DOM element to render payment methods in
+ * @param {HTMLElement} placeOrderButtonContainer - DOM element express payment buttons mount into,
+ *   in place of the standard Place Order button
  * @param {Object} creditCardFormRef - React-style ref for credit card form
  * @param {Function} validateCheckoutForms - Function that returns true if all Checkout forms are valid
  * @returns {Promise<Object>} - The rendered payment methods component
  */
-export const renderPaymentMethods = async (container, creditCardFormRef, validateCheckoutForms) => renderContainer(
+export const renderPaymentMethods = async (
+  paymentMethodsContainer,
+  placeOrderButtonContainer,
+  creditCardFormRef,
+  validateCheckoutForms,
+) => renderContainer(
   CONTAINERS.PAYMENT_METHODS,
   async () => CheckoutProvider.render(PaymentMethods, {
     slots: {
@@ -369,9 +376,7 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
         },
         [PaymentMethodCode.PAYPAL_BUTTONS]: {
           render: (ctx) => {
-            const $paypalButtons = document.createElement('div');
-
-            PaymentServices.render(PayPalButtons, {
+            mountPlaceOrderSlot((el) => PaymentServices.render(PayPalButtons, {
               onButtonClick: (showPaymentSheet) => {
                 if (validateCheckoutForms()) {
                   showPaymentSheet();
@@ -385,26 +390,26 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
                   message: localizedError.message,
                 });
               },
-            })($paypalButtons);
-            ctx.replaceHTML($paypalButtons);
+            })(el), placeOrderButtonContainer);
+
+            ctx.replaceHTML(createExpressPaymentNotice('PayPal'));
           },
           enabled: false,
         },
         [PaymentMethodCode.APPLE_PAY]: {
           render: (ctx) => {
-            const $applePay = document.createElement('div');
-
             const checkoutData = events.lastPayload('checkout/updated')
               || events.lastPayload('checkout/initialized')
               || null;
 
             if (checkoutData === null) {
               console.error('Cannot render apple pay button without checkout data.');
-              ctx.replaceHTML($applePay);
+              unmountPlaceOrderSlot();
+              ctx.replaceHTML(document.createElement('div'));
               return;
             }
 
-            PaymentServices.render(ApplePay, {
+            mountPlaceOrderSlot((el) => PaymentServices.render(ApplePay, {
               location: PaymentLocation.CHECKOUT,
               getCartId: () => ctx.cartId,
               isVirtualCart: checkoutData.isVirtual,
@@ -419,9 +424,9 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
                   message: localizedError.message,
                 });
               },
-            })($applePay);
+            })(el), placeOrderButtonContainer);
 
-            ctx.replaceHTML($applePay);
+            ctx.replaceHTML(createExpressPaymentNotice('Apple Pay'));
           },
           enabled: false,
         },
@@ -430,9 +435,7 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
         },
         [PaymentMethodCode.GOOGLE_PAY]: {
           render: (ctx) => {
-            const $googlePay = document.createElement('div');
-
-            PaymentServices.render(GooglePay, {
+            mountPlaceOrderSlot((el) => PaymentServices.render(GooglePay, {
               onButtonClick: (showPaymentSheet) => {
                 if (validateCheckoutForms()) {
                   showPaymentSheet();
@@ -444,8 +447,9 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
                   message: localizedError.message,
                 });
               },
-            })($googlePay);
-            ctx.replaceHTML($googlePay);
+            })(el), placeOrderButtonContainer);
+
+            ctx.replaceHTML(createExpressPaymentNotice('Google Pay'));
           },
           enabled: false,
         },
@@ -457,8 +461,21 @@ export const renderPaymentMethods = async (container, creditCardFormRef, validat
         },
       },
     },
-  })(container),
+  })(paymentMethodsContainer),
 );
+
+/**
+ * Creates a short notice explaining that the given express payment method's button renders in
+ * the Place Order slot instead of inline in the Payment section.
+ * @param {string} label - Display label of the express payment method (e.g. "Apple Pay")
+ * @returns {HTMLElement} - The notice element
+ */
+const createExpressPaymentNotice = (label) => {
+  const $notice = document.createElement('p');
+  $notice.className = 'checkout-payment-methods__express-notice';
+  $notice.textContent = `Complete your purchase using the ${label} button below.`;
+  return $notice;
+};
 
 /**
  * Renders terms and conditions with agreement slots and manual consent mode
@@ -621,20 +638,65 @@ export const renderCartSummaryList = async (container) => renderContainer(
   },
 );
 
+// Serializes every mount/unmount of the Place Order slot's occupant (the standard "Place order"
+// button, or the currently-selected express payment method's own button) so a new occupant is
+// never rendered while the previous one is still being removed.
+let placeOrderSlotQueue = Promise.resolve();
+let placeOrderSlotMount = null; // Promise<RenderAPI> | null
+
+/**
+ * Mounts a new occupant into the Place Order slot, unmounting whatever was previously there.
+ * @param {(container: HTMLElement) => Promise<Object>} mount - Starts the dropin render.
+ * @param {HTMLElement} container - The Place Order slot element.
+ * @returns {Promise<void>}
+ */
+const mountPlaceOrderSlot = (mount, container) => {
+  placeOrderSlotQueue = unmountPlaceOrderSlot().then(async () => {
+    try {
+      placeOrderSlotMount = mount(container);
+      await placeOrderSlotMount;
+    } catch (error) {
+      console.error('Failed to mount Place Order slot occupant:', error);
+      placeOrderSlotMount = null;
+    }
+  });
+  return placeOrderSlotQueue;
+};
+
+/**
+ * Unmounts whatever currently occupies the Place Order slot, if anything.
+ * @returns {Promise<void>}
+ */
+const unmountPlaceOrderSlot = () => {
+  placeOrderSlotQueue = placeOrderSlotQueue.then(async () => {
+    if (placeOrderSlotMount) {
+      try {
+        const api = await placeOrderSlotMount;
+        api.remove();
+      } catch (error) {
+        console.error('Failed to unmount Place Order slot occupant:', error);
+      } finally {
+        placeOrderSlotMount = null;
+      }
+    }
+  });
+  return placeOrderSlotQueue;
+};
+
 /**
  * Renders place order button with handler functions - follows multi-step pattern
  * @param {HTMLElement} container - DOM element to render the place order button in
  * @param {Object} options - Configuration object with handler functions
  * @param {Function} options.handleValidation - Validation handler function
  * @param {Function} options.handlePlaceOrder - Place order handler function
- * @returns {Promise<Object>} - The rendered place order component
+ * @returns {Promise<void>}
  */
-export const renderPlaceOrder = async (container, options = {}) => renderContainer(
-  CONTAINERS.PLACE_ORDER_BUTTON,
-  async () => CheckoutProvider.render(PlaceOrder, {
+export const renderPlaceOrder = async (container, options = {}) => mountPlaceOrderSlot(
+  (el) => CheckoutProvider.render(PlaceOrder, {
     handleValidation: options.handleValidation,
     handlePlaceOrder: options.handlePlaceOrder,
-  })(container),
+  })(el),
+  container,
 );
 
 /**


### PR DESCRIPTION
This pull request relocates Payment Services' express payment method buttons (Apple Pay, Google Pay, PayPal) to the bottom of the checkout page. This allows us to restore the default checkout layout (Billing, Terms and Conditions, Payment) without requiring the customer to scroll up and down. Demo:
<img width="800" height="660" alt="CleanShot 2026-08-12 at 15 41 58" src="https://github.com/user-attachments/assets/9a9d3917-e01d-4fea-91ad-5ba014e41e9e" />

Fixes [PAY-6967](https://jira.corp.adobe.com/browse/PAY-6967).

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://PAY-6967--aem-boilerplate-commerce--hlxsites.aem.live/
