### PR TITLE
PREX-2255: correctly handle currentSku

### DIFF
--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -365,12 +365,18 @@ export default async function decorate(block) {
   }
 
   function handleProductChanges({ productContext }) {
+    const incomingSku = productContext?.sku;
+    // Ignore productContext pushes for a different SKU once currentSku is set
+    // (e.g. the cart dropin's own add-to-cart tracking push for another product).
+    if (context.currentSku !== undefined && incomingSku !== context.currentSku) {
+      return;
+    }
     const pricing = productContext?.pricing;
     const price = pricing
       ? (pricing.specialPrice ?? pricing.regularPrice)
       : undefined;
     updateContext({
-      currentSku: productContext?.sku,
+      currentSku: incomingSku,
       currentProductPrice: price,
     });
   }


### PR DESCRIPTION
Fixed issue where product context updates would incorrectly currentSku in product recommendations request.

https://jira.corp.adobe.com/browse/PREX-2255

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://PREX-2255-p2--aem-boilerplate-commerce--hlxsites.aem.live/
