### PR TITLE
feat: add product comparison block

### DIFF
--- a/blocks/product-compare-bar/README.md
+++ b/blocks/product-compare-bar/README.md
@@ -1,0 +1,57 @@
+# Product Compare Bar Block
+
+## Overview
+
+A persistent fixed bottom bar that collects products for side-by-side comparison. Authors place it on any page where product browsing occurs. Products are added or removed via the `compare/products` event bus event emitted by other blocks (PLP, PDP product cards). When the visitor is ready, the Compare button navigates to the configured compare page with the selected SKUs as a URL parameter.
+
+## Integration
+
+### Block Configuration
+
+| Configuration Key | Format | Description |
+|---|---|---|
+| `page` | URL path string | Path to the product comparison page. Defaults to `/product-compare`. |
+
+**Example:**
+
+```
+| Product Compare Bar |                  |
+| page                | /product-compare |
+```
+
+### Event Bus
+
+The bar listens to the `compare/products` event from `@dropins/tools/event-bus.js`.
+
+**Event name:** `compare/products`
+
+**Payload:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sku` | `string` | Product SKU — used as the unique key and appended to the compare URL. |
+| `img` | `string` | Product image URL shown in the bar. |
+| `name` | `string` | Product name shown in the bar and used for accessible button labels. |
+
+**Emit from any block:**
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.emit('compare/products', { sku: 'MH01-XS-Black', img: '/path/to/image.jpg', name: 'Chaz Kangeroo Hoodie' });
+```
+
+**Toggle behavior:** Emitting the event for a SKU already in the bar removes it. This allows PLP "Compare" buttons to reflect active/inactive state without additional coordination.
+
+### URL Parameter
+
+When the visitor clicks Compare, the bar navigates to `{page}?compare=SKU1,SKU2,SKU3`. This matches the `?compare=` parameter consumed by the `product-compare` block.
+
+## Behavior
+
+- **Max 3 products** — additional `compare/products` events are ignored once 3 products are selected.
+- **In-memory state** — selections reset on page navigation.
+- **Bar visibility** — hidden until the first product is added; shown automatically on add.
+- **Remove button** — clicking `×` on a product card removes that product from the selection.
+- **Clear All** — removes all products and hides the bar.
+- **Compare link** — disabled (via `aria-disabled`) when no products are selected.

--- a/blocks/product-compare-bar/product-compare-bar.css
+++ b/blocks/product-compare-bar/product-compare-bar.css
@@ -1,0 +1,82 @@
+/* ── Fixed bar ──────────────────────────────────────────────────────────────── */
+
+.product-compare-bar__container {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-medium);
+    padding: var(--spacing-small) var(--spacing-medium);
+    background: var(--background-color);
+    border-top: var(--shape-border-width-2) solid var(--color-neutral-300);
+    box-shadow: 0 -4px 16px rgb(0 0 0 / 8%);
+}
+
+.product-compare-bar__container[hidden] {
+    display: none;
+}
+
+/* ── Product cards ──────────────────────────────────────────────────────────── */
+
+.product-compare-bar__products {
+    display: flex;
+    flex: 1;
+    gap: var(--spacing-small);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.product-compare-bar__products::-webkit-scrollbar {
+    display: none;
+}
+
+.product-compare-bar__product {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xsmall);
+    padding: var(--spacing-xsmall);
+    border: var(--shape-border-width-1) solid var(--color-neutral-300);
+    border-radius: var(--shape-border-radius-m);
+    flex-shrink: 0;
+}
+
+.product-compare-bar__product img {
+    width: 56px;
+    height: 56px;
+    object-fit: contain;
+}
+
+.product-compare-bar__product-name {
+    font: var(--type-body-2-font);
+    letter-spacing: var(--type-body-2-letter-spacing);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 120px;
+}
+
+/* ── Actions ────────────────────────────────────────────────────────────────── */
+
+.product-compare-bar__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    flex-shrink: 0;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────────── */
+
+@media (min-width: 600px) {
+    .product-compare-bar__product-name {
+        max-width: 160px;
+    }
+}
+
+@media (min-width: 900px) {
+    .product-compare-bar__product-name {
+        max-width: 200px;
+    }
+}

--- a/blocks/product-compare-bar/product-compare-bar.js
+++ b/blocks/product-compare-bar/product-compare-bar.js
@@ -1,0 +1,130 @@
+import {
+  Button, Icon, Image, provider as UI,
+} from '@dropins/tools/components.js';
+import { h } from '@dropins/tools/preact.js';
+import { isAemAssetsEnabled, tryGenerateAemAssetsOptimizedUrl } from '@dropins/tools/lib/aem/assets.js';
+import { events } from '@dropins/tools/event-bus.js';
+import { readBlockConfig } from '../../scripts/aem.js';
+
+const MAX_PRODUCTS = 3;
+const IMAGE_SIZE = { width: 56, height: 56 };
+
+export default async function decorate(block) {
+  const config = readBlockConfig(block);
+  const comparePage = config.page ?? '/product-compare';
+
+  const products = []; // { sku, img, name }[]
+
+  // ── Build DOM ─────────────────────────────────────────────────────────────
+
+  const container = document.createElement('div');
+  container.className = 'product-compare-bar__container';
+
+  const productsEl = document.createElement('div');
+  productsEl.className = 'product-compare-bar__products';
+
+  const actionsEl = document.createElement('div');
+  actionsEl.className = 'product-compare-bar__actions';
+
+  const compareBtnWrap = document.createElement('div');
+  compareBtnWrap.className = 'product-compare-bar__compare';
+
+  const clearBtnWrap = document.createElement('div');
+  clearBtnWrap.className = 'product-compare-bar__clear';
+
+  actionsEl.append(compareBtnWrap, clearBtnWrap);
+  container.append(productsEl, actionsEl);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  async function render() {
+    productsEl.innerHTML = '';
+
+    await Promise.all(products.map(async ({ sku, img, name }) => {
+      const item = document.createElement('div');
+      item.className = 'product-compare-bar__product';
+      item.dataset.sku = sku;
+
+      if (img) {
+        const imgSrc = img.replace(/^https?:/, '');
+        const useAem = isAemAssetsEnabled();
+        const src = useAem ? tryGenerateAemAssetsOptimizedUrl(imgSrc, sku, {}) : imgSrc;
+        const params = useAem
+          ? {
+            ...IMAGE_SIZE, crop: undefined, fit: undefined, auto: undefined,
+          }
+          : { ...IMAGE_SIZE };
+        const imgWrap = document.createElement('div');
+        await UI.render(Image, {
+          src,
+          alt: name,
+          loading: 'lazy',
+          params,
+        })(imgWrap);
+        item.append(imgWrap);
+      }
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'product-compare-bar__product-name';
+      nameEl.textContent = name;
+
+      const removeBtnWrap = document.createElement('div');
+      await UI.render(Button, {
+        icon: h(Icon, { source: 'Close' }),
+        variant: 'tertiary',
+        'aria-label': `Remove ${name}`,
+        // eslint-disable-next-line no-use-before-define
+        onClick: () => removeProduct(sku),
+      })(removeBtnWrap);
+
+      item.append(nameEl, removeBtnWrap);
+      productsEl.append(item);
+    }));
+
+    const skus = products.map((p) => p.sku).join(',');
+    await UI.render(Button, {
+      children: 'Compare',
+      href: skus ? `${comparePage}?compare=${skus}` : undefined,
+      variant: 'primary',
+      disabled: !skus,
+    })(compareBtnWrap);
+
+    container.hidden = products.length === 0;
+  }
+
+  function removeProduct(sku) {
+    const idx = products.findIndex((p) => p.sku === sku);
+    if (idx !== -1) products.splice(idx, 1);
+    render();
+  }
+
+  // ── Static buttons ────────────────────────────────────────────────────────
+
+  await UI.render(Button, {
+    children: 'Clear All',
+    variant: 'secondary',
+    onClick: () => {
+      products.length = 0;
+      render();
+    },
+  })(clearBtnWrap);
+
+  // ── Events ────────────────────────────────────────────────────────────────
+
+  events.on('compare/products', ({ sku, img, name } = {}) => {
+    if (!sku) return;
+    const idx = products.findIndex((p) => p.sku === sku);
+    if (idx !== -1) {
+      products.splice(idx, 1);
+    } else if (products.length < MAX_PRODUCTS) {
+      products.push({ sku, img, name });
+    }
+    render();
+  });
+
+  // ── Mount ─────────────────────────────────────────────────────────────────
+
+  block.innerHTML = '';
+  block.append(container);
+  await render();
+}

--- a/blocks/product-compare/README.md
+++ b/blocks/product-compare/README.md
@@ -1,0 +1,65 @@
+# Product Compare Block
+
+## Overview
+
+The Product Compare block renders a side-by-side comparison table for up to three products. Products are loaded from the Catalog Service via the `@dropins/storefront-product-discovery` search API and displayed with images, prices, and product attributes. Authors place the block on a page; visitors populate it by searching for products through the built-in search form.
+
+## Integration
+
+<!-- ### Block Configuration
+
+No block configuration is read via `readBlockConfig()`. -->
+
+### URL Parameters
+
+| Parameter | Format | Description |
+|-----------|--------|-------------|
+| `compare` | `?compare=SKU1,SKU2,SKU3` | Comma-separated list of SKUs to compare. Written on add/remove; read on page load to restore state. |
+
+<!-- ### Local Storage
+
+No localStorage keys are used by this block. -->
+
+<!-- ### Events
+
+#### Event Listeners
+
+No direct event listeners are implemented in this block.
+
+#### Event Emitters
+
+No events are emitted by this block. -->
+
+## Behavior Patterns
+
+### Page Context Detection
+
+- **Initial load with `?compare=` SKUs**: Fetches products by SKU and renders the comparison table immediately.
+- **Initial load without SKUs**: Renders only the search form, ready to add products.
+- **Maximum columns reached (3)**: Hides the search form until a product is removed.
+
+### User Interaction Flows
+
+1. **Search**: Visitor types in the search field; results debounce at 300 ms and appear in a dropdown.
+2. **Add product**: Clicking a search result appends a column to the table without a full re-render; clears the search field. If no table exists yet, a full render is performed.
+3. **Remove product**: Clicking the × button on a column header removes that column by index, keeping `thead` and `tbody` in sync. Updates the `?compare=` URL parameter.
+4. **Remove last product**: Removes the table entirely and shows the search form.
+5. **Clear search**: Clicking the × button inside the search field or selecting a product clears the input and hides the dropdown.
+
+### Price Display
+
+- **Simple product, no sale**: displays regular price.
+- **Simple product, on sale**: displays final price (normal) + regular price (struck through).
+- **Configurable product**: displays min–max price range using `display="from to"`. Shows both final and regular ranges when on sale.
+
+### Image Optimization
+
+- Uses the dropin `Image` component with `width: 400, height: 400` params.
+- When AEM Assets is enabled (`isAemAssetsEnabled()`), generates an optimized URL via `tryGenerateAemAssetsOptimizedUrl` and clears `crop`/`fit`/`auto` params.
+- No image URL: the image link is rendered empty rather than showing a broken placeholder.
+
+### Error Handling
+
+- **Fetch failure**: Catches API errors and renders an "Unable to load product comparison" message.
+- **No matching products**: Renders a "No matching products found" message.
+- **Unknown SKU in URL**: The API returns no item for that SKU; it is silently skipped in the rendered table.

--- a/blocks/product-compare/README.md
+++ b/blocks/product-compare/README.md
@@ -6,9 +6,22 @@ The Product Compare block renders a side-by-side comparison table for up to thre
 
 ## Integration
 
-<!-- ### Block Configuration
+### Block Configuration
 
-No block configuration is read via `readBlockConfig()`. -->
+Both keys are optional. Omitting them falls back to showing all attributes and searching all products.
+
+| Configuration Key | Format | Description |
+|---|---|---|
+| `attributes` | Comma-separated attribute names | Restricts which product attributes appear as rows in the comparison table, in the authored order. Names must match the `name` field returned by the Catalog Service (e.g. `color, weight, sensor_size`). |
+| `filter` | Comma-separated `attribute:value` pairs | Narrows which products are eligible for comparison. Applied to both the search dropdown and the initial SKU lookup. Use this to restrict comparisons to a category or a merchant-defined flag (e.g. `comparable:1, product_type:camera`). The attribute must be configured as **filterable** in the Adobe Commerce Catalog for the filter to take effect. |
+
+**Example — cameras only, specific attributes:**
+
+```
+| Product Compare |                                       |
+| attributes      | sensor_size, iso_range, weight, color  |
+| filter          | product_type:camera, comparable:1      |
+```
 
 ### URL Parameters
 

--- a/blocks/product-compare/product-compare.css
+++ b/blocks/product-compare/product-compare.css
@@ -1,0 +1,151 @@
+.product-compare {
+    margin-block: var(--spacing-big);
+}
+
+/* ── Add-product search form ────────────────────────────────────────────────── */
+
+.product-compare__search {
+    position: relative;
+    justify-self: end;
+    margin-bottom: var(--spacing-medium);
+    max-width: 400px;
+    width: 100%;
+}
+
+.product-compare__search-field {
+    position: relative;
+}
+
+.product-compare__search-reset {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+    z-index: 1;
+}
+
+.product-compare__search-dropdown {
+    background: var(--background-color);
+    border-top: none;
+    border: var(--shape-border-width-1) solid var(--color-neutral-300);
+    box-shadow: var(--shape-shadow-2);
+    display: flex;
+    flex-direction: column;
+    left: 0;
+    list-style: none;
+    margin: 0;
+    max-height: 360px;
+    overflow-y: auto;
+    padding: 0;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 20;
+}
+
+.product-compare__search-dropdown li button {
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    padding: var(--spacing-xsmall) var(--spacing-small);
+}
+
+.product-compare__search-dropdown li button:hover {
+    cursor: pointer;
+    background: var(--color-neutral-100);
+}
+
+.product-compare table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.product-compare thead th {
+    position: relative;
+    padding: var(--spacing-small);
+    text-align: center;
+    vertical-align: top;
+    border-bottom: var(--shape-border-width-2) solid var(--color-neutral-300);
+    min-width: 160px;
+}
+
+.product-compare__remove {
+    position: absolute;
+    top: var(--spacing-xxsmall);
+    right: var(--spacing-xxsmall);
+}
+
+.product-compare thead a img {
+    display: block;
+    width: 100%;
+    max-width: 160px;
+    margin: 0 auto;
+    aspect-ratio: 1;
+    object-fit: contain;
+}
+
+.product-compare thead p {
+    margin: var(--spacing-xxsmall) 0;
+}
+
+.product-compare tbody th,
+.product-compare tbody td {
+    padding: var(--spacing-xsmall) var(--spacing-small);
+    border-bottom: var(--shape-border-width-1) solid var(--color-neutral-200);
+    vertical-align: middle;
+}
+
+.product-compare tbody th {
+    text-align: left;
+    font: var(--type-body-2-strong-font);
+    letter-spacing: var(--type-body-2-strong-letter-spacing);
+    color: var(--color-neutral-700);
+    white-space: nowrap;
+}
+
+.product-compare tbody td {
+    text-align: center;
+    border-left: var(--shape-border-width-1) solid var(--color-neutral-300);
+}
+
+.product-compare tbody tr:nth-child(even) {
+    background: var(--color-neutral-100);
+}
+
+.product-compare thead th + th {
+    border-left: var(--shape-border-width-1) solid var(--color-neutral-300);
+}
+
+.product-compare__price {
+    display: flex;
+    gap: var(--spacing-xxsmall);
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.product-compare__price .special-price-crossed {
+    text-decoration: line-through;
+    color: var(--color-neutral-500);
+}
+
+/* Empty corner cell: narrower than product columns */
+.product-compare thead th:first-child {
+    min-width: 120px;
+}
+
+@media (min-width: 900px) {
+    .product-compare thead th {
+        min-width: 200px;
+    }
+
+    .product-compare thead th:first-child {
+        min-width: 160px;
+    }
+
+    .product-compare thead a img {
+        max-width: 200px;
+    }
+}

--- a/blocks/product-compare/product-compare.js
+++ b/blocks/product-compare/product-compare.js
@@ -1,0 +1,430 @@
+import {
+  Button, Image, Input, Icon, PriceRange, provider as UI,
+} from '@dropins/tools/components.js';
+import { debounce } from '@dropins/tools/lib.js';
+import { isAemAssetsEnabled, tryGenerateAemAssetsOptimizedUrl } from '@dropins/tools/lib/aem/assets.js';
+import { h } from '@dropins/tools/preact.js';
+import { search } from '@dropins/storefront-product-discovery/api.js';
+import { getProductLink } from '../../scripts/commerce.js';
+import '../../scripts/initializers/search.js';
+
+const IMAGE_SIZE = { width: 400, height: 400 };
+
+const MAX_PRODUCTS = 3;
+const SEARCH_SCOPE = 'product-compare';
+
+/**
+ * Returns { currency, regular, final } where `final` is non-null only when on sale.
+ * Mirrors the dropin's SimpleProductPrice / ComplexProductPrice rendering logic.
+ */
+function buildPriceProps(product) {
+  const { price, priceRange } = product;
+
+  if (priceRange?.minimum) {
+    const currency = priceRange.minimum.regular?.amount?.currency ?? 'USD';
+    const minFinal = priceRange.minimum.final?.amount?.value;
+    const minRegular = priceRange.minimum.regular?.amount?.value;
+    const maxFinal = priceRange.maximum?.final?.amount?.value;
+    const maxRegular = priceRange.maximum?.regular?.amount?.value;
+    const hasSpecial = minFinal < minRegular || maxFinal < maxRegular;
+    return {
+      currency,
+      regular: { display: 'from to', minimumAmount: minRegular, maximumAmount: maxRegular },
+      final: hasSpecial
+        ? { display: 'from to', minimumAmount: minFinal, maximumAmount: maxFinal }
+        : null,
+    };
+  }
+
+  const currency = price?.regular?.amount?.currency ?? 'USD';
+  const regularVal = price?.regular?.amount?.value;
+  const finalVal = price?.final?.amount?.value;
+  const hasSpecial = finalVal !== undefined && regularVal !== undefined && finalVal < regularVal;
+  return {
+    currency,
+    regular: { amount: regularVal },
+    final: hasSpecial ? { amount: finalVal } : null,
+  };
+}
+
+async function fetchProductsBySkus(skus) {
+  const result = await search(
+    { filter: [{ attribute: 'sku', in: skus }], pageSize: skus.length },
+    { scope: `${SEARCH_SCOPE}-lookup` },
+  );
+  return result?.items ?? [];
+}
+
+function getCurrentSkus(block) {
+  return Array.from(block.querySelectorAll('thead th[data-sku]'))
+    .map((th) => th.dataset.sku);
+}
+
+/**
+ * Builds a product column <th> with dropin-rendered remove button and price.
+ * @param {object} p Product item from the search API
+ * @param {Function} onRemove Called when the remove button is clicked
+ */
+async function buildProductTh(p, onRemove) {
+  const link = getProductLink(p.urlKey, p.sku);
+  const image = p.images?.[0];
+  const { currency, regular, final } = buildPriceProps(p);
+
+  // <th> is only valid inside a table; wrap so the browser parses it correctly.
+  const frag = document.createRange().createContextualFragment(`
+    <table><thead><tr>
+      <th>
+        <div class="product-compare__remove"></div>
+        <a></a>
+        <p><a></a></p>
+        <div class="product-compare__price"></div>
+      </th>
+    </tr></thead></table>
+  `);
+
+  const th = frag.querySelector('th');
+  th.dataset.sku = p.sku;
+
+  const removeBtnWrap = th.querySelector('.product-compare__remove');
+  const imgLink = th.querySelector('a');
+  const nameLink = th.querySelector('p > a');
+  const priceWrap = th.querySelector('.product-compare__price');
+
+  imgLink.href = link;
+  nameLink.href = link;
+  nameLink.textContent = p.name;
+
+  if (image?.url) {
+    const imgSrc = image.url.replace(/^https?:/, '');
+    const useAem = isAemAssetsEnabled();
+    const src = useAem ? tryGenerateAemAssetsOptimizedUrl(imgSrc, p.sku, {}) : imgSrc;
+    const params = useAem
+      ? {
+        ...IMAGE_SIZE, crop: undefined, fit: undefined, auto: undefined,
+      }
+      : { ...IMAGE_SIZE };
+    await UI.render(Image, {
+      src,
+      alt: image.label || p.name,
+      loading: 'lazy',
+      params,
+    })(imgLink);
+  }
+
+  await UI.render(Button, {
+    icon: h(Icon, { source: 'Close' }),
+    variant: 'tertiary',
+    'aria-label': `Remove ${p.name}`,
+    onClick: onRemove,
+  })(removeBtnWrap);
+
+  if (regular.amount || regular.minimumAmount) {
+    if (!final) {
+      await UI.render(PriceRange, { ...regular, currency })(priceWrap);
+    } else {
+      const finalEl = document.createElement('span');
+      finalEl.className = 'regular-price-normal';
+      await UI.render(PriceRange, { ...final, currency })(finalEl);
+
+      const regularEl = document.createElement('span');
+      regularEl.className = 'special-price-crossed';
+      await UI.render(PriceRange, { ...regular, currency })(regularEl);
+
+      priceWrap.append(finalEl, regularEl);
+    }
+  }
+
+  return th;
+}
+
+/** Removes a product column by resolving its index so thead and tbody stay in sync. */
+function removeProductColumn(block, sku) {
+  const th = block.querySelector(`thead th[data-sku="${sku}"]`);
+  if (!th) return;
+
+  const colIndex = Array.from(th.closest('tr').children).indexOf(th);
+  th.remove();
+
+  const tbody = block.querySelector('tbody');
+  if (tbody) {
+    Array.from(tbody.rows).forEach((row) => {
+      row.cells[colIndex]?.remove();
+    });
+  }
+
+  const remaining = getCurrentSkus(block);
+  const url = new URL(window.location.href);
+  if (remaining.length) {
+    url.searchParams.set('compare', remaining.join(','));
+  } else {
+    url.searchParams.delete('compare');
+    block.querySelector('table')?.remove();
+  }
+  window.history.replaceState({}, '', url);
+
+  const searchWrap = block.querySelector('.product-compare__search');
+  if (searchWrap) searchWrap.hidden = false;
+}
+
+/**
+ * Adds a product column without re-fetching — item data comes directly from the search result.
+ * Falls back to a full re-render when no table exists yet.
+ */
+async function addProductColumn(block, item) {
+  const currentSkus = getCurrentSkus(block);
+  if (currentSkus.includes(item.sku) || currentSkus.length >= MAX_PRODUCTS) return;
+
+  const newSkus = [...currentSkus, item.sku];
+  const url = new URL(window.location.href);
+  url.searchParams.set('compare', newSkus.join(','));
+  window.history.replaceState({}, '', url);
+
+  // No table yet — initial add, full render (no visible content to flicker)
+  if (!block.querySelector('table')) {
+    await renderBlock(block, newSkus);
+    return;
+  }
+
+  // Append new header column using the item already in hand — no second fetch
+  const th = await buildProductTh(item, () => removeProductColumn(block, item.sku));
+  block.querySelector('thead tr').append(th);
+
+  // Update tbody: add td to existing rows, create new rows for new attributes
+  const tbody = block.querySelector('tbody');
+  const attrRows = new Map();
+  if (tbody) {
+    Array.from(tbody.rows).forEach((row) => {
+      const key = row.querySelector('th[data-attr]')?.dataset.attr;
+      if (key) attrRows.set(key, row);
+    });
+  }
+
+  (item.attributes ?? []).forEach(({ name, label, value }) => {
+    if (!value) return;
+    if (attrRows.has(name)) {
+      const td = document.createElement('td');
+      td.textContent = value;
+      attrRows.get(name).append(td);
+    } else {
+      const row = document.createElement('tr');
+      const attrTh = document.createElement('th');
+      attrTh.scope = 'row';
+      attrTh.dataset.attr = name;
+      attrTh.textContent = label;
+      row.append(attrTh);
+      currentSkus.forEach(() => {
+        const td = document.createElement('td');
+        td.textContent = '--';
+        row.append(td);
+      });
+      const td = document.createElement('td');
+      td.textContent = value;
+      row.append(td);
+      tbody?.append(row);
+      attrRows.set(name, row);
+    }
+  });
+
+  // Pad empty td for existing rows the new product lacks
+  attrRows.forEach((row, name) => {
+    if (!(item.attributes ?? []).some((a) => a.name === name)) {
+      const td = document.createElement('td');
+      td.textContent = '--';
+      row.append(td);
+    }
+  });
+
+  if (newSkus.length >= MAX_PRODUCTS) {
+    const searchWrap = block.querySelector('.product-compare__search');
+    if (searchWrap) searchWrap.hidden = true;
+  }
+}
+
+/**
+ * Renders the add-product search form and results dropdown.
+ * @param {HTMLElement} container
+ * @param {Function} getSkus Live callback — called on each selection to read the current SKU list
+ * @param {Function} onAdd Called with the selected product item
+ */
+async function renderSearch(container, getSkus, onAdd) {
+  const itemMap = new Map();
+
+  const dropdown = document.createElement('ul');
+  dropdown.className = 'product-compare__search-dropdown';
+  dropdown.hidden = true;
+
+  const updateDropdown = (items) => {
+    dropdown.innerHTML = '';
+    itemMap.clear();
+    if (!items?.length) { dropdown.hidden = true; return; }
+    items.forEach((item) => {
+      itemMap.set(item.sku, item);
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = item.name;
+      btn.dataset.sku = item.sku;
+      li.append(btn);
+      dropdown.append(li);
+    });
+    dropdown.hidden = false;
+  };
+
+  let inputWrap;
+  let resetBtnWrap;
+
+  const clearSearch = () => {
+    updateDropdown([]);
+    if (resetBtnWrap) resetBtnWrap.hidden = true;
+    const inputEl = inputWrap?.querySelector('input');
+    if (inputEl) {
+      inputEl.value = '';
+      inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  };
+
+  dropdown.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-sku]');
+    if (!btn) return;
+    const item = itemMap.get(btn.dataset.sku);
+    if (!item || getSkus().includes(item.sku)) return;
+    clearSearch();
+    onAdd(item);
+  });
+
+  const triggerSearch = debounce(async (phrase) => {
+    const result = await search({ phrase, pageSize: 5 }, { scope: SEARCH_SCOPE });
+    updateDropdown(result?.items ?? []);
+  }, 300);
+
+  const fieldWrap = document.createElement('div');
+  fieldWrap.className = 'product-compare__search-field';
+
+  inputWrap = document.createElement('div');
+
+  resetBtnWrap = document.createElement('div');
+  resetBtnWrap.className = 'product-compare__search-reset';
+  resetBtnWrap.hidden = true;
+
+  await UI.render(Input, {
+    name: 'product-compare-search',
+    placeholder: 'Search to add a product...',
+    'aria-label': 'Search products to compare',
+    onValue: (phrase) => {
+      resetBtnWrap.hidden = !phrase;
+      if (!phrase || phrase.length < 2) { updateDropdown([]); return; }
+      triggerSearch(phrase);
+    },
+  })(inputWrap);
+
+  await UI.render(Button, {
+    icon: h(Icon, { source: 'Close' }),
+    variant: 'tertiary',
+    'aria-label': 'Clear search',
+    onClick: clearSearch,
+  })(resetBtnWrap);
+
+  container.addEventListener('focusout', (e) => {
+    if (!container.contains(e.relatedTarget)) {
+      setTimeout(() => { dropdown.hidden = true; }, 200);
+    }
+  });
+
+  fieldWrap.append(inputWrap, resetBtnWrap);
+  container.append(fieldWrap, dropdown);
+}
+
+/**
+ * Clears and fully re-renders the block: search form then comparison table.
+ * @param {HTMLElement} block
+ * @param {string[]} skus
+ */
+async function renderBlock(block, skus) {
+  block.innerHTML = '';
+
+  const searchWrap = document.createElement('div');
+  searchWrap.className = 'product-compare__search';
+  searchWrap.hidden = skus.length >= MAX_PRODUCTS;
+  block.append(searchWrap);
+  renderSearch(searchWrap, () => getCurrentSkus(block), (item) => addProductColumn(block, item));
+
+  if (!skus.length) return;
+
+  let products;
+  try {
+    products = await fetchProductsBySkus(skus);
+  } catch (err) {
+    console.error('[product-compare]', err);
+    const msg = document.createElement('p');
+    msg.textContent = 'Unable to load product comparison.';
+    block.append(msg);
+    return;
+  }
+
+  if (!products.length) {
+    const msg = document.createElement('p');
+    msg.textContent = 'No matching products found.';
+    block.append(msg);
+    return;
+  }
+
+  const attrMap = new Map();
+  products.forEach((p) => {
+    (p.attributes ?? []).forEach(({ name, label }) => {
+      if (!attrMap.has(name)) attrMap.set(name, label);
+    });
+  });
+
+  const table = document.createElement('table');
+  const headerRow = document.createElement('tr');
+  headerRow.append(document.createElement('th'));
+
+  const productCols = await Promise.all(
+    products.map((p) => buildProductTh(p, () => removeProductColumn(block, p.sku))),
+  );
+  productCols.forEach((th) => headerRow.append(th));
+
+  const thead = document.createElement('thead');
+  thead.append(headerRow);
+  table.append(thead);
+
+  const tbody = document.createElement('tbody');
+  attrMap.forEach((label, name) => {
+    const values = products.map(
+      (p) => p.attributes?.find((a) => a.name === name)?.value ?? '',
+    );
+    if (values.every((v) => !v)) return;
+
+    const row = document.createElement('tr');
+    const th = document.createElement('th');
+    th.scope = 'row';
+    th.dataset.attr = name;
+    th.textContent = label;
+    row.append(th);
+
+    values.forEach((val) => {
+      const td = document.createElement('td');
+      td.textContent = val || '--';
+      row.append(td);
+    });
+
+    tbody.append(row);
+  });
+
+  table.append(tbody);
+  block.append(table);
+}
+
+/**
+ * Loads and decorates the block. Reads initial SKUs from the ?compare= URL parameter.
+ * @param {Element} block
+ */
+export default async function decorate(block) {
+  const skus = (new URLSearchParams(window.location.search).get('compare') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, MAX_PRODUCTS);
+
+  await renderBlock(block, skus);
+}

--- a/blocks/product-compare/product-compare.js
+++ b/blocks/product-compare/product-compare.js
@@ -6,6 +6,7 @@ import { isAemAssetsEnabled, tryGenerateAemAssetsOptimizedUrl } from '@dropins/t
 import { h } from '@dropins/tools/preact.js';
 import { search } from '@dropins/storefront-product-discovery/api.js';
 import { getProductLink } from '../../scripts/commerce.js';
+import { readBlockConfig } from '../../scripts/aem.js';
 import '../../scripts/initializers/search.js';
 
 const IMAGE_SIZE = { width: 400, height: 400 };
@@ -47,9 +48,9 @@ function buildPriceProps(product) {
   };
 }
 
-async function fetchProductsBySkus(skus) {
+async function fetchProductsBySkus(skus, searchFilters = []) {
   const result = await search(
-    { filter: [{ attribute: 'sku', in: skus }], pageSize: skus.length },
+    { filter: [{ attribute: 'sku', in: skus }, ...searchFilters], pageSize: skus.length },
     { scope: `${SEARCH_SCOPE}-lookup` },
   );
   return result?.items ?? [];
@@ -169,8 +170,10 @@ function removeProductColumn(block, sku) {
 /**
  * Adds a product column without re-fetching — item data comes directly from the search result.
  * Falls back to a full re-render when no table exists yet.
+ * @param {string[]|null} allowedAttrs Authored attribute allowlist, or null to show all.
+ * @param {object[]} searchFilters Parsed filter objects kept in sync with renderBlock.
  */
-async function addProductColumn(block, item) {
+async function addProductColumn(block, item, allowedAttrs = null, searchFilters = []) {
   const currentSkus = getCurrentSkus(block);
   if (currentSkus.includes(item.sku) || currentSkus.length >= MAX_PRODUCTS) return;
 
@@ -181,7 +184,7 @@ async function addProductColumn(block, item) {
 
   // No table yet — initial add, full render (no visible content to flicker)
   if (!block.querySelector('table')) {
-    await renderBlock(block, newSkus);
+    await renderBlock(block, newSkus, allowedAttrs, searchFilters);
     return;
   }
 
@@ -199,7 +202,10 @@ async function addProductColumn(block, item) {
     });
   }
 
-  (item.attributes ?? []).forEach(({ name, label, value }) => {
+  const attrs = (item.attributes ?? [])
+    .filter(({ name }) => !allowedAttrs || allowedAttrs.includes(name));
+
+  attrs.forEach(({ name, label, value }) => {
     if (!value) return;
     if (attrRows.has(name)) {
       const td = document.createElement('td');
@@ -227,7 +233,7 @@ async function addProductColumn(block, item) {
 
   // Pad empty td for existing rows the new product lacks
   attrRows.forEach((row, name) => {
-    if (!(item.attributes ?? []).some((a) => a.name === name)) {
+    if (!attrs.some((a) => a.name === name)) {
       const td = document.createElement('td');
       td.textContent = '--';
       row.append(td);
@@ -245,8 +251,9 @@ async function addProductColumn(block, item) {
  * @param {HTMLElement} container
  * @param {Function} getSkus Live callback — called on each selection to read the current SKU list
  * @param {Function} onAdd Called with the selected product item
+ * @param {object[]} searchFilters Parsed filter objects forwarded to every search call
  */
-async function renderSearch(container, getSkus, onAdd) {
+async function renderSearch(container, getSkus, onAdd, searchFilters = []) {
   const itemMap = new Map();
 
   const dropdown = document.createElement('ul');
@@ -293,7 +300,14 @@ async function renderSearch(container, getSkus, onAdd) {
   });
 
   const triggerSearch = debounce(async (phrase) => {
-    const result = await search({ phrase, pageSize: 5 }, { scope: SEARCH_SCOPE });
+    const result = await search(
+      {
+        phrase,
+        pageSize: 5,
+        ...(searchFilters.length ? { filter: searchFilters } : {}),
+      },
+      { scope: SEARCH_SCOPE },
+    );
     updateDropdown(result?.items ?? []);
   }, 300);
 
@@ -338,21 +352,28 @@ async function renderSearch(container, getSkus, onAdd) {
  * Clears and fully re-renders the block: search form then comparison table.
  * @param {HTMLElement} block
  * @param {string[]} skus
+ * @param {string[]|null} allowedAttrs Authored attribute allowlist, or null to show all.
+ * @param {object[]} searchFilters Parsed filter objects applied to every search call.
  */
-async function renderBlock(block, skus) {
+async function renderBlock(block, skus, allowedAttrs = null, searchFilters = []) {
   block.innerHTML = '';
 
   const searchWrap = document.createElement('div');
   searchWrap.className = 'product-compare__search';
   searchWrap.hidden = skus.length >= MAX_PRODUCTS;
   block.append(searchWrap);
-  renderSearch(searchWrap, () => getCurrentSkus(block), (item) => addProductColumn(block, item));
+  renderSearch(
+    searchWrap,
+    () => getCurrentSkus(block),
+    (item) => addProductColumn(block, item, allowedAttrs, searchFilters),
+    searchFilters,
+  );
 
   if (!skus.length) return;
 
   let products;
   try {
-    products = await fetchProductsBySkus(skus);
+    products = await fetchProductsBySkus(skus, searchFilters);
   } catch (err) {
     console.error('[product-compare]', err);
     const msg = document.createElement('p');
@@ -369,11 +390,22 @@ async function renderBlock(block, skus) {
   }
 
   const attrMap = new Map();
-  products.forEach((p) => {
-    (p.attributes ?? []).forEach(({ name, label }) => {
-      if (!attrMap.has(name)) attrMap.set(name, label);
+  if (allowedAttrs) {
+    // Preserve authored order; look up the label from the first product that carries the attribute.
+    allowedAttrs.forEach((name) => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const p of products) {
+        const attr = p.attributes?.find((a) => a.name === name);
+        if (attr) { attrMap.set(name, attr.label); break; }
+      }
     });
-  });
+  } else {
+    products.forEach((p) => {
+      (p.attributes ?? []).forEach(({ name, label }) => {
+        if (!attrMap.has(name)) attrMap.set(name, label);
+      });
+    });
+  }
 
   const table = document.createElement('table');
   const headerRow = document.createElement('tr');
@@ -417,14 +449,29 @@ async function renderBlock(block, skus) {
 
 /**
  * Loads and decorates the block. Reads initial SKUs from the ?compare= URL parameter.
+ * Supports optional `attributes` and `filters` config rows for attribute display and search scoping
  * @param {Element} block
  */
 export default async function decorate(block) {
+  const config = readBlockConfig(block);
+
+  const allowedAttrs = config.attributes
+    ? config.attributes.split(',').map((s) => s.trim()).filter(Boolean)
+    : null;
+
+  // Each entry is "attribute:value"; maps to { attribute, in } filter objects.
+  const searchFilters = config.filter
+    ? config.filter.split(',').flatMap((pair) => {
+      const [attribute, value] = pair.split(':').map((s) => s.trim());
+      return attribute && value ? [{ attribute, in: [value] }] : [];
+    })
+    : [];
+
   const skus = (new URLSearchParams(window.location.search).get('compare') ?? '')
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean)
     .slice(0, MAX_PRODUCTS);
 
-  await renderBlock(block, skus);
+  await renderBlock(block, skus, allowedAttrs, searchFilters);
 }

--- a/blocks/product-compare/product-compare.js
+++ b/blocks/product-compare/product-compare.js
@@ -250,7 +250,7 @@ async function addProductColumn(block, item, allowedAttrs = null, searchFilters 
       }
     });
 
-    if (newSkus.length >= MAX_PRODUCTS) {
+    if (liveSkus.length + 1 >= MAX_PRODUCTS) {
       const searchWrap = block.querySelector('.product-compare__search');
       if (searchWrap) searchWrap.hidden = true;
     }
@@ -476,7 +476,10 @@ export default async function decorate(block) {
   // Each entry is "attribute:value"; maps to { attribute, in } filter objects.
   const searchFilters = config.filter
     ? config.filter.split(',').flatMap((pair) => {
-      const [attribute, value] = pair.split(':').map((s) => s.trim());
+      const colonIdx = pair.indexOf(':');
+      if (colonIdx === -1) return [];
+      const attribute = pair.slice(0, colonIdx).trim();
+      const value = pair.slice(colonIdx + 1).trim();
       return attribute && value ? [{ attribute, in: [value] }] : [];
     })
     : [];

--- a/blocks/product-compare/product-compare.js
+++ b/blocks/product-compare/product-compare.js
@@ -12,6 +12,7 @@ import '../../scripts/initializers/search.js';
 const IMAGE_SIZE = { width: 400, height: 400 };
 
 const MAX_PRODUCTS = 3;
+
 const SEARCH_SCOPE = 'product-compare';
 
 /**
@@ -27,7 +28,8 @@ function buildPriceProps(product) {
     const minRegular = priceRange.minimum.regular?.amount?.value;
     const maxFinal = priceRange.maximum?.final?.amount?.value;
     const maxRegular = priceRange.maximum?.regular?.amount?.value;
-    const hasSpecial = minFinal < minRegular || maxFinal < maxRegular;
+    const hasSpecial = (minFinal !== undefined && minFinal < minRegular)
+      || (maxFinal !== undefined && maxFinal < maxRegular);
     return {
       currency,
       regular: { display: 'from to', minimumAmount: minRegular, maximumAmount: maxRegular },
@@ -119,7 +121,7 @@ async function buildProductTh(p, onRemove) {
     onClick: onRemove,
   })(removeBtnWrap);
 
-  if (regular.amount || regular.minimumAmount) {
+  if (regular.amount !== undefined || regular.minimumAmount !== undefined) {
     if (!final) {
       await UI.render(PriceRange, { ...regular, currency })(priceWrap);
     } else {
@@ -174,75 +176,87 @@ function removeProductColumn(block, sku) {
  * @param {object[]} searchFilters Parsed filter objects kept in sync with renderBlock.
  */
 async function addProductColumn(block, item, allowedAttrs = null, searchFilters = []) {
+  // eslint-disable-next-line no-param-reassign
+  if (block.addPending) return;
   const currentSkus = getCurrentSkus(block);
   if (currentSkus.includes(item.sku) || currentSkus.length >= MAX_PRODUCTS) return;
 
-  const newSkus = [...currentSkus, item.sku];
-  const url = new URL(window.location.href);
-  url.searchParams.set('compare', newSkus.join(','));
-  window.history.replaceState({}, '', url);
+  // eslint-disable-next-line no-param-reassign
+  block.addPending = true;
+  try {
+    const newSkus = [...currentSkus, item.sku];
+    const url = new URL(window.location.href);
+    url.searchParams.set('compare', newSkus.join(','));
+    window.history.replaceState({}, '', url);
 
-  // No table yet — initial add, full render (no visible content to flicker)
-  if (!block.querySelector('table')) {
-    await renderBlock(block, newSkus, allowedAttrs, searchFilters);
-    return;
-  }
+    // No table yet — initial add, full render (no visible content to flicker)
+    if (!block.querySelector('table')) {
+      await renderBlock(block, newSkus, allowedAttrs, searchFilters);
+      return;
+    }
 
-  // Append new header column using the item already in hand — no second fetch
-  const th = await buildProductTh(item, () => removeProductColumn(block, item.sku));
-  block.querySelector('thead tr').append(th);
+    // Append new header column using the item already in hand — no second fetch
+    const th = await buildProductTh(item, () => removeProductColumn(block, item.sku));
 
-  // Update tbody: add td to existing rows, create new rows for new attributes
-  const tbody = block.querySelector('tbody');
-  const attrRows = new Map();
-  if (tbody) {
-    Array.from(tbody.rows).forEach((row) => {
-      const key = row.querySelector('th[data-attr]')?.dataset.attr;
-      if (key) attrRows.set(key, row);
+    // Re-read live SKUs after the async gap — a remove may have fired during buildProductTh.
+    const liveSkus = getCurrentSkus(block);
+    block.querySelector('thead tr').append(th);
+
+    // Update tbody: add td to existing rows, create new rows for new attributes
+    const tbody = block.querySelector('tbody');
+    const attrRows = new Map();
+    if (tbody) {
+      Array.from(tbody.rows).forEach((row) => {
+        const key = row.querySelector('th[data-attr]')?.dataset.attr;
+        if (key) attrRows.set(key, row);
+      });
+    }
+
+    const attrs = (item.attributes ?? [])
+      .filter(({ name }) => !allowedAttrs || allowedAttrs.includes(name));
+
+    attrs.forEach(({ name, label, value }) => {
+      if (!value) return;
+      if (attrRows.has(name)) {
+        const td = document.createElement('td');
+        td.textContent = value;
+        attrRows.get(name).append(td);
+      } else {
+        const row = document.createElement('tr');
+        const attrTh = document.createElement('th');
+        attrTh.scope = 'row';
+        attrTh.dataset.attr = name;
+        attrTh.textContent = label;
+        row.append(attrTh);
+        liveSkus.forEach(() => {
+          const td = document.createElement('td');
+          td.textContent = '--';
+          row.append(td);
+        });
+        const td = document.createElement('td');
+        td.textContent = value;
+        row.append(td);
+        tbody?.append(row);
+        attrRows.set(name, row);
+      }
     });
-  }
 
-  const attrs = (item.attributes ?? [])
-    .filter(({ name }) => !allowedAttrs || allowedAttrs.includes(name));
-
-  attrs.forEach(({ name, label, value }) => {
-    if (!value) return;
-    if (attrRows.has(name)) {
-      const td = document.createElement('td');
-      td.textContent = value;
-      attrRows.get(name).append(td);
-    } else {
-      const row = document.createElement('tr');
-      const attrTh = document.createElement('th');
-      attrTh.scope = 'row';
-      attrTh.dataset.attr = name;
-      attrTh.textContent = label;
-      row.append(attrTh);
-      currentSkus.forEach(() => {
+    // Pad empty td for existing rows the new product lacks
+    attrRows.forEach((row, name) => {
+      if (!attrs.some((a) => a.name === name)) {
         const td = document.createElement('td');
         td.textContent = '--';
         row.append(td);
-      });
-      const td = document.createElement('td');
-      td.textContent = value;
-      row.append(td);
-      tbody?.append(row);
-      attrRows.set(name, row);
-    }
-  });
+      }
+    });
 
-  // Pad empty td for existing rows the new product lacks
-  attrRows.forEach((row, name) => {
-    if (!attrs.some((a) => a.name === name)) {
-      const td = document.createElement('td');
-      td.textContent = '--';
-      row.append(td);
+    if (newSkus.length >= MAX_PRODUCTS) {
+      const searchWrap = block.querySelector('.product-compare__search');
+      if (searchWrap) searchWrap.hidden = true;
     }
-  });
-
-  if (newSkus.length >= MAX_PRODUCTS) {
-    const searchWrap = block.querySelector('.product-compare__search');
-    if (searchWrap) searchWrap.hidden = true;
+  } finally {
+    // eslint-disable-next-line no-param-reassign
+    block.addPending = false;
   }
 }
 
@@ -362,7 +376,7 @@ async function renderBlock(block, skus, allowedAttrs = null, searchFilters = [])
   searchWrap.className = 'product-compare__search';
   searchWrap.hidden = skus.length >= MAX_PRODUCTS;
   block.append(searchWrap);
-  renderSearch(
+  await renderSearch(
     searchWrap,
     () => getCurrentSkus(block),
     (item) => addProductColumn(block, item, allowedAttrs, searchFilters),

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -137,9 +137,9 @@ export default async function decorate(block) {
     const wrap = document.createElement('div');
     wrap.className = 'product-discovery-product-actions__compare';
     UI.render(Button, {
-      'aria-label': `Compare ${productName}`,
-      children: labels.Global?.Compare ?? 'Compare',
-      variant: 'secondary',
+      icon: Icon({ source: 'Bulk' }),
+      'aria-label': `labels.Global?.Compare ?? 'Compare' ${productName}`,
+      variant: 'tertiary',
       onClick: () => events.emit('compare/products', {
         sku: product.sku,
         img: product.images?.[0]?.url ?? '',

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -132,6 +132,23 @@ export default async function decorate(block) {
     return button;
   };
 
+  const getCompareButton = (product) => {
+    const productName = product.name || product.sku;
+    const wrap = document.createElement('div');
+    wrap.className = 'product-discovery-product-actions__compare';
+    UI.render(Button, {
+      'aria-label': `Compare ${productName}`,
+      children: labels.Global?.Compare ?? 'Compare',
+      variant: 'secondary',
+      onClick: () => events.emit('compare/products', {
+        sku: product.sku,
+        img: product.images?.[0]?.url ?? '',
+        name: productName,
+      }),
+    })(wrap);
+    return wrap;
+  };
+
   await Promise.all([
     // Sort By
     provider.render(SortBy, {})($productSort),
@@ -188,6 +205,8 @@ export default async function decorate(block) {
           // Add to Cart Button
           const addToCartBtn = getAddToCartButton(ctx.product);
           addToCartBtn.className = 'product-discovery-product-actions__add-to-cart';
+          // Compare Button
+          const compareBtn = getCompareButton(ctx.product);
           // Wishlist Button
           const $wishlistToggle = document.createElement('div');
           $wishlistToggle.classList.add('product-discovery-product-actions__wishlist-toggle');
@@ -196,6 +215,7 @@ export default async function decorate(block) {
             variant: 'tertiary',
           })($wishlistToggle);
           actionsWrapper.appendChild(addToCartBtn);
+          actionsWrapper.appendChild(compareBtn);
           actionsWrapper.appendChild($wishlistToggle);
 
           // Conditionally load and render Requisition List Button

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -138,7 +138,7 @@ export default async function decorate(block) {
     wrap.className = 'product-discovery-product-actions__compare';
     UI.render(Button, {
       icon: Icon({ source: 'Bulk' }),
-      'aria-label': `labels.Global?.Compare ?? 'Compare' ${productName}`,
+      'aria-label': `${labels.Global?.Compare ?? 'Compare'} ${productName}`,
       variant: 'tertiary',
       onClick: () => events.emit('compare/products', {
         sku: product.sku,


### PR DESCRIPTION
Closes / addresses ACCS-1357.

## What

Implements product comparison as a native EDS block (`blocks/product-compare`) rather than a new drop-in. The block reuses the existing `@dropins/storefront-product-discovery` search API for both keyword search and SKU lookup, the `PriceRange` component for price rendering (including sale and configurable range display), and the `Image` component for AEM Assets-aware image optimization — all without introducing any new dropin dependency or API contract.

The comparison state is encoded in the URL (`?compare=SKU1,SKU2,SKU3`), making comparison pages shareable and bookmark-able with no localStorage or server-side session needed.

Also adds a `product-compare-bar` block — a fixed bottom bar authors can place on any page. It listens to the `compare/products` event bus event and shows selected products with their images, a Remove button per card, a Compare link to the compare page, and a Clear All action. All interactive elements use dropin `Button`/`Icon`/`Image` components. The PLP `ProductActions` slot now includes a Compare button that emits this event.

## TODO

- [x] Product Comparison Block
- [x] Add Products from PLP

## Preview
- PLP: https://b2b-comparison--boilerplate-b2b-accs--adobe-commerce.aem.page/drafts/carlos/apparel
- Compare Page: https://b2b-comparison--boilerplate-b2b-accs--adobe-commerce.aem.page/drafts/carlos/product-compare?compare=ADB169%2CADB171

## Test URLs

- Before: https://b2b-integration--boilerplate-b2b-accs--adobe-commerce.aem.page/
- After (compare page): https://b2b-comparison--boilerplate-b2b-accs--adobe-commerce.aem.page/drafts/carlos/product-compare?compare=ADB169%2CADB171