### PR TITLE
Show per-source stock and a variant availability overview on the PDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ helix-importer-ui
 scripts/__dropins__/**/*.map
 .env
 
+# Local storefront config (points at a specific tenant/endpoint — keep out of git)
+config.json
+
 # Ensure these files are tracked
 !CLAUDE.md
 !AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,6 @@ helix-importer-ui
 scripts/__dropins__/**/*.map
 .env
 
-# Local storefront config (points at a specific tenant/endpoint — keep out of git)
-config.json
-
 # Ensure these files are tracked
 !CLAUDE.md
 !AGENTS.md

--- a/blocks/product-details/availability-ui.js
+++ b/blocks/product-details/availability-ui.js
@@ -1,11 +1,9 @@
-// Availability UI from Elsie primitives. Fulfillment icons: Delivery for ship, Business
-// for in-store pickup. Rendered via UI.render, mounted once then updated with setProps.
+// Availability UI (badge + per-source list) from Elsie primitives, mounted once then setProps.
 import { Icon, provider as UI } from '@dropins/tools/components.js';
 import { h } from '@dropins/tools/preact.js';
 
 const num = (n) => new Intl.NumberFormat(document.documentElement.lang || 'en').format(n);
 
-// Aggregate stock line: the scarcity cue, so low stays a warning.
 const AGG_ICON = { 'in-stock': 'CheckWithCircle', low: 'Warning', 'out-of-stock': 'WarningWithCircle' };
 
 function StockIndicator({ state, text }) {
@@ -15,7 +13,6 @@ function StockIndicator({ state, text }) {
   ]);
 }
 
-// Per-source rows are fulfillment visibility, not a per-location warning: available vs not.
 function sourceRowState(source, labels) {
   const t = labels?.Custom?.SaleableQty ?? {};
   if (!source.is_in_stock) return { state: 'out-of-stock', text: t.OutOfStock ?? 'Out of stock' };
@@ -25,40 +22,29 @@ function sourceRowState(source, labels) {
   return { state: 'available', text: t.InStock ?? 'In stock' };
 }
 
-function SourceRow({ source, pickup, labels }) {
+function SourceRow({ source, labels }) {
   const { state, text } = sourceRowState(source, labels);
   const t = labels?.Custom?.SaleableQty ?? {};
-  // sourceAvailability returns only source_code, so resolve a label: a storefront
-  // placeholder keyed by code (localizable) first, then the pickup name, else the code.
-  const name = t.Source?.[source.source_code] ?? pickup?.name ?? source.source_code;
-  const raw = `${source.source_code} · available_qty=${source.available_qty ?? 'null'}`
-    + ` · is_in_stock=${source.is_in_stock} · pickup=${pickup ? 'yes' : 'no'}`;
-  const fulfillTitle = pickup ? (t.PickupLocation ?? 'Pickup location') : (t.ShipsFrom ?? 'Ships from');
-  return h('li', { className: 'pdp-avail__row', 'data-state': state, title: raw }, [
+  // sourceAvailability returns only source_code, so label it from a placeholder, else the code.
+  const name = t.Source?.[source.source_code] ?? source.source_code;
+  return h('li', { className: 'pdp-avail__row', 'data-state': state }, [
     h(Icon, {
-      source: pickup ? 'Business' : 'Delivery', size: '16', className: 'pdp-avail__fulfill', title: fulfillTitle,
+      source: 'Delivery', size: '16', className: 'pdp-avail__fulfill', 'aria-hidden': 'true',
     }),
     h('span', { className: 'pdp-avail__name' }, name),
     h('span', { className: 'pdp-avail__qty' }, text),
   ]);
 }
 
-function SourceList({ sources, pickupByCode, labels }) {
+function SourceList({ sources, labels }) {
   const t = labels?.Custom?.SaleableQty ?? {};
   return h('div', { className: 'pdp-avail' }, [
     h('p', { className: 'pdp-avail__title' }, t.ByLocation ?? 'Availability by location'),
-    h('ul', { className: 'pdp-avail__list' }, sources.map((s) => h(SourceRow, {
-      key: s.source_code,
-      source: s,
-      pickup: pickupByCode.get(s.source_code),
-      labels,
-    }))),
+    h('ul', { className: 'pdp-avail__list' }, sources.map((s) => h(SourceRow, { key: s.source_code, source: s, labels }))),
   ]);
 }
 
-// Mount once per element, then re-render via setProps. The pending render is stored
-// synchronously so two rapid calls share one mount; a failed mount is cleared to retry.
-// isCurrent guards setProps so a superseded render never overwrites fresher content.
+// Mount once per element, then re-render via setProps. isCurrent skips a superseded render.
 const mounted = new WeakMap();
 async function mount($el, Component, props, isCurrent) {
   const existing = mounted.get($el);
@@ -85,7 +71,7 @@ async function mount($el, Component, props, isCurrent) {
   }
 }
 
-// Renders the stock line, or hides it when model is null. Skips the reveal if superseded.
+// Render the stock line, or hide it when model is null.
 export async function renderStockIndicator($el, model, isCurrent = () => true) {
   if (!$el) return;
   if (!model) {
@@ -100,14 +86,12 @@ export async function renderStockIndicator($el, model, isCurrent = () => true) {
       $el.hidden = false;
     }
   } catch (error) {
-    console.debug('availability-ui: stock indicator render failed', error);
+    console.debug('availability: stock indicator render failed', error);
   }
 }
 
-// Renders the per-source list, or hides it when there are no sources. Skips if superseded.
-export async function renderSourceList($el, {
-  sources, pickupByCode, labels, isCurrent = () => true,
-}) {
+// Render the per-source list, or hide it when empty.
+export async function renderSourceList($el, { sources, labels, isCurrent = () => true }) {
   if (!$el) return;
   if (!sources?.length) {
     $el.removeAttribute('data-loading');
@@ -115,12 +99,12 @@ export async function renderSourceList($el, {
     return;
   }
   try {
-    await mount($el, SourceList, { sources, pickupByCode, labels }, isCurrent);
+    await mount($el, SourceList, { sources, labels }, isCurrent);
     if (isCurrent()) {
       $el.removeAttribute('data-loading');
       $el.hidden = false;
     }
   } catch (error) {
-    console.debug('availability-ui: source list render failed', error);
+    console.debug('availability: source list render failed', error);
   }
 }

--- a/blocks/product-details/availability-ui.js
+++ b/blocks/product-details/availability-ui.js
@@ -1,0 +1,126 @@
+// Availability UI from Elsie primitives. Fulfillment icons: Delivery for ship, Business
+// for in-store pickup. Rendered via UI.render, mounted once then updated with setProps.
+import { Icon, provider as UI } from '@dropins/tools/components.js';
+import { h } from '@dropins/tools/preact.js';
+
+const num = (n) => new Intl.NumberFormat(document.documentElement.lang || 'en').format(n);
+
+// Aggregate stock line: the scarcity cue, so low stays a warning.
+const AGG_ICON = { 'in-stock': 'CheckWithCircle', low: 'Warning', 'out-of-stock': 'WarningWithCircle' };
+
+function StockIndicator({ state, text }) {
+  return h('div', { className: `pdp-stock pdp-stock--${state}` }, [
+    h(Icon, { source: AGG_ICON[state], size: '16', 'aria-hidden': 'true' }),
+    h('span', { className: 'pdp-stock__text' }, text),
+  ]);
+}
+
+// Per-source rows are fulfillment visibility, not a per-location warning: available vs not.
+function sourceRowState(source, labels) {
+  const t = labels?.Custom?.SaleableQty ?? {};
+  if (!source.is_in_stock) return { state: 'out-of-stock', text: t.OutOfStock ?? 'Out of stock' };
+  if (source.available_qty != null) {
+    return { state: 'available', text: (t.Available ?? '{qty} available').replace('{qty}', num(Number(source.available_qty))) };
+  }
+  return { state: 'available', text: t.InStock ?? 'In stock' };
+}
+
+function SourceRow({ source, pickup, labels }) {
+  const { state, text } = sourceRowState(source, labels);
+  const t = labels?.Custom?.SaleableQty ?? {};
+  // sourceAvailability returns only source_code, so resolve a label: a storefront
+  // placeholder keyed by code (localizable) first, then the pickup name, else the code.
+  const name = t.Source?.[source.source_code] ?? pickup?.name ?? source.source_code;
+  const raw = `${source.source_code} · available_qty=${source.available_qty ?? 'null'}`
+    + ` · is_in_stock=${source.is_in_stock} · pickup=${pickup ? 'yes' : 'no'}`;
+  const fulfillTitle = pickup ? (t.PickupLocation ?? 'Pickup location') : (t.ShipsFrom ?? 'Ships from');
+  return h('li', { className: 'pdp-avail__row', 'data-state': state, title: raw }, [
+    h(Icon, {
+      source: pickup ? 'Business' : 'Delivery', size: '16', className: 'pdp-avail__fulfill', title: fulfillTitle,
+    }),
+    h('span', { className: 'pdp-avail__name' }, name),
+    h('span', { className: 'pdp-avail__qty' }, text),
+  ]);
+}
+
+function SourceList({ sources, pickupByCode, labels }) {
+  const t = labels?.Custom?.SaleableQty ?? {};
+  return h('div', { className: 'pdp-avail' }, [
+    h('p', { className: 'pdp-avail__title' }, t.ByLocation ?? 'Availability by location'),
+    h('ul', { className: 'pdp-avail__list' }, sources.map((s) => h(SourceRow, {
+      key: s.source_code,
+      source: s,
+      pickup: pickupByCode.get(s.source_code),
+      labels,
+    }))),
+  ]);
+}
+
+// Mount once per element, then re-render via setProps. The pending render is stored
+// synchronously so two rapid calls share one mount; a failed mount is cleared to retry.
+// isCurrent guards setProps so a superseded render never overwrites fresher content.
+const mounted = new WeakMap();
+async function mount($el, Component, props, isCurrent) {
+  const existing = mounted.get($el);
+  if (existing) {
+    let handle = null;
+    try {
+      handle = await existing;
+    } catch (error) {
+      mounted.delete($el);
+    }
+    if (handle) {
+      if (isCurrent()) handle.setProps(() => props);
+      return;
+    }
+  }
+  if (!isCurrent()) return;
+  const pending = UI.render(Component, props)($el);
+  mounted.set($el, pending);
+  try {
+    await pending;
+  } catch (error) {
+    mounted.delete($el);
+    throw error;
+  }
+}
+
+// Renders the stock line, or hides it when model is null. Skips the reveal if superseded.
+export async function renderStockIndicator($el, model, isCurrent = () => true) {
+  if (!$el) return;
+  if (!model) {
+    $el.removeAttribute('data-loading');
+    $el.hidden = true;
+    return;
+  }
+  try {
+    await mount($el, StockIndicator, model, isCurrent);
+    if (isCurrent()) {
+      $el.removeAttribute('data-loading');
+      $el.hidden = false;
+    }
+  } catch (error) {
+    console.debug('availability-ui: stock indicator render failed', error);
+  }
+}
+
+// Renders the per-source list, or hides it when there are no sources. Skips if superseded.
+export async function renderSourceList($el, {
+  sources, pickupByCode, labels, isCurrent = () => true,
+}) {
+  if (!$el) return;
+  if (!sources?.length) {
+    $el.removeAttribute('data-loading');
+    $el.hidden = true;
+    return;
+  }
+  try {
+    await mount($el, SourceList, { sources, pickupByCode, labels }, isCurrent);
+    if (isCurrent()) {
+      $el.removeAttribute('data-loading');
+      $el.hidden = false;
+    }
+  } catch (error) {
+    console.debug('availability-ui: source list render failed', error);
+  }
+}

--- a/blocks/product-details/availability-ui.js
+++ b/blocks/product-details/availability-ui.js
@@ -22,25 +22,34 @@ function sourceRowState(source, labels) {
   return { state: 'available', text: t.InStock ?? 'In stock' };
 }
 
-function SourceRow({ source, labels }) {
+function SourceRow({ source, pickup, labels }) {
   const { state, text } = sourceRowState(source, labels);
   const t = labels?.Custom?.SaleableQty ?? {};
-  // sourceAvailability returns only source_code, so label it from a placeholder, else the code.
-  const name = t.Source?.[source.source_code] ?? source.source_code;
+  // sourceAvailability has only source_code, so label it: placeholder, pickup name, else code.
+  const name = t.Source?.[source.source_code] ?? pickup?.name ?? source.source_code;
+  // The fulfillment icon carries ship-vs-pickup; its title makes that accessible.
+  const fulfillTitle = pickup
+    ? (t.PickupLocation ?? 'Pickup location')
+    : (t.ShipsFrom ?? 'Ships from');
   return h('li', { className: 'pdp-avail__row', 'data-state': state }, [
     h(Icon, {
-      source: 'Delivery', size: '16', className: 'pdp-avail__fulfill', 'aria-hidden': 'true',
+      source: pickup ? 'Business' : 'Delivery',
+      size: '16',
+      className: 'pdp-avail__fulfill',
+      title: fulfillTitle,
     }),
     h('span', { className: 'pdp-avail__name' }, name),
     h('span', { className: 'pdp-avail__qty' }, text),
   ]);
 }
 
-function SourceList({ sources, labels }) {
+function SourceList({ sources, pickupByCode, labels }) {
   const t = labels?.Custom?.SaleableQty ?? {};
   return h('div', { className: 'pdp-avail' }, [
     h('p', { className: 'pdp-avail__title' }, t.ByLocation ?? 'Availability by location'),
-    h('ul', { className: 'pdp-avail__list' }, sources.map((s) => h(SourceRow, { key: s.source_code, source: s, labels }))),
+    h('ul', { className: 'pdp-avail__list' }, sources.map((s) => h(SourceRow, {
+      key: s.source_code, source: s, pickup: pickupByCode?.get(s.source_code), labels,
+    }))),
   ]);
 }
 
@@ -91,7 +100,9 @@ export async function renderStockIndicator($el, model, isCurrent = () => true) {
 }
 
 // Render the per-source list, or hide it when empty.
-export async function renderSourceList($el, { sources, labels, isCurrent = () => true }) {
+export async function renderSourceList($el, {
+  sources, pickupByCode, labels, isCurrent = () => true,
+}) {
   if (!$el) return;
   if (!sources?.length) {
     $el.removeAttribute('data-loading');
@@ -99,7 +110,7 @@ export async function renderSourceList($el, { sources, labels, isCurrent = () =>
     return;
   }
   try {
-    await mount($el, SourceList, { sources, labels }, isCurrent);
+    await mount($el, SourceList, { sources, pickupByCode, labels }, isCurrent);
     if (isCurrent()) {
       $el.removeAttribute('data-loading');
       $el.hidden = false;

--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -127,3 +127,159 @@
   overflow: hidden;
   white-space: nowrap;
 }
+
+.product-details__saleable-qty {
+  margin: var(--spacing-xsmall) 0 var(--spacing-small);
+}
+
+/* Stock indicator: icon + text, no filled pill. */
+.pdp-stock {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xxsmall);
+  font: var(--type-details-caption-1-font);
+  letter-spacing: var(--type-details-caption-1-letter-spacing);
+}
+
+.pdp-stock--in-stock { color: var(--color-positive-800); }
+.pdp-stock--low { color: var(--color-warning-800); }
+.pdp-stock--out-of-stock { color: var(--color-alert-800); }
+
+/* Per-source list: an icon-led list, one row per fulfillment location. */
+.product-details__source-availability {
+  margin: 0 0 var(--spacing-medium);
+}
+
+.pdp-avail__title {
+  margin: 0 0 var(--spacing-xxsmall);
+  font: var(--type-details-caption-1-font);
+  letter-spacing: var(--type-details-caption-1-letter-spacing);
+  color: var(--color-neutral-700);
+}
+
+.pdp-avail__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pdp-avail__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+  padding: var(--spacing-xsmall) 0;
+  border-bottom: 1px solid var(--color-neutral-200);
+  font: var(--type-details-caption-1-font);
+  letter-spacing: var(--type-details-caption-1-letter-spacing);
+}
+
+.pdp-avail__row:last-child { border-bottom: 0; }
+
+.pdp-avail__fulfill { color: var(--color-neutral-600); }
+
+.pdp-avail__name {
+  flex: 1;
+  font-weight: 600;
+}
+
+.pdp-avail__qty {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xxsmall);
+  white-space: nowrap;
+}
+
+/* Informational, not a per-source warning: available reads positive, out-of-stock muted. */
+.pdp-avail__row[data-state="available"] .pdp-avail__qty { color: var(--color-positive-800); }
+.pdp-avail__row[data-state="out-of-stock"] .pdp-avail__qty { color: var(--color-neutral-500); }
+
+.product-details__matrix {
+  width: 100%;
+  margin: var(--spacing-small) 0 var(--spacing-medium);
+  border-collapse: collapse;
+  font: var(--type-details-caption-1-font);
+}
+
+.product-details__matrix th,
+.product-details__matrix td {
+  border: 1px solid var(--color-neutral-300);
+  padding: var(--spacing-xxsmall) var(--spacing-xsmall);
+  text-align: center;
+  vertical-align: top;
+}
+
+.product-details__matrix thead th,
+.product-details__matrix tbody th {
+  background: var(--color-neutral-100);
+  font-weight: 700;
+}
+
+.product-details__matrix__cell {
+  min-width: 84px;
+}
+
+.product-details__matrix__cell--none {
+  background: var(--color-neutral-200);
+  color: var(--color-neutral-500);
+}
+
+.product-details__matrix__price,
+.product-details__matrix__qty,
+.product-details__matrix__restock {
+  display: block;
+}
+
+.product-details__matrix__price {
+  font-weight: 700;
+}
+
+.product-details__matrix__cell[data-state="in-stock"] .product-details__matrix__qty {
+  color: var(--color-positive-800);
+}
+
+.product-details__matrix__cell[data-state="low"] .product-details__matrix__qty {
+  color: var(--color-warning-800);
+}
+
+.product-details__matrix__cell[data-state="out-of-stock"] .product-details__matrix__qty {
+  color: var(--color-alert-800);
+}
+
+/* The one API gap, drawn as a muted dashed placeholder so it stands out. */
+.product-details__matrix__restock {
+  margin-top: var(--spacing-xxsmall);
+  padding: 0 var(--spacing-xxsmall);
+  border: 1px dashed var(--color-neutral-400);
+  border-radius: 3px;
+  font: var(--type-details-caption-2-font);
+  color: var(--color-neutral-500);
+}
+
+/* Reserve space (invisibly) while availability loads, so the result lands without a shift. */
+.product-details__saleable-qty[data-loading] {
+  min-height: 1.25rem;
+}
+
+.product-details__source-availability[data-loading] {
+  min-height: 4.5rem;
+}
+
+/* Matrix trigger: a secondary action that opens the grid in a modal (no inline space). */
+.product-details__matrix-trigger {
+  margin: var(--spacing-small) 0 var(--spacing-medium);
+  padding: var(--spacing-xsmall) var(--spacing-medium);
+  border: 1px solid var(--color-neutral-500);
+  border-radius: var(--shape-border-radius-2, 4px);
+  background: transparent;
+  font: var(--type-details-caption-1-font);
+  cursor: pointer;
+}
+
+.product-details__matrix-trigger:hover {
+  background: var(--color-neutral-100);
+}
+
+.product-details__matrix-modal {
+  padding: var(--spacing-medium);
+  overflow-x: auto;
+}

--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -223,9 +223,37 @@
   color: var(--color-neutral-500);
 }
 
+/* Per-variant list (1 or 3+ axes) renders on the design-system Table. */
+.product-details__matrix__availability {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xxsmall);
+}
+
+.product-details__matrix__qty[data-state="in-stock"] { color: var(--color-positive-800); }
+.product-details__matrix__qty[data-state="low"] { color: var(--color-warning-800); }
+.product-details__matrix__qty[data-state="out-of-stock"] { color: var(--color-alert-800); }
+
+.product-details__matrix__sources {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.product-details__matrix__source {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-medium);
+  padding: var(--spacing-xxsmall) 0;
+}
+
+.product-details__matrix__source[data-state="out"] {
+  color: var(--color-neutral-500);
+}
+
 .product-details__matrix__price,
-.product-details__matrix__qty,
-.product-details__matrix__restock {
+.product-details__matrix__qty {
   display: block;
 }
 
@@ -243,16 +271,6 @@
 
 .product-details__matrix__cell[data-state="out-of-stock"] .product-details__matrix__qty {
   color: var(--color-alert-800);
-}
-
-/* The one API gap, drawn as a muted dashed placeholder so it stands out. */
-.product-details__matrix__restock {
-  margin-top: var(--spacing-xxsmall);
-  padding: 0 var(--spacing-xxsmall);
-  border: 1px dashed var(--color-neutral-400);
-  border-radius: 3px;
-  font: var(--type-details-caption-2-font);
-  color: var(--color-neutral-500);
 }
 
 /* Reserve space (invisibly) while availability loads, so the result lands without a shift. */
@@ -280,6 +298,7 @@
 }
 
 .product-details__matrix-modal {
-  padding: var(--spacing-medium);
+  /* Top padding clears the modal's 48px close button (position: absolute, top-right). */
+  padding: 48px var(--spacing-medium) var(--spacing-medium);
   overflow-x: auto;
 }

--- a/blocks/product-details/product-details.css
+++ b/blocks/product-details/product-details.css
@@ -128,11 +128,11 @@
   white-space: nowrap;
 }
 
+/* Aggregate stock line: icon + text, no filled pill. */
 .product-details__saleable-qty {
   margin: var(--spacing-xsmall) 0 var(--spacing-small);
 }
 
-/* Stock indicator: icon + text, no filled pill. */
 .pdp-stock {
   display: inline-flex;
   align-items: center;
@@ -145,7 +145,7 @@
 .pdp-stock--low { color: var(--color-warning-800); }
 .pdp-stock--out-of-stock { color: var(--color-alert-800); }
 
-/* Per-source list: an icon-led list, one row per fulfillment location. */
+/* Per-source availability list, one row per source. */
 .product-details__source-availability {
   margin: 0 0 var(--spacing-medium);
 }
@@ -193,6 +193,16 @@
 .pdp-avail__row[data-state="available"] .pdp-avail__qty { color: var(--color-positive-800); }
 .pdp-avail__row[data-state="out-of-stock"] .pdp-avail__qty { color: var(--color-neutral-500); }
 
+/* Reserve space (invisibly) while availability loads, so the result lands without a shift. */
+.product-details__saleable-qty[data-loading] {
+  min-height: 1.25rem;
+}
+
+.product-details__source-availability[data-loading] {
+  min-height: 4.5rem;
+}
+
+/* Per-variant matrix table (shown in a modal). */
 .product-details__matrix {
   width: 100%;
   margin: var(--spacing-small) 0 var(--spacing-medium);
@@ -223,17 +233,12 @@
   color: var(--color-neutral-500);
 }
 
-/* Per-variant list (1 or 3+ axes) renders on the design-system Table. */
 .product-details__matrix__availability {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--spacing-xxsmall);
 }
-
-.product-details__matrix__qty[data-state="in-stock"] { color: var(--color-positive-800); }
-.product-details__matrix__qty[data-state="low"] { color: var(--color-warning-800); }
-.product-details__matrix__qty[data-state="out-of-stock"] { color: var(--color-alert-800); }
 
 .product-details__matrix__sources {
   margin: 0;
@@ -271,15 +276,6 @@
 
 .product-details__matrix__cell[data-state="out-of-stock"] .product-details__matrix__qty {
   color: var(--color-alert-800);
-}
-
-/* Reserve space (invisibly) while availability loads, so the result lands without a shift. */
-.product-details__saleable-qty[data-loading] {
-  min-height: 1.25rem;
-}
-
-.product-details__source-availability[data-loading] {
-  min-height: 4.5rem;
 }
 
 /* Matrix trigger: a secondary action that opens the grid in a modal (no inline space). */

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -189,36 +189,51 @@ async function updateSaleableQty(els, sku, labels, isCurrent = () => true) {
   });
 }
 
-// Variant matrix for configurable products: color x size grid from `variants` +
-// `sourceAvailability`. Returns/renders nothing for simple products, so it self-guards.
-async function updateVariantMatrix($el, sku, labels, isCurrent = () => true) {
-  if (!$el || !sku) return;
-  $el.hidden = true;
-  $el.replaceChildren();
-  let model;
-  try {
-    model = await fetchVariantMatrix(sku, {
-      csFetch: CS_FETCH_GRAPHQL,
-      coreFetch: CORE_FETCH_GRAPHQL,
-    });
-  } catch (error) {
-    console.debug('variant-matrix: failed', error);
+// Variant availability overview for configurable products, behind a trigger. The fetch
+// (options + variants + per-variant availability) runs only when the shopper opens the
+// modal, so a PDP that is never expanded pays nothing. Simple products get no trigger.
+function setupVariantMatrix($el, product, labels) {
+  if (!$el) return;
+  const sku = product?.sku;
+  // Only configurables carry options; simple products have none, so show no trigger.
+  if (!sku || (product?.options?.length ?? 0) === 0) {
+    $el.hidden = true;
+    $el.replaceChildren();
     return;
   }
-  if (!model || !isCurrent()) return;
 
-  // The grid is large, so keep it behind a trigger (a modal) instead of reserving inline space.
   const t = labels?.Custom?.SaleableQty ?? {};
   const trigger = document.createElement('button');
   trigger.type = 'button';
   trigger.className = 'product-details__matrix-trigger';
-  trigger.textContent = t.ViewMatrix ?? 'Availability by size & color';
+  trigger.textContent = t.ViewMatrix ?? 'See availability for all options';
+
+  let model; // memoize a resolved fetch (including a definitive null) across re-opens
   trigger.addEventListener('click', async () => {
     const content = document.createElement('div');
     content.className = 'product-details__matrix-modal';
-    renderMatrix(content, model, labels);
+    content.textContent = t.Loading ?? 'Loading…';
     const modal = await createModal([content]);
     modal.showModal();
+
+    if (model === undefined) {
+      try {
+        model = await fetchVariantMatrix(sku, {
+          csFetch: CS_FETCH_GRAPHQL,
+          coreFetch: CORE_FETCH_GRAPHQL,
+        });
+      } catch (error) {
+        console.debug('variant-matrix: failed', error);
+        content.textContent = t.Unavailable ?? 'Variant availability is unavailable.';
+        return; // leave model unset so re-opening retries the fetch
+      }
+    }
+    if (model) {
+      content.textContent = '';
+      renderMatrix(content, model, labels);
+    } else {
+      content.textContent = t.Unavailable ?? 'Variant availability is unavailable.';
+    }
   });
   $el.replaceChildren(trigger);
   $el.hidden = false;
@@ -322,23 +337,14 @@ export default async function decorate(block) {
     );
   }, { eager: true });
 
-  // Variant matrix keyed on the parent (configurable) sku, so it fetches once, not per
-  // variant selection. Hidden for simple products.
+  // Variant overview trigger, set up from the parent (configurable) sku. That sku is
+  // constant across variant selections, so rebuild only when it actually changes.
   let matrixSku;
-  let matrixReq = 0;
   events.on('pdp/data', (data) => {
     const parentSku = data?.sku;
-    if (!parentSku) {
-      matrixReq += 1;
-      matrixSku = undefined;
-      $variantMatrix.hidden = true;
-      return;
-    }
     if (parentSku === matrixSku) return;
     matrixSku = parentSku;
-    matrixReq += 1;
-    const reqId = matrixReq;
-    updateVariantMatrix($variantMatrix, parentSku, labels, () => reqId === matrixReq);
+    setupVariantMatrix($variantMatrix, data, labels);
   }, { eager: true });
 
   const gallerySlots = {

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -101,6 +101,21 @@ const SOURCE_AVAILABILITY_QUERY = `
   }
 `;
 
+// WORKAROUND: sourceAvailability exposes no source name or pickup flag yet, so we join the core
+// pickupLocations query on source_code == pickup_location_code to label pickup sources.
+// TODO: when SourceAvailability exposes `name` and `is_pickup_location_active`, drop this second
+// query and read those fields directly.
+const PICKUP_LOCATIONS_QUERY = `
+  query GET_PICKUP_LOCATIONS($sku: String!) {
+    pickupLocations(productsInfo: [{ sku: $sku }], pageSize: 100) {
+      items {
+        pickup_location_code
+        name
+      }
+    }
+  }
+`;
+
 // Stock line from a SKU's sources: out of stock / only N left (all exact) / in stock.
 function badgeFromSources(sources, labels) {
   const inStock = sources.filter((s) => s.is_in_stock);
@@ -124,6 +139,12 @@ async function renderAvailability($badge, $list, sku, labels, isCurrent = () => 
   }
   $badge.setAttribute('data-loading', ''); $badge.hidden = false;
   $list.setAttribute('data-loading', ''); $list.hidden = false;
+
+  // Pickup runs in parallel but never gates the stock line; it only enriches the source list.
+  const pickupReq = CORE_FETCH_GRAPHQL.fetchGraphQl(PICKUP_LOCATIONS_QUERY, {
+    method: 'GET',
+    variables: { sku },
+  }).catch(() => null);
 
   let res;
   try {
@@ -150,7 +171,15 @@ async function renderAvailability($badge, $list, sku, labels, isCurrent = () => 
     return;
   }
   renderStockIndicator($badge, badgeFromSources(sources, labels), isCurrent);
-  renderSourceList($list, { sources, labels, isCurrent });
+
+  // Await pickup only to enrich the list; the stock line is already on screen.
+  const pickupRes = await pickupReq;
+  if (!isCurrent()) return;
+  const items = pickupRes?.data?.pickupLocations?.items ?? [];
+  const pickupByCode = new Map(items.map((i) => [i.pickup_location_code, i]));
+  renderSourceList($list, {
+    sources, pickupByCode, labels, isCurrent,
+  });
 }
 
 // Per-variant overview, behind a trigger that opens the matrix in a modal. Configurables only.

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -86,8 +86,8 @@ function formatNumericAttributeValue(value) {
   return new Intl.NumberFormat(document.documentElement.lang).format(Number(trimmed));
 }
 
-// The PDP dropin reads Catalog Service, which has no stock, so query per-source qty here.
-// available_qty is null above the store display threshold; the query is off until enabled.
+// sourceAvailability is a core-endpoint query (Catalog Service has no stock). available_qty is null
+// above the store display threshold; the query is off until enabled for the store.
 const SOURCE_AVAILABILITY_QUERY = `
   query GET_SOURCE_AVAILABILITY($skus: [String!]!) {
     sourceAvailability(skus: $skus) {
@@ -101,101 +101,62 @@ const SOURCE_AVAILABILITY_QUERY = `
   }
 `;
 
-// Pickup locations for the SKU, joined to sources by pickup_location_code == source_code.
-// Best-effort: if in-store pickup is off the query errors and the join is skipped.
-const PICKUP_LOCATIONS_QUERY = `
-  query GET_PICKUP_LOCATIONS($sku: String!) {
-    pickupLocations(productsInfo: [{ sku: $sku }], pageSize: 100) {
-      items {
-        pickup_location_code
-        name
-      }
-    }
-  }
-`;
-
-function hideSaleableQty($badge, $list) {
-  renderStockIndicator($badge, null);
-  renderSourceList($list, { sources: [] });
-}
-
-async function updateSaleableQty(els, sku, labels, isCurrent = () => true) {
-  const $badge = els?.badge ?? null;
-  const $list = els?.list ?? null;
-  if (!$badge && !$list) return;
-  if (!sku) {
-    hideSaleableQty($badge, $list);
-    return;
-  }
-  // Reserve space with a skeleton while the lookup runs, so the result lands without a shift.
-  if ($badge) { $badge.setAttribute('data-loading', ''); $badge.hidden = false; }
-  if ($list) { $list.setAttribute('data-loading', ''); $list.hidden = false; }
-
-  // Fire both together, but the stock line only needs availability, so pickup never gates it.
-  const availReq = CORE_FETCH_GRAPHQL.fetchGraphQl(SOURCE_AVAILABILITY_QUERY, {
-    method: 'GET',
-    variables: { skus: [sku] },
-  });
-  const pickupReq = CORE_FETCH_GRAPHQL.fetchGraphQl(PICKUP_LOCATIONS_QUERY, {
-    method: 'GET',
-    variables: { sku },
-  }).catch(() => null);
-
-  let availRes;
-  try {
-    availRes = await availReq;
-  } catch (error) {
-    console.debug('saleable-qty: sourceAvailability fetch failed', error);
-    if (isCurrent()) hideSaleableQty($badge, $list);
-    return;
-  }
-  if (!isCurrent()) return; // a newer variant was selected while this request was in flight
-  // Query off for the store, a backend without it, or no source data: hide (don't assert OOS).
-  const sources = availRes?.errors?.length
-    ? []
-    : (availRes?.data?.sourceAvailability?.find((s) => s.sku === sku)?.sources ?? []);
-  if (sources.length === 0) {
-    hideSaleableQty($badge, $list);
-    return;
-  }
-
+// Stock line from a SKU's sources: out of stock / only N left (all exact) / in stock.
+function badgeFromSources(sources, labels) {
   const inStock = sources.filter((s) => s.is_in_stock);
-  const fmt = (n) => new Intl.NumberFormat(document.documentElement.lang).format(n);
   const t = labels?.Custom?.SaleableQty ?? {};
-
-  // Aggregate stock line: out of stock / only N left (all sources exact) / in stock.
-  let state;
-  let text;
-  if (inStock.length === 0) {
-    state = 'out-of-stock';
-    text = t.OutOfStock ?? 'Out of stock';
-  } else if (inStock.every((s) => s.available_qty != null)) {
-    state = 'low';
+  if (inStock.length === 0) return { state: 'out-of-stock', text: t.OutOfStock ?? 'Out of stock' };
+  if (inStock.every((s) => s.available_qty != null)) {
     const total = inStock.reduce((sum, s) => sum + Number(s.available_qty), 0);
-    text = (t.OnlyXLeft ?? 'Only {qty} left').replace('{qty}', fmt(total));
-  } else {
-    state = 'in-stock';
-    text = t.InStock ?? 'In stock';
+    const qty = new Intl.NumberFormat(document.documentElement.lang).format(total);
+    return { state: 'low', text: (t.OnlyXLeft ?? 'Only {qty} left').replace('{qty}', qty) };
   }
-  renderStockIndicator($badge, { state, text }, isCurrent);
-
-  // Pickup only enriches the source list, so await it separately.
-  const pickupRes = await pickupReq;
-  if (!isCurrent()) return;
-  const items = pickupRes?.data?.pickupLocations?.items ?? [];
-  const pickupByCode = new Map(items.map((i) => [i.pickup_location_code, i]));
-  renderSourceList($list, {
-    sources, pickupByCode, labels, isCurrent,
-  });
+  return { state: 'in-stock', text: t.InStock ?? 'In stock' };
 }
 
-// Variant availability overview for configurable products, behind a trigger. The fetch
-// (options + variants + per-variant availability) runs only when the shopper opens the
-// modal, so a PDP that is never expanded pays nothing. Simple products get no trigger.
+// Query per-source stock for one concrete SKU (a simple product or a selected variant) and render
+// the "only N left" line + per-source list. A configurable uses the matrix, not this.
+async function renderAvailability($badge, $list, sku, labels, isCurrent = () => true) {
+  if (!sku) {
+    renderStockIndicator($badge, null);
+    renderSourceList($list, { sources: [] });
+    return;
+  }
+  $badge.setAttribute('data-loading', ''); $badge.hidden = false;
+  $list.setAttribute('data-loading', ''); $list.hidden = false;
+
+  let res;
+  try {
+    res = await CORE_FETCH_GRAPHQL.fetchGraphQl(SOURCE_AVAILABILITY_QUERY, {
+      method: 'GET',
+      variables: { skus: [sku] },
+    });
+  } catch (error) {
+    console.debug('sourceAvailability fetch failed', error);
+    if (isCurrent()) {
+      renderStockIndicator($badge, null);
+      renderSourceList($list, { sources: [] });
+    }
+    return;
+  }
+  if (!isCurrent()) return; // a newer selection landed while this request was in flight
+  // Off for the store, a backend without it, or no data: hide rather than assert out of stock.
+  const sources = res?.errors?.length
+    ? []
+    : (res?.data?.sourceAvailability?.find((s) => s.sku === sku)?.sources ?? []);
+  if (sources.length === 0) {
+    renderStockIndicator($badge, null);
+    renderSourceList($list, { sources: [] });
+    return;
+  }
+  renderStockIndicator($badge, badgeFromSources(sources, labels), isCurrent);
+  renderSourceList($list, { sources, labels, isCurrent });
+}
+
+// Per-variant overview, behind a trigger that opens the matrix in a modal. Configurables only.
 function setupVariantMatrix($el, product, labels) {
   if (!$el) return;
   const sku = product?.sku;
-  // Only configurables carry options; simple products have none, so show no trigger.
   if (!sku || (product?.options?.length ?? 0) === 0) {
     $el.hidden = true;
     $el.replaceChildren();
@@ -310,40 +271,34 @@ export default async function decorate(block) {
 
   block.replaceChildren(fragment);
 
-  // Secondary lookups against Catalog + core. Start immediately (no LCP-blocking work here);
-  // eager:true replays the current pdp/data, request tokens drop out-of-order responses, and
-  // a skeleton reserves space so the async result lands without a layout shift.
-  let saleableQtySku;
-  let saleableQtyReq = 0;
-  events.on('pdp/data', (data) => {
-    const nextSku = data?.variantSku ?? data?.sku;
-    // Product not found (no sku): invalidate any in-flight lookup and hide.
-    if (!nextSku) {
-      saleableQtyReq += 1;
-      saleableQtySku = undefined;
-      renderStockIndicator($saleableQty, null);
-      renderSourceList($sourceAvailability, { sources: [] });
-      return;
-    }
-    if (nextSku === saleableQtySku) return;
-    saleableQtySku = nextSku;
-    saleableQtyReq += 1;
-    const reqId = saleableQtyReq;
-    updateSaleableQty(
-      { badge: $saleableQty, list: $sourceAvailability },
-      nextSku,
-      labels,
-      () => reqId === saleableQtyReq,
-    );
-  }, { eager: true });
+  // The "only N left" line + per-source list are per-SKU: shown for a simple product or a selected
+  // variant. A configurable with nothing chosen shows neither; the matrix is the all-options view.
+  // eager:true replays pdp/data; a token drops out-of-order responses.
+  let availSku;
+  let availReq = 0;
 
-  // Variant overview trigger, set up from the parent (configurable) sku. That sku is
-  // constant across variant selections, so rebuild only when it actually changes.
+  function refreshAvailability(sku) {
+    if (sku === availSku) return;
+    availSku = sku;
+    const token = availReq + 1;
+    availReq = token;
+    renderAvailability($saleableQty, $sourceAvailability, sku, labels, () => token === availReq);
+  }
+
+  const skuFor = (data) => data?.variantSku
+    || ((data?.options?.length ?? 0) > 0 ? undefined : data?.sku);
+
+  events.on('pdp/data', (data) => refreshAvailability(skuFor(data)), { eager: true });
+  // Runtime option changes emit pdp/values (not pdp/data), so re-query for the selected variant.
+  events.on('pdp/values', () => {
+    refreshAvailability(pdpApi.getProductConfigurationValues?.()?.variantSku);
+  });
+
+  // Per-variant matrix trigger, keyed on the parent sku so it rebuilds only when that changes.
   let matrixSku;
   events.on('pdp/data', (data) => {
-    const parentSku = data?.sku;
-    if (parentSku === matrixSku) return;
-    matrixSku = parentSku;
+    if (data?.sku === matrixSku) return;
+    matrixSku = data?.sku;
     setupVariantMatrix($variantMatrix, data, labels);
   }, { eager: true });
 

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -31,7 +31,12 @@ import {
   setJsonLd,
   fetchPlaceholders,
   getProductLink,
+  CORE_FETCH_GRAPHQL,
+  CS_FETCH_GRAPHQL,
 } from '../../scripts/commerce.js';
+import { fetchVariantMatrix, renderMatrix } from './variant-matrix.js';
+import { renderStockIndicator, renderSourceList } from './availability-ui.js';
+import createModal from '../modal/modal.js';
 
 // Initializers
 import { IMAGES_SIZES } from '../../scripts/initializers/pdp.js';
@@ -81,6 +86,144 @@ function formatNumericAttributeValue(value) {
   return new Intl.NumberFormat(document.documentElement.lang).format(Number(trimmed));
 }
 
+// The PDP dropin reads Catalog Service, which has no stock, so query per-source qty here.
+// available_qty is null above the store display threshold; the query is off until enabled.
+const SOURCE_AVAILABILITY_QUERY = `
+  query GET_SOURCE_AVAILABILITY($skus: [String!]!) {
+    sourceAvailability(skus: $skus) {
+      sku
+      sources {
+        source_code
+        available_qty
+        is_in_stock
+      }
+    }
+  }
+`;
+
+// Pickup locations for the SKU, joined to sources by pickup_location_code == source_code.
+// Best-effort: if in-store pickup is off the query errors and the join is skipped.
+const PICKUP_LOCATIONS_QUERY = `
+  query GET_PICKUP_LOCATIONS($sku: String!) {
+    pickupLocations(productsInfo: [{ sku: $sku }], pageSize: 100) {
+      items {
+        pickup_location_code
+        name
+      }
+    }
+  }
+`;
+
+function hideSaleableQty($badge, $list) {
+  renderStockIndicator($badge, null);
+  renderSourceList($list, { sources: [] });
+}
+
+async function updateSaleableQty(els, sku, labels, isCurrent = () => true) {
+  const $badge = els?.badge ?? null;
+  const $list = els?.list ?? null;
+  if (!$badge && !$list) return;
+  if (!sku) {
+    hideSaleableQty($badge, $list);
+    return;
+  }
+  // Reserve space with a skeleton while the lookup runs, so the result lands without a shift.
+  if ($badge) { $badge.setAttribute('data-loading', ''); $badge.hidden = false; }
+  if ($list) { $list.setAttribute('data-loading', ''); $list.hidden = false; }
+
+  // Fire both together, but the stock line only needs availability, so pickup never gates it.
+  const availReq = CORE_FETCH_GRAPHQL.fetchGraphQl(SOURCE_AVAILABILITY_QUERY, {
+    method: 'GET',
+    variables: { skus: [sku] },
+  });
+  const pickupReq = CORE_FETCH_GRAPHQL.fetchGraphQl(PICKUP_LOCATIONS_QUERY, {
+    method: 'GET',
+    variables: { sku },
+  }).catch(() => null);
+
+  let availRes;
+  try {
+    availRes = await availReq;
+  } catch (error) {
+    console.debug('saleable-qty: sourceAvailability fetch failed', error);
+    if (isCurrent()) hideSaleableQty($badge, $list);
+    return;
+  }
+  if (!isCurrent()) return; // a newer variant was selected while this request was in flight
+  // Query off for the store, a backend without it, or no source data: hide (don't assert OOS).
+  const sources = availRes?.errors?.length
+    ? []
+    : (availRes?.data?.sourceAvailability?.find((s) => s.sku === sku)?.sources ?? []);
+  if (sources.length === 0) {
+    hideSaleableQty($badge, $list);
+    return;
+  }
+
+  const inStock = sources.filter((s) => s.is_in_stock);
+  const fmt = (n) => new Intl.NumberFormat(document.documentElement.lang).format(n);
+  const t = labels?.Custom?.SaleableQty ?? {};
+
+  // Aggregate stock line: out of stock / only N left (all sources exact) / in stock.
+  let state;
+  let text;
+  if (inStock.length === 0) {
+    state = 'out-of-stock';
+    text = t.OutOfStock ?? 'Out of stock';
+  } else if (inStock.every((s) => s.available_qty != null)) {
+    state = 'low';
+    const total = inStock.reduce((sum, s) => sum + Number(s.available_qty), 0);
+    text = (t.OnlyXLeft ?? 'Only {qty} left').replace('{qty}', fmt(total));
+  } else {
+    state = 'in-stock';
+    text = t.InStock ?? 'In stock';
+  }
+  renderStockIndicator($badge, { state, text }, isCurrent);
+
+  // Pickup only enriches the source list, so await it separately.
+  const pickupRes = await pickupReq;
+  if (!isCurrent()) return;
+  const items = pickupRes?.data?.pickupLocations?.items ?? [];
+  const pickupByCode = new Map(items.map((i) => [i.pickup_location_code, i]));
+  renderSourceList($list, {
+    sources, pickupByCode, labels, isCurrent,
+  });
+}
+
+// Variant matrix for configurable products: color x size grid from `variants` +
+// `sourceAvailability`. Returns/renders nothing for simple products, so it self-guards.
+async function updateVariantMatrix($el, sku, labels, isCurrent = () => true) {
+  if (!$el || !sku) return;
+  $el.hidden = true;
+  $el.replaceChildren();
+  let model;
+  try {
+    model = await fetchVariantMatrix(sku, {
+      csFetch: CS_FETCH_GRAPHQL,
+      coreFetch: CORE_FETCH_GRAPHQL,
+    });
+  } catch (error) {
+    console.debug('variant-matrix: failed', error);
+    return;
+  }
+  if (!model || !isCurrent()) return;
+
+  // The grid is large, so keep it behind a trigger (a modal) instead of reserving inline space.
+  const t = labels?.Custom?.SaleableQty ?? {};
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'product-details__matrix-trigger';
+  trigger.textContent = t.ViewMatrix ?? 'Availability by size & color';
+  trigger.addEventListener('click', async () => {
+    const content = document.createElement('div');
+    content.className = 'product-details__matrix-modal';
+    renderMatrix(content, model, labels);
+    const modal = await createModal([content]);
+    modal.showModal();
+  });
+  $el.replaceChildren(trigger);
+  $el.hidden = false;
+}
+
 export default async function decorate(block) {
   const eventProduct = events.lastPayload('pdp/data') ?? null;
   // bug: the pdp sends an object with event data even if product is not found.
@@ -108,6 +251,7 @@ export default async function decorate(block) {
       <div class="product-details__right-column">
         <div class="product-details__header"></div>
         <div class="product-details__price"></div>
+        <div class="product-details__saleable-qty" role="status" aria-live="polite" hidden></div>
         <div class="product-details__gallery"></div>
         <div class="product-details__short-description"></div>
         <div class="product-details__gift-card-options"></div>
@@ -120,6 +264,8 @@ export default async function decorate(block) {
           </div>
           <div class="product-details__add-to-cart-status" role="status" aria-live="polite"></div>
         </div>
+        <div class="product-details__source-availability" hidden></div>
+        <div class="product-details__variant-matrix" hidden></div>
         <div class="product-details__description"></div>
         <div class="product-details__attributes"></div>
       </div>
@@ -130,6 +276,9 @@ export default async function decorate(block) {
   const $gallery = fragment.querySelector('.product-details__gallery');
   const $header = fragment.querySelector('.product-details__header');
   const $price = fragment.querySelector('.product-details__price');
+  const $saleableQty = fragment.querySelector('.product-details__saleable-qty');
+  const $sourceAvailability = fragment.querySelector('.product-details__source-availability');
+  const $variantMatrix = fragment.querySelector('.product-details__variant-matrix');
   const $galleryMobile = fragment.querySelector('.product-details__right-column .product-details__gallery');
   const $shortDescription = fragment.querySelector('.product-details__short-description');
   const $options = fragment.querySelector('.product-details__options');
@@ -145,6 +294,52 @@ export default async function decorate(block) {
   const $attributes = fragment.querySelector('.product-details__attributes');
 
   block.replaceChildren(fragment);
+
+  // Secondary lookups against Catalog + core. Start immediately (no LCP-blocking work here);
+  // eager:true replays the current pdp/data, request tokens drop out-of-order responses, and
+  // a skeleton reserves space so the async result lands without a layout shift.
+  let saleableQtySku;
+  let saleableQtyReq = 0;
+  events.on('pdp/data', (data) => {
+    const nextSku = data?.variantSku ?? data?.sku;
+    // Product not found (no sku): invalidate any in-flight lookup and hide.
+    if (!nextSku) {
+      saleableQtyReq += 1;
+      saleableQtySku = undefined;
+      renderStockIndicator($saleableQty, null);
+      renderSourceList($sourceAvailability, { sources: [] });
+      return;
+    }
+    if (nextSku === saleableQtySku) return;
+    saleableQtySku = nextSku;
+    saleableQtyReq += 1;
+    const reqId = saleableQtyReq;
+    updateSaleableQty(
+      { badge: $saleableQty, list: $sourceAvailability },
+      nextSku,
+      labels,
+      () => reqId === saleableQtyReq,
+    );
+  }, { eager: true });
+
+  // Variant matrix keyed on the parent (configurable) sku, so it fetches once, not per
+  // variant selection. Hidden for simple products.
+  let matrixSku;
+  let matrixReq = 0;
+  events.on('pdp/data', (data) => {
+    const parentSku = data?.sku;
+    if (!parentSku) {
+      matrixReq += 1;
+      matrixSku = undefined;
+      $variantMatrix.hidden = true;
+      return;
+    }
+    if (parentSku === matrixSku) return;
+    matrixSku = parentSku;
+    matrixReq += 1;
+    const reqId = matrixReq;
+    updateVariantMatrix($variantMatrix, parentSku, labels, () => reqId === matrixReq);
+  }, { eager: true });
 
   const gallerySlots = {
     CarouselThumbnail: (ctx) => {
@@ -248,8 +443,9 @@ export default async function decorate(block) {
       formatValue: formatNumericAttributeValue,
     })($attributes),
 
-    // Wishlist button - WishlistToggle Container
-    wishlistRender.render(WishlistToggle, {
+    // Skip if the product wasn't found; WishlistToggle reads product.topLevelSku
+    // and throws on a null product, which would sink the rest of this render.
+    product && wishlistRender.render(WishlistToggle, {
       product,
     })($wishlistToggleBtn),
   ]);

--- a/blocks/product-details/variant-matrix.js
+++ b/blocks/product-details/variant-matrix.js
@@ -1,7 +1,11 @@
-// Configurable variant matrix (color x size). Catalog Service `products`(options) +
-// `variants` joined with `sourceAvailability` for per-variant qty. The incoming/restock
-// qty + date is not an MSI concept and needs a custom product attribute.
-// No top-level imports so the pure builders/renderers can be tested in isolation.
+import { Table, provider as UI } from '@dropins/tools/components.js';
+import { h } from '@dropins/tools/preact.js';
+
+// Configurable variant availability. Catalog Service `products`(options) + `variants`
+// joined with `sourceAvailability` for per-variant qty. Two option axes render as a grid
+// (rows x cols); any other count (one, or three-plus) renders a per-variant list built on
+// the design-system Table (accessible caption, mobile stacking, per-source detail rows).
+// buildMatrixModel stays framework-free, so the model logic can be tested on its own.
 
 // id/title/inStock live on the ProductViewOptionValue interface, so select them there
 // (not inside a Swatch fragment) or dropdown axes like Size come back empty.
@@ -69,51 +73,97 @@ function toAxis(opt) {
   return { title: opt.title, values: opt.values.map((v) => ({ id: v.id, title: v.title })) };
 }
 
-// Pure: turn the fetched options/variants/availability into a grid model. Rows = first
-// option, columns = second option. Returns null for anything that is not a 2-axis matrix.
-export function buildMatrixModel({ product, variants, availabilityBySku }) {
-  const options = product?.options ?? [];
-  if (options.length !== 2) return null;
-  const [rowOpt, colOpt] = options;
-  const rowIds = new Set(rowOpt.values.map((v) => v.id));
-  const colIds = new Set(colOpt.values.map((v) => v.id));
-
-  const cells = new Map();
-  variants.forEach((v) => {
-    const sels = v.selections ?? [];
-    const rowId = sels.find((s) => rowIds.has(s));
-    const colId = sels.find((s) => colIds.has(s));
-    const sku = v.product?.sku;
-    if (!rowId || !colId || !sku) return;
-    const sources = availabilityBySku.get(sku) ?? [];
-    const { state, qty } = cellFromSources(sources, v.product?.inStock);
-    cells.set(`${rowId}|${colId}`, {
-      sku,
-      price: v.product?.price?.final?.amount ?? null,
-      sources,
-      state,
-      qty,
-      restock: null, // GAP: incoming qty + available-from date are not exposed by the API
-    });
-  });
-
+// Normalize one variant into a cell payload: sku, price, live availability.
+function toCell(v, availabilityBySku) {
+  const sku = v.product?.sku;
+  if (!sku) return null;
+  const sources = availabilityBySku.get(sku) ?? [];
+  const { state, qty } = cellFromSources(sources, v.product?.inStock);
   return {
-    rowOpt: toAxis(rowOpt),
-    colOpt: toAxis(colOpt),
-    cell: (rowId, colId) => cells.get(`${rowId}|${colId}`) ?? null,
+    sels: v.selections ?? [],
+    sku,
+    price: v.product?.price?.final?.amount ?? null,
+    sources,
+    state,
+    qty,
   };
 }
 
-// Render the grid model into $el.
-export function renderMatrix($el, model, labels) {
-  if (!$el || !model) return;
+// Pure: turn the fetched options/variants/availability into a render model. Exactly two
+// axes become a grid (rows = first option, cols = second); any other count becomes a
+// per-variant list. Returns null when there is nothing to show (no options or variants).
+export function buildMatrixModel({ product, variants, availabilityBySku }) {
+  const options = product?.options ?? [];
+  const cells = variants.map((v) => toCell(v, availabilityBySku)).filter(Boolean);
+  if (options.length === 0 || cells.length === 0) return null;
+
+  if (options.length === 2) {
+    const [rowOpt, colOpt] = options;
+    const rowIds = new Set(rowOpt.values.map((v) => v.id));
+    const colIds = new Set(colOpt.values.map((v) => v.id));
+    const byCoord = new Map();
+    cells.forEach((cell) => {
+      const rowId = cell.sels.find((s) => rowIds.has(s));
+      const colId = cell.sels.find((s) => colIds.has(s));
+      if (rowId && colId) byCoord.set(`${rowId}|${colId}`, cell);
+    });
+    return {
+      layout: 'grid',
+      rowOpt: toAxis(rowOpt),
+      colOpt: toAxis(colOpt),
+      cell: (rowId, colId) => byCoord.get(`${rowId}|${colId}`) ?? null,
+    };
+  }
+
+  // One or three-plus axes: label each variant by its selected value titles, in option order.
+  const titleById = new Map();
+  options.forEach((o) => o.values.forEach((v) => titleById.set(v.id, v.title)));
+  const rows = cells.map((cell) => ({
+    ...cell,
+    label: options
+      .map((o) => cell.sels.find((s) => o.values.some((v) => v.id === s)))
+      .map((id) => titleById.get(id))
+      .filter(Boolean)
+      .join(' / '),
+  }));
+  return { layout: 'list', rows };
+}
+
+// Formatters + label bundle bound to the current locale.
+function formatters(labels) {
   const t = labels?.Custom?.SaleableQty ?? {};
   const lang = document.documentElement.lang || 'en';
-  const fmt = (n) => new Intl.NumberFormat(lang).format(n);
-  const money = (a) => (a
-    ? new Intl.NumberFormat(lang, { style: 'currency', currency: a.currency }).format(a.value)
-    : '');
+  return {
+    t,
+    fmt: (n) => new Intl.NumberFormat(lang).format(n),
+    money: (a) => (a
+      ? new Intl.NumberFormat(lang, { style: 'currency', currency: a.currency }).format(a.value)
+      : ''),
+  };
+}
 
+function qtyText(cell, t, fmt) {
+  if (cell.state === 'out-of-stock') return t.OutOfStock ?? 'Out of stock';
+  if (cell.qty != null) return (t.Available ?? '{qty} available').replace('{qty}', fmt(cell.qty));
+  return t.InStock ?? 'In stock';
+}
+
+// Per-source breakdown, surfaced on hover for debugging.
+function sourcesTitle(sources) {
+  return sources
+    .map((s) => `${s.source_code}: ${s.is_in_stock ? (s.available_qty ?? 'in stock') : 'out'}`)
+    .join('\n');
+}
+
+function qtySpan(cell, t, fmt) {
+  const qty = document.createElement('span');
+  qty.className = 'product-details__matrix__qty';
+  qty.textContent = qtyText(cell, t, fmt);
+  return qty;
+}
+
+// Two axes: a grid, rows = first option, columns = second.
+function renderGrid($el, model, { t, fmt, money }) {
   const table = document.createElement('table');
   table.className = 'product-details__matrix';
 
@@ -150,45 +200,91 @@ export function renderMatrix($el, model, labels) {
         return;
       }
       td.dataset.state = cell.state;
-      // Per-source breakdown on hover, for debugging.
-      td.title = cell.sources
-        .map((s) => `${s.source_code}: ${s.is_in_stock ? (s.available_qty ?? 'in stock') : 'out'}`)
-        .join('\n');
+      td.title = sourcesTitle(cell.sources);
 
       const price = document.createElement('span');
       price.className = 'product-details__matrix__price';
       price.textContent = money(cell.price);
 
-      const qty = document.createElement('span');
-      qty.className = 'product-details__matrix__qty';
-      if (cell.state === 'out-of-stock') qty.textContent = t.OutOfStock ?? 'Out of stock';
-      else if (cell.qty != null) qty.textContent = (t.Available ?? '{qty} available').replace('{qty}', fmt(cell.qty));
-      else qty.textContent = t.InStock ?? 'In stock';
-
-      // The one API gap, drawn as a placeholder so it is visually obvious.
-      const restock = document.createElement('span');
-      restock.className = 'product-details__matrix__restock';
-      restock.textContent = t.RestockGap ?? 'restock: not in API';
-
-      td.append(price, qty, restock);
+      td.append(price, qtySpan(cell, t, fmt));
       tr.append(td);
     });
     tbody.append(tr);
   });
   table.append(tbody);
-
   $el.replaceChildren(table);
   $el.hidden = false;
 }
 
+// One source's availability text, for the per-variant details row.
+function sourceText(s, t, fmt) {
+  if (!s.is_in_stock) return t.OutOfStock ?? 'Out of stock';
+  if (s.available_qty != null) return (t.Available ?? '{qty} available').replace('{qty}', fmt(Number(s.available_qty)));
+  return t.InStock ?? 'In stock';
+}
+
+// Per-source breakdown, rendered as a details row under its variant (real content, not a
+// tooltip), so it is reachable on touch and by screen readers.
+function sourcesNode(sources, t, fmt) {
+  return h('ul', { className: 'product-details__matrix__sources' }, sources.map((s) => h('li', {
+    key: s.source_code,
+    className: 'product-details__matrix__source',
+    'data-state': s.is_in_stock ? 'in' : 'out',
+  }, [
+    h('span', { className: 'product-details__matrix__source-name' }, s.source_code),
+    h('span', { className: 'product-details__matrix__source-qty' }, sourceText(s, t, fmt)),
+  ])));
+}
+
+// A variant's aggregate stock line.
+function availabilityNode(row, t, fmt) {
+  return h('div', { className: 'product-details__matrix__availability' }, [
+    h('span', { className: 'product-details__matrix__qty', 'data-state': row.state }, qtyText(row, t, fmt)),
+  ]);
+}
+
+// One or three-plus axes: a per-variant list on the design-system Table. Per-source rows
+// ride along as always-open details rows (the Table has no built-in expander, so the set
+// is controlled; we open them all rather than hide the breakdown behind a hover).
+function renderList($el, model, { t, fmt, money }) {
+  const props = {
+    columns: [
+      { label: t.Variant ?? 'Variant', key: 'variant' },
+      { label: t.Price ?? 'Price', key: 'price' },
+      { label: t.Availability ?? 'Availability', key: 'availability' },
+    ],
+    rowData: model.rows.map((row) => ({
+      variant: row.label,
+      price: money(row.price),
+      availability: availabilityNode(row, t, fmt),
+      _rowDetails: row.sources.length ? sourcesNode(row.sources, t, fmt) : undefined,
+    })),
+    expandedRows: new Set(model.rows.map((_, i) => i)),
+    mobileLayout: 'stacked',
+    caption: t.TableCaption ?? 'Availability for every option combination.',
+  };
+  $el.replaceChildren();
+  UI.render(Table, props)($el).catch((error) => {
+    console.debug('variant-matrix: table render failed', error);
+  });
+}
+
+// Render the model into $el, dispatching on layout.
+export function renderMatrix($el, model, labels) {
+  if (!$el || !model) return;
+  const f = formatters(labels);
+  if (model.layout === 'list') renderList($el, model, f);
+  else renderGrid($el, model, f);
+}
+
 // Fetch options + variants (Catalog Service) and per-variant availability (core-saas),
 // then build the model. Fetch clients are injected so this module imports nothing.
-// Returns null when the SKU is not a 2-axis configurable (so the caller hides the panel).
+// Returns null when the SKU is not a multi-variant configurable (so the caller can say so).
 export async function fetchVariantMatrix(sku, { csFetch, coreFetch }) {
   const optRes = await csFetch.fetchGraphQl(OPTIONS_QUERY, { method: 'GET', variables: { skus: [sku] } });
   if (optRes?.errors?.length) return null;
   const product = (optRes?.data?.products ?? []).find((p) => p.__typename === 'ComplexProductView');
-  if (!product || (product.options ?? []).length !== 2) return null;
+  if (!product || (product.options ?? []).length === 0) return null;
 
   // Page through variants until the cursor runs out (bounded). Fail closed on any page
   // error or if the bound is hit with more pages remaining, so the grid is never partial.

--- a/blocks/product-details/variant-matrix.js
+++ b/blocks/product-details/variant-matrix.js
@@ -1,0 +1,224 @@
+// Configurable variant matrix (color x size). Catalog Service `products`(options) +
+// `variants` joined with `sourceAvailability` for per-variant qty. The incoming/restock
+// qty + date is not an MSI concept and needs a custom product attribute.
+// No top-level imports so the pure builders/renderers can be tested in isolation.
+
+// id/title/inStock live on the ProductViewOptionValue interface, so select them there
+// (not inside a Swatch fragment) or dropdown axes like Size come back empty.
+const OPTIONS_QUERY = `
+  query GET_MATRIX_OPTIONS($skus: [String!]!) {
+    products(skus: $skus) {
+      __typename
+      ... on ComplexProductView {
+        options {
+          id
+          title
+          values { id title }
+        }
+      }
+    }
+  }
+`;
+
+const VARIANTS_QUERY = `
+  query GET_MATRIX_VARIANTS($sku: String!, $cursor: String) {
+    variants(sku: $sku, cursor: $cursor) {
+      cursor
+      variants {
+        selections
+        product {
+          sku
+          __typename
+          ... on SimpleProductView {
+            inStock
+            price { final { amount { value currency } } }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const MAX_VARIANT_PAGES = 20; // bound the cursor loop
+const MAX_AVAILABILITY_SKUS = 100; // sourceAvailability caps at 100 SKUs per call
+
+const MATRIX_AVAILABILITY_QUERY = `
+  query GET_MATRIX_AVAILABILITY($skus: [String!]!) {
+    sourceAvailability(skus: $skus) {
+      sku
+      sources { source_code available_qty is_in_stock }
+    }
+  }
+`;
+
+// Per-variant state from its sources; falls back to the Catalog Service inStock boolean
+// when sourceAvailability is unavailable (query off, or a backend without it).
+function cellFromSources(sources, inStock) {
+  if (sources.length === 0) {
+    return { state: inStock === false ? 'out-of-stock' : 'in-stock', qty: null };
+  }
+  const live = sources.filter((s) => s.is_in_stock);
+  if (live.length === 0) return { state: 'out-of-stock', qty: null };
+  if (live.every((s) => s.available_qty != null)) {
+    return { state: 'low', qty: live.reduce((sum, s) => sum + Number(s.available_qty), 0) };
+  }
+  return { state: 'in-stock', qty: null };
+}
+
+function toAxis(opt) {
+  return { title: opt.title, values: opt.values.map((v) => ({ id: v.id, title: v.title })) };
+}
+
+// Pure: turn the fetched options/variants/availability into a grid model. Rows = first
+// option, columns = second option. Returns null for anything that is not a 2-axis matrix.
+export function buildMatrixModel({ product, variants, availabilityBySku }) {
+  const options = product?.options ?? [];
+  if (options.length !== 2) return null;
+  const [rowOpt, colOpt] = options;
+  const rowIds = new Set(rowOpt.values.map((v) => v.id));
+  const colIds = new Set(colOpt.values.map((v) => v.id));
+
+  const cells = new Map();
+  variants.forEach((v) => {
+    const sels = v.selections ?? [];
+    const rowId = sels.find((s) => rowIds.has(s));
+    const colId = sels.find((s) => colIds.has(s));
+    const sku = v.product?.sku;
+    if (!rowId || !colId || !sku) return;
+    const sources = availabilityBySku.get(sku) ?? [];
+    const { state, qty } = cellFromSources(sources, v.product?.inStock);
+    cells.set(`${rowId}|${colId}`, {
+      sku,
+      price: v.product?.price?.final?.amount ?? null,
+      sources,
+      state,
+      qty,
+      restock: null, // GAP: incoming qty + available-from date are not exposed by the API
+    });
+  });
+
+  return {
+    rowOpt: toAxis(rowOpt),
+    colOpt: toAxis(colOpt),
+    cell: (rowId, colId) => cells.get(`${rowId}|${colId}`) ?? null,
+  };
+}
+
+// Render the grid model into $el.
+export function renderMatrix($el, model, labels) {
+  if (!$el || !model) return;
+  const t = labels?.Custom?.SaleableQty ?? {};
+  const lang = document.documentElement.lang || 'en';
+  const fmt = (n) => new Intl.NumberFormat(lang).format(n);
+  const money = (a) => (a
+    ? new Intl.NumberFormat(lang, { style: 'currency', currency: a.currency }).format(a.value)
+    : '');
+
+  const table = document.createElement('table');
+  table.className = 'product-details__matrix';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  const corner = document.createElement('th');
+  corner.textContent = `${model.rowOpt.title} / ${model.colOpt.title}`;
+  headRow.append(corner);
+  model.colOpt.values.forEach((c) => {
+    const th = document.createElement('th');
+    th.scope = 'col';
+    th.textContent = c.title;
+    headRow.append(th);
+  });
+  thead.append(headRow);
+  table.append(thead);
+
+  const tbody = document.createElement('tbody');
+  model.rowOpt.values.forEach((r) => {
+    const tr = document.createElement('tr');
+    const rowHead = document.createElement('th');
+    rowHead.scope = 'row';
+    rowHead.textContent = r.title;
+    tr.append(rowHead);
+
+    model.colOpt.values.forEach((c) => {
+      const td = document.createElement('td');
+      td.className = 'product-details__matrix__cell';
+      const cell = model.cell(r.id, c.id);
+      if (!cell) {
+        td.classList.add('product-details__matrix__cell--none');
+        td.textContent = '—';
+        tr.append(td);
+        return;
+      }
+      td.dataset.state = cell.state;
+      // Per-source breakdown on hover, for debugging.
+      td.title = cell.sources
+        .map((s) => `${s.source_code}: ${s.is_in_stock ? (s.available_qty ?? 'in stock') : 'out'}`)
+        .join('\n');
+
+      const price = document.createElement('span');
+      price.className = 'product-details__matrix__price';
+      price.textContent = money(cell.price);
+
+      const qty = document.createElement('span');
+      qty.className = 'product-details__matrix__qty';
+      if (cell.state === 'out-of-stock') qty.textContent = t.OutOfStock ?? 'Out of stock';
+      else if (cell.qty != null) qty.textContent = (t.Available ?? '{qty} available').replace('{qty}', fmt(cell.qty));
+      else qty.textContent = t.InStock ?? 'In stock';
+
+      // The one API gap, drawn as a placeholder so it is visually obvious.
+      const restock = document.createElement('span');
+      restock.className = 'product-details__matrix__restock';
+      restock.textContent = t.RestockGap ?? 'restock: not in API';
+
+      td.append(price, qty, restock);
+      tr.append(td);
+    });
+    tbody.append(tr);
+  });
+  table.append(tbody);
+
+  $el.replaceChildren(table);
+  $el.hidden = false;
+}
+
+// Fetch options + variants (Catalog Service) and per-variant availability (core-saas),
+// then build the model. Fetch clients are injected so this module imports nothing.
+// Returns null when the SKU is not a 2-axis configurable (so the caller hides the panel).
+export async function fetchVariantMatrix(sku, { csFetch, coreFetch }) {
+  const optRes = await csFetch.fetchGraphQl(OPTIONS_QUERY, { method: 'GET', variables: { skus: [sku] } });
+  if (optRes?.errors?.length) return null;
+  const product = (optRes?.data?.products ?? []).find((p) => p.__typename === 'ComplexProductView');
+  if (!product || (product.options ?? []).length !== 2) return null;
+
+  // Page through variants until the cursor runs out (bounded). Fail closed on any page
+  // error or if the bound is hit with more pages remaining, so the grid is never partial.
+  const variants = [];
+  let cursor = null;
+  for (let page = 0; page < MAX_VARIANT_PAGES; page += 1) {
+    // eslint-disable-next-line no-await-in-loop -- cursor paging is inherently sequential
+    const vr = await csFetch.fetchGraphQl(VARIANTS_QUERY, { method: 'GET', variables: { sku, cursor } });
+    if (vr?.errors?.length) return null;
+    variants.push(...(vr?.data?.variants?.variants ?? []));
+    cursor = vr?.data?.variants?.cursor ?? null;
+    if (!cursor) break;
+  }
+  if (cursor || variants.length === 0) return null;
+
+  // Per-variant availability from core, in <=100-SKU chunks (best-effort enrichment;
+  // cells fall back to the Catalog Service inStock boolean when it is missing).
+  const skus = [...new Set(variants.map((v) => v.product?.sku).filter(Boolean))];
+  const chunks = [];
+  for (let i = 0; i < skus.length; i += MAX_AVAILABILITY_SKUS) {
+    chunks.push(skus.slice(i, i + MAX_AVAILABILITY_SKUS));
+  }
+  const availabilityBySku = new Map();
+  const results = await Promise.all(chunks.map((chunk) => coreFetch
+    .fetchGraphQl(MATRIX_AVAILABILITY_QUERY, { method: 'GET', variables: { skus: chunk } })
+    .catch(() => null)));
+  results.forEach((res) => {
+    const rows = res?.data?.sourceAvailability ?? [];
+    rows.forEach((s) => availabilityBySku.set(s.sku, s.sources ?? []));
+  });
+
+  return buildMatrixModel({ product, variants, availabilityBySku });
+}

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "public": {
     "default": {
-      "commerce-core-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
-      "commerce-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/JNjfhWJ3MJvZhj3bwsamRP/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/JNjfhWJ3MJvZhj3bwsamRP/graphql",
       "headers": {
         "all": {
           "Store": "default"

--- a/config.json
+++ b/config.json
@@ -1,0 +1,30 @@
+{
+  "public": {
+    "default": {
+      "commerce-core-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
+      "commerce-endpoint": "https://na1-qa.api.commerce.adobe.com/QUxJ3FeSXX7nmPAGdqUBMX/graphql",
+      "headers": {
+        "all": {
+          "Store": "default"
+        },
+        "cs": {
+          "Magento-Website-Code": "base",
+          "Magento-Store-Code": "main_website_store",
+          "Magento-Store-View-Code": "default"
+        }
+      },
+      "analytics": {
+        "base-currency-code": "USD",
+        "environment": "Testing",
+        "store-code": "main_website_store",
+        "store-id": 1,
+        "store-name": "Default Store View",
+        "store-view-code": "default",
+        "store-view-id": 1,
+        "website-code": "base",
+        "website-id": 1,
+        "website-name": "Main Website"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The PDP drop-in shows only an in-stock boolean from Catalog Service, with no quantity and no per-location view. This adds saleable stock detail to the PDP by querying the core inventory GraphQL, and leaves the drop-in untouched.

## What it shows

- **Aggregate stock line** for the selected product or variant: out of stock, "Only N left", or in stock.
- **Availability by location**: a per-source list of which locations have the item, the quantity at each, and whether the location ships or is a pickup point.
- **Availability for all options** (configurable products): a button opens an overview in a modal. Two option axes render as a grid (for example color by size). One axis, or three-plus axes, render as a per-variant list on the design-system Table, with an accessible caption, mobile stacking, and a per-location breakdown under each variant.

## How it works

- Per-source quantity comes from the core inventory `sourceAvailability` query; pickup points come from `pickupLocations`. Options, variants, and price come from Catalog Service (`products`, `variants`). The block owns the fetch, and the view layer is split into a stock line, a source list, and the matrix.
- Quantity is exact only at or below the store display threshold. Above it the backend masks the number and the UI shows "in stock", so the client never invents a count.
- A configurable parent carries no stock of its own, so the stock line keys on the selected variant and the overview queries the child SKUs.
- The overview fetch is deferred to the trigger click, so a PDP that is never expanded makes no extra requests.
- Fast variant switching is safe: out-of-order responses are dropped with a request token, and the matrix fails closed rather than render a partial grid.
- Everything degrades gracefully. If the query is off for the store, or the backend does not expose it, the panels stay hidden instead of asserting a state.

## Preview
- Simple: https://source-inventory--aem-boilerplate-commerce--hlxsites.aem.page/products/recycled-performance-hat/adb174
- Configurable with option matrix: https://source-inventory--aem-boilerplate-commerce--hlxsites.aem.page/products/configurable-test/con005?optionsUIDs=Y29uZmlndXJhYmxlLzkzLzE0 (Click "See availability for all options")

<img width="300" alt="Screenshot 2026-08-19 at 16 54 46" src="https://github.com/user-attachments/assets/66ecbd3a-9f7c-4ea0-a4a2-378c53e1f37a" />
<img width="300" alt="Screenshot 2026-08-19 at 16 54 27" src="https://github.com/user-attachments/assets/ac7414cd-775c-4a1d-a965-97a255e95656" />
