### PR TITLE
USF-3077 [Accessibility] - Programmatic label does not convey purpose of control - Header ( Cart )

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -357,6 +357,11 @@ export default async function decorate(block) {
       cartButton.removeAttribute('data-count');
     }
 
+    cartButton.setAttribute(
+      'aria-label',
+      (labels.Global?.CartWithItems ?? 'Cart with {count} item(s)').replace('{count}', totalQuantity),
+    );
+
     // Skip the announcement for the initial value on page load so screen
     // reader users aren't told about the cart contents before they've
     // interacted with it; only announce actual changes.

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -359,7 +359,11 @@ export default async function decorate(block) {
 
     cartButton.setAttribute(
       'aria-label',
-      (labels.Global?.CartWithItems ?? 'Cart with {count} item(s)').replace('{count}', totalQuantity),
+      totalQuantity === 1
+        ? (labels.Global?.CartWithItem?.replace('{count}', totalQuantity)
+          ?? `Cart with ${totalQuantity} item`)
+        : (labels.Global?.CartWithItems?.replace('{count}', totalQuantity)
+          ?? `Cart with ${totalQuantity} items`),
     );
 
     // Skip the announcement for the initial value on page load so screen


### PR DESCRIPTION
## Summary
- The header cart button's aria-label was always the static "Cart", giving screen reader users no indication of how many items are in it.
- The label now reflects the current cart quantity with proper singular/plural wording (e.g. "Cart with 1 item" / "Cart with 5 items"), sourced from the `Global.CartWithItem` / `Global.CartWithItems` placeholders, with code fallbacks if either key isn't published yet.

Test URLs
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/
- After: https://USF-3077--aem-boilerplate-commerce--hlxsites.aem.page/