### PR TITLE
USF-3080: Identify expand collapse states to SR

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -387,8 +387,8 @@ export default async function decorate(block) {
   /** Search */
   const searchFragment = document.createRange().createContextualFragment(`
   <div class="search-wrapper nav-tools-wrapper">
-    <button type="button" class="nav-search-button">${labels.Global?.Search ?? 'Search'}</button>
-    <div class="nav-search-input nav-search-panel nav-tools-panel">
+    <button type="button" class="nav-search-button" aria-haspopup="dialog" aria-expanded="false" aria-controls="search-panel">${labels.Global?.Search ?? 'Search'}</button>
+    <div class="nav-search-input nav-search-panel nav-tools-panel" id="search-panel">
       <form id="search-bar-form"></form>
       <div class="search-bar-result" style="display: none;"></div>
     </div>
@@ -502,6 +502,10 @@ export default async function decorate(block) {
     }
 
     togglePanel(searchPanel, state);
+    searchButton.setAttribute(
+      'aria-expanded',
+      searchPanel.classList.contains('nav-tools-panel--show') ? 'true' : 'false',
+    );
     if (state) searchForm?.querySelector('input')?.focus();
   }
 


### PR DESCRIPTION
Identify expand collapse states to screen readers.

Test URLs:
- Before: https://main--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://usf-3080-new--aem-boilerplate-commerce--hlxsites.aem.live/

