### PR TITLE
PAY-6967: Move billing address back after payment methods

### DIFF
--- a/blocks/commerce-checkout/fragments.js
+++ b/blocks/commerce-checkout/fragments.js
@@ -55,8 +55,8 @@ export function createCheckoutFragment() {
           <div class="checkout__shipping-form ${CHECKOUT_BLOCK}"></div>
           <div class="checkout__bill-to-shipping ${CHECKOUT_BLOCK}"></div>
           <div class="checkout__delivery ${CHECKOUT_BLOCK}"></div>
-          <div class="checkout__billing-form ${CHECKOUT_BLOCK}"></div>
           <div class="checkout__payment-methods ${CHECKOUT_BLOCK}"></div>
+          <div class="checkout__billing-form ${CHECKOUT_BLOCK}"></div>
           <div class="checkout__terms-and-conditions ${CHECKOUT_BLOCK}"></div>
           <div class="checkout__place-order ${CHECKOUT_BLOCK}"></div>
         </div>


### PR DESCRIPTION
The default checkout layout (payment, billing, terms & conditions, place order) was disrupted when we introduced Apple Pay in #690: rendering its buttom inside the "Payment" section made it a de facto replacement for "Place order", but since it sat mid-page rather than at the bottom, it broke the scroll flow—customers had to scroll down to fill in billing and accept terms, then scroll back up to find the button and place the order.

The same PR worked around this by swapping "billing" ahead of "payment" to keep the button closer to the end of the page, but this was itself non-linear (terms & conditions was never swapped) and confusing on mobile where the "order summary" block is rendered below the payment button, possibly leaving the customer with no visible CTA when they arrive to the bottom of the page.

Now that payment buttons have been relocated to the bottom of the page as a true replacement for "Place order" (#1398), that workaround is no longer needed. This pull request restores that original default layout: payment first, then billing.

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://pay-6967-layout--aem-boilerplate-commerce--hlxsites.aem.live/
