### PR TITLE
ci: baseline B2B SaaS E2E run on b2b (whitespace-only)

### DIFF
--- a/.github/workflows/run-b2b-e2e-saas-tests.yaml
+++ b/.github/workflows/run-b2b-e2e-saas-tests.yaml
@@ -15,6 +15,7 @@ jobs:
       CYPRESS_IMS_ORG_ID: ${{ secrets.CYPRESS_IMS_ORG_ID }}
       CYPRESS_IMS_CLIENT_SECRET: ${{ secrets.CYPRESS_IMS_CLIENT_SECRET }}
 
+
   cypress-b2b-saas-run:
     if: always()
     needs: cypress-b2b-saas-groups


### PR DESCRIPTION
Whitespace-only change (one blank line) to trigger a fresh CI run and get a baseline of the B2B SaaS E2E suite on the current tip of `b2b`. Last recorded run on `b2b` was 2026-08-11.

Not intended to be merged.

Test URLs:
- Before: https://b2b--boilerplate-b2b-accs--adobe-commerce.aem.live/
- After: https://ci-b2b-e2e-baseline--boilerplate-b2b-accs--adobe-commerce.aem.live/

