### PR TITLE
PAY-6967: Fix payment buttons reverting to Place Order on reload

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -237,12 +237,26 @@ export default async function decorate(block) {
     renderGiftOptions($giftOptions),
   ]);
 
+  const EXPRESS_PAYMENT_METHODS = [
+    paymentsApi.PaymentMethodCode.PAYPAL_BUTTONS,
+    paymentsApi.PaymentMethodCode.APPLE_PAY,
+    paymentsApi.PaymentMethodCode.GOOGLE_PAY,
+  ];
+
+  const isExpressPaymentMethod = (method) => (
+    method && EXPRESS_PAYMENT_METHODS.includes(method.code)
+  );
+
   async function initializeCheckout(data) {
     await initReCaptcha(0);
     if (data.isGuest) await displayGuestAddressForms(data);
     else {
       removeOverlaySpinner(loaderRef, $loader, $loaderStatus);
       await displayCustomerAddressForms(data);
+    }
+    if (!isExpressPaymentMethod(data.selectedPaymentMethod) && !isPlaceOrderRendered($placeOrder)) {
+      // Express payment methods replace the place order button; restore it for non-express methods
+      await renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
     }
   }
 
@@ -314,25 +328,9 @@ export default async function decorate(block) {
     window.location.reload();
   }
 
-  const EXPRESS_PAYMENT_METHODS = [
-    paymentsApi.PaymentMethodCode.PAYPAL_BUTTONS,
-    paymentsApi.PaymentMethodCode.APPLE_PAY,
-    paymentsApi.PaymentMethodCode.GOOGLE_PAY,
-  ];
-
-  const isExpressPaymentMethod = (method) => (
-    method && EXPRESS_PAYMENT_METHODS.includes(method.code)
-  );
-
   function handleCheckoutValues(payload) {
-    const { isBillToShipping, selectedPaymentMethod } = payload;
+    const { isBillToShipping } = payload;
     $billingForm.style.display = isBillToShipping ? 'none' : 'block';
-
-    if (!isExpressPaymentMethod(selectedPaymentMethod)
-        && !isPlaceOrderRendered($placeOrder)) {
-      // Express payment methods replace the place order button; restore it for non-express methods
-      renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
-    }
   }
 
   async function handleOrderPlaced(orderData) {


### PR DESCRIPTION
## How to reproduce

1. Go to checkout as a logged-in customer.
2. Select Apple Pay (or Google Pay or PayPal). Page should look like "Expected" below.
3. Reload the page.

| Expected behavior | Actual behavior |
|----------|--------|
| <img width="726" height="832" alt="CleanShot 2026-09-01 at 13 58 55" src="https://github.com/user-attachments/assets/dd3855a3-cb81-4a2b-9125-0ba63a2cc864" /> | <img width="727" height="833" alt="CleanShot 2026-09-01 at 13 59 23" src="https://github.com/user-attachments/assets/29530a59-fc3e-4779-a8cf-c6f9c35258e0" /> |

## Root cause

When we relocated the APS payment buttons to the bottom of the checkout page in https://github.com/hlxsites/aem-boilerplate-commerce/pull/1398, the logic that restores the default "Place order" button (after switching back from an express payment method) was anchored to the `checkout/values` event.

On page reload, `checkout/values` fires repeatedly with `selectedPaymentMethod: undefined` while the various checkout forms initialize, before eventually firing with the correct, persisted payment method. The Apple Pay button mounts correctly in response to `checkout/updated`, but the very next (stale) `checkout/values` firing sees `selectedPaymentMethod: undefined`, treats that as "no express method selected," and immediately reverts it back to "Place order" - before `checkout/values` eventually catches up with the correct payment method code:

```
checkout/values    → selectedPaymentMethod: undefined
checkout/updated   → selectedPaymentMethod: payment_services_paypal_apple_pay (Apple Pay button mounts)
checkout/values    → selectedPaymentMethod: undefined  ← reverts to Place order
checkout/values    → selectedPaymentMethod: undefined
checkout/values    → selectedPaymentMethod: undefined
checkout/values    → selectedPaymentMethod: payment_services_paypal_apple_pay (too late - already reverted)
```

## Proposed fix

Anchor the restore logic to `checkout/updated` instead - the same event that drives the selected payment method's slot rendering, so the payment method code is already known at that point.

## Test URLs
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://fix-pay-btn-revert--aem-boilerplate-commerce--hlxsites.aem.live/
