### PR TITLE
Upgrade Payment Services drop-in to v4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dropins/storefront-cart": "^3.3.1",
         "@dropins/storefront-checkout": "^3.3.1",
         "@dropins/storefront-order": "^4.0.1",
-        "@dropins/storefront-payment-services": "4.2.0-beta1",
+        "@dropins/storefront-payment-services": "^4.2.1",
         "@dropins/storefront-pdp": "^3.3.0",
         "@dropins/storefront-personalization": "^3.2.1",
         "@dropins/storefront-product-discovery": "3.1.2-beta1",
@@ -2097,9 +2097,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-payment-services": {
-      "version": "4.2.0-beta1",
-      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.2.0-beta1.tgz",
-      "integrity": "sha512-DyuR4wdUTMABJNiQRpu8nKmJ6BRv0ieTDQDjrXKaaC46CuN4fA1VjpbsqbnjPtC7wsC33Si+eO4a/e0QIXU+8A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@dropins/storefront-payment-services/-/storefront-payment-services-4.2.1.tgz",
+      "integrity": "sha512-yo8oNQk4uysxXbHLK4vGpOPvRf1BU5R1k/Uh2WSVHVsT9UkjL44GKiExowtqfwDx6lwpOxQpTynAhTM0eadQ4A==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@dropins/storefront-pdp": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dropins/storefront-cart": "^3.3.1",
     "@dropins/storefront-checkout": "^3.3.1",
     "@dropins/storefront-order": "^4.0.1",
-    "@dropins/storefront-payment-services": "4.2.0-beta1",
+    "@dropins/storefront-payment-services": "^4.2.1",
     "@dropins/storefront-pdp": "^3.3.0",
     "@dropins/storefront-personalization": "^3.2.1",
     "@dropins/storefront-product-discovery": "3.1.2-beta1",


### PR DESCRIPTION
Upgrade Payment Services from v4.2.0-beta1 to v4.2.1: https://github.com/adobe-commerce/storefront-payment-services/compare/v4.2.0-beta1...v4.2.1. Source code is identical, hence no updates to `scripts/__dropins__`,

Test URLs:
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://upgrade-payments--aem-boilerplate-commerce--hlxsites.aem.live/
