### PR TITLE
fix: verify dropin versions before vendoring to prevent silent downgrades

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -14,6 +14,15 @@ if (fs.existsSync(dropinsDir)) {
 // Create scripts/__dropins__ directory if not exists
 fs.mkdirSync(dropinsDir, { recursive: true });
 
+// Read package-lock.json to get the expected resolved versions
+const packageLock = JSON.parse(fs.readFileSync('./package-lock.json', 'utf8'));
+
+// Verify that every @dropins/* dependency in node_modules matches the version
+// declared in package-lock.json. A mismatch means `npm install` did not
+// reconcile node_modules correctly (e.g. stale prerelease version) and
+// vendoring would silently ship the wrong dropin code.
+const versionMismatches = [];
+
 // Copy specified files from node_modules/@dropins to scripts/__dropins__
 fs.readdirSync('node_modules/@dropins', { withFileTypes: true }).forEach((file) => {
   // Skip if package is not in package.json dependencies / skip devDependencies
@@ -25,11 +34,34 @@ fs.readdirSync('node_modules/@dropins', { withFileTypes: true }).forEach((file) 
   if (!file.isDirectory()) {
     return;
   }
+
+  // Check installed version against package-lock.json
+  const pkgName = `@dropins/${file.name}`;
+  const installedPkgPath = path.join('node_modules', '@dropins', file.name, 'package.json');
+  if (fs.existsSync(installedPkgPath)) {
+    const installedVersion = JSON.parse(fs.readFileSync(installedPkgPath, 'utf8')).version;
+    const lockEntry = packageLock.packages[`node_modules/${pkgName}`];
+    const expectedVersion = lockEntry && lockEntry.version;
+    if (expectedVersion && installedVersion !== expectedVersion) {
+      versionMismatches.push({ pkgName, installedVersion, expectedVersion });
+    }
+  }
+
   fs.cpSync(path.join('node_modules', '@dropins', file.name), path.join(dropinsDir, file.name), {
     recursive: true,
     filter: (src) => (!src.endsWith('package.json')),
   });
 });
+
+if (versionMismatches.length > 0) {
+  console.error('\n🚨 Drop-in version mismatch detected!\n');
+  console.error('The following packages in node_modules do not match package-lock.json:');
+  versionMismatches.forEach(({ pkgName, installedVersion, expectedVersion }) => {
+    console.error(`  ${pkgName}: installed ${installedVersion}, expected ${expectedVersion}`);
+  });
+  console.error('\nRun "rm -rf node_modules && npm install" to fix this.\n');
+  process.exit(1);
+}
 
 // Other files to copy
 [
@@ -49,10 +81,10 @@ function checkPackageLockForArtifactory() {
         return;
       }
       try {
-        const packageLock = JSON.parse(data);
+        const lockData = JSON.parse(data);
         let found = false;
-        Object.keys(packageLock.packages).forEach((packageName) => {
-          const packageInfo = packageLock.packages[packageName];
+        Object.keys(lockData.packages).forEach((packageName) => {
+          const packageInfo = lockData.packages[packageName];
           if (packageInfo.resolved && packageInfo.resolved.includes('artifactory')) {
             console.warn(`Warning: artifactory found in resolved property for package ${packageName}`);
             found = true;


### PR DESCRIPTION
**Problem**

`postinstall.js` blindly copies every `@dropins/*` package from `node_modules/` into `scripts/__dropins__/` without checking whether the installed version matches what `package-lock.json` declares. When `node_modules/` is stale (e.g. after pulling a branch that pins a different version), `install:dropins` silently vendors the wrong version.

This caused [#1410](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1410) — `storefront-product-discovery` was downgraded from `3.1.2-beta1` to `3.1.1` because `node_modules/` had the old version and `install:dropins` copied it without validation.

**Fix**

Before copying, the script now reads `package-lock.json` and compares each `@dropins/*` version in `node_modules/` against the locked version. If any mismatch is found, the script exits with an error and tells the developer to run `rm -rf node_modules && npm install`.

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://fix-postinstall-version-check--aem-boilerplate-commerce--hlxsites.aem.live/

