### PR TITLE
perf(commerce-orders-list): guard auth before loading the account drop-in

### DIFF
--- a/blocks/commerce-orders-list/commerce-orders-list.js
+++ b/blocks/commerce-orders-list/commerce-orders-list.js
@@ -1,6 +1,3 @@
-import { render as accountRenderer } from '@dropins/storefront-account/render.js';
-import { OrdersList } from '@dropins/storefront-account/containers/OrdersList.js';
-import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 import {
   checkIsAuthenticated,
@@ -13,10 +10,12 @@ import {
   getProductLink,
 } from '../../scripts/commerce.js';
 
-// Initialize
-import '../../scripts/initializers/account.js';
-
 export default async function decorate(block) {
+  if (!checkIsAuthenticated()) {
+    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
+    return;
+  }
+
   const { 'minified-view': minifiedViewConfig = 'false' } = readBlockConfig(block);
   const createProductLink = (productData) => {
     // If product is null/undefined, it's been deleted from catalog
@@ -32,39 +31,47 @@ export default async function decorate(block) {
     return rootLink('#');
   };
 
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    await accountRenderer.render(OrdersList, {
-      minifiedView: minifiedViewConfig === 'true',
-      routeTracking: ({ carrier, number }) => {
-        if (carrier === 'ups') {
-          return `${UPS_TRACKING_URL}?tracknum=${number}`;
-        }
-        return '';
-      },
-      routeOrdersList: () => rootLink(CUSTOMER_ORDERS_PATH),
-      routeOrderDetails: (orderNumber) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
-      routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
-      routeOrderProduct: createProductLink,
-      slots: {
-        OrderItemImage: (ctx) => {
-          const { data, defaultImageProps } = ctx;
-          const anchor = document.createElement('a');
-          anchor.href = createProductLink(ctx.data);
+  // Load the drop-in lazily, after the guard, so logged-out users don't download it.
+  const [
+    { render: accountRenderer },
+    { OrdersList },
+    { tryRenderAemAssetsImage },
+  ] = await Promise.all([
+    import('@dropins/storefront-account/render.js'),
+    import('@dropins/storefront-account/containers/OrdersList.js'),
+    import('@dropins/tools/lib/aem/assets.js'),
+    import('../../scripts/initializers/account.js'),
+  ]);
 
-          tryRenderAemAssetsImage(ctx, {
-            alias: data.product.sku,
-            imageProps: defaultImageProps,
-            wrapper: anchor,
+  await accountRenderer.render(OrdersList, {
+    minifiedView: minifiedViewConfig === 'true',
+    routeTracking: ({ carrier, number }) => {
+      if (carrier === 'ups') {
+        return `${UPS_TRACKING_URL}?tracknum=${number}`;
+      }
+      return '';
+    },
+    routeOrdersList: () => rootLink(CUSTOMER_ORDERS_PATH),
+    routeOrderDetails: (orderNumber) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
+    routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
+    routeOrderProduct: createProductLink,
+    slots: {
+      OrderItemImage: (ctx) => {
+        const { data, defaultImageProps } = ctx;
+        const anchor = document.createElement('a');
+        anchor.href = createProductLink(ctx.data);
 
-            params: {
-              width: defaultImageProps.width,
-              height: defaultImageProps.height,
-            },
-          });
-        },
+        tryRenderAemAssetsImage(ctx, {
+          alias: data.product.sku,
+          imageProps: defaultImageProps,
+          wrapper: anchor,
+
+          params: {
+            width: defaultImageProps.width,
+            height: defaultImageProps.height,
+          },
+        });
       },
-    })(block);
-  }
+    },
+  })(block);
 }


### PR DESCRIPTION
Logged-out visitors to `/customer/orders` are redirected to login, but the block statically imported the account drop-in first, so they downloaded the whole `storefront-account` + `tools` + preact chain (including the 84KB `AddressForm` container) just to be bounced.

This checks auth at the top of `decorate()` and returns early. The drop-in now loads via dynamic `import()` only when the user is authenticated, matching the lazy-loading already used in `header.js` and `product-details.js`.

Logged-in users are unchanged (LCP ~2.7s). Mobile PSI on the logged-out page goes 76 to 88.

The anonymous `/customer/orders` score is noisy (it races the client-side redirect) and will not reliably hit 90 from the boilerplate alone. A deterministic fix belongs in the `storefront-account` drop-in (eager skeleton, split `OrdersList` from `AddressForm`) or in PSI policy (test authenticated, or exclude auth-gated routes).

Test (logged out):
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders
- After: https://fix-orders-lcp-guard--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders