### PR TITLE
COMOPT-2093: Wire new catalog-view headers in company-switcher

### DIFF
--- a/scripts/initializers/company-switcher.js
+++ b/scripts/initializers/company-switcher.js
@@ -1,5 +1,6 @@
 import { initializers } from '@dropins/tools/initializer.js';
 import { initialize, setEndpoint } from '@dropins/storefront-company-switcher/api.js';
+import { getHeaders } from '@dropins/tools/lib/aem/configs.js';
 import { initializeDropin } from './index.js';
 import { CORE_FETCH_GRAPHQL, CS_FETCH_GRAPHQL } from '../commerce.js';
 
@@ -11,5 +12,8 @@ await initializeDropin(async () => {
   return initializers.mountImmediately(initialize, {
     fetchGraphQlModules: [CORE_FETCH_GRAPHQL, CS_FETCH_GRAPHQL],
     groupGraphQlModules: [CS_FETCH_GRAPHQL],
+    catalogViewGraphQlModules: [CS_FETCH_GRAPHQL],
+    catalogViewHeader: 'ac-view-id',
+    catalogViewDefault: getHeaders('cs')['ac-view-id'],
   });
 })();

--- a/scripts/initializers/company-switcher.js
+++ b/scripts/initializers/company-switcher.js
@@ -8,12 +8,20 @@ await initializeDropin(async () => {
   // Set Fetch GraphQL (Core)
   setEndpoint(CORE_FETCH_GRAPHQL);
 
+  // Resolve the actual-cased catalog view header key from the CS config, since
+  // config.json may seed it with different casing (e.g. 'AC-View-Id').
+  const csHeaders = getHeaders('cs');
+  const catalogViewIdKey = 'ac-view-id';
+  const catalogViewKey = Object.keys(csHeaders).find(
+    (key) => key.toLowerCase() === catalogViewIdKey,
+  ) || catalogViewIdKey;
+
   // Initialize company switcher
   return initializers.mountImmediately(initialize, {
     fetchGraphQlModules: [CORE_FETCH_GRAPHQL, CS_FETCH_GRAPHQL],
     groupGraphQlModules: [CS_FETCH_GRAPHQL],
     catalogViewGraphQlModules: [CS_FETCH_GRAPHQL],
-    catalogViewHeader: 'ac-view-id',
-    catalogViewDefault: getHeaders('cs')['ac-view-id'],
+    catalogViewHeader: catalogViewKey,
+    catalogViewDefault: csHeaders[catalogViewKey],
   });
 })();


### PR DESCRIPTION
- Added header mounts for catalogView
- Implemented in https://github.com/adobe-commerce/storefront-company-switcher/pull/72

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/COMOPT-2093

Test URLs
- Before: https://b2b-integration--aem-boilerplate-commerce--hlxsites.aem.page
- After: https://COMOPT-2093-2--aem-boilerplate-commerce--hlxsites.aem.page
