### PR TITLE
USF-3138: announce mini cart update message to screen readers

### DIFF
--- a/blocks/commerce-mini-cart/commerce-mini-cart.js
+++ b/blocks/commerce-mini-cart/commerce-mini-cart.js
@@ -43,6 +43,8 @@ export default async function decorate(block) {
   // Create a container for the update message
   const updateMessage = document.createElement('div');
   updateMessage.className = 'commerce-mini-cart__update-message';
+  updateMessage.setAttribute('role', 'status');
+  updateMessage.setAttribute('aria-live', 'polite');
 
   // Create shadow wrapper
   const shadowWrapper = document.createElement('div');


### PR DESCRIPTION
## Summary
Add `role="status"` and `aria-live="polite"` to the mini cart update message div so screen readers announce status messages like "Product(s) updated in your cart" when products are added, updated, or removed.
## Ticket
[USF-3138](https://jira.corp.adobe.com/browse/USF-3138)
## Test URLs
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-3138--aem-boilerplate-commerce--hlxsites.aem.page/