### PR TITLE
Fix race condition that resets APS method to checkmo on reload

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -201,7 +201,7 @@ export default async function decorate(block) {
     shippingFormSkeleton,
     _billToShipping,
     _shippingMethods,
-    paymentMethods,
+    _paymentMethods,
     billingFormSkeleton,
     _orderSummary,
     _cartSummary,
@@ -345,27 +345,10 @@ export default async function decorate(block) {
     await renderCheckoutSuccess(block, { orderData });
   }
 
-  function handlePaymentServicesInitialized({ availablePaymentMethods }) {
-    availablePaymentMethods.forEach((code) => {
-      paymentMethods.setProps((prev) => ({
-        slots: {
-          Methods: {
-            ...prev.slots.Methods,
-            [code]: {
-              ...prev.slots.Methods[code],
-              enabled: !!prev.slots.Methods[code].render,
-            },
-          },
-        },
-      }));
-    });
-  }
-
   events.on('authenticated', handleAuthenticated);
   events.on('checkout/initialized', handleCheckoutUpdated, { eager: true });
   events.on('checkout/updated', handleCheckoutUpdated);
   events.on('checkout/values', handleCheckoutValues);
-  events.on('payment-services/initialized/checkout', handlePaymentServicesInitialized, { eager: true });
   events.on('order/placed', handleOrderPlaced);
   events.on('cart/initialized', redirectToCartIfEmpty, { eager: true });
   events.on('cart/data', redirectToCartIfEmpty);

--- a/blocks/commerce-checkout/containers.js
+++ b/blocks/commerce-checkout/containers.js
@@ -339,6 +339,18 @@ export const renderShippingMethods = async (container) => renderContainer(
 );
 
 /**
+ * Resolves with the payment method codes Payment Services has confirmed are available
+ * for checkout, waiting for its initialization event if it hasn't fired yet.
+ * @returns {Promise<string[]>}
+ */
+const getAvailablePaymentServicesMethods = () => new Promise((resolve) => {
+  const subscription = events.on('payment-services/initialized/checkout', ({ availablePaymentMethods }) => {
+    subscription?.off();
+    resolve(availablePaymentMethods);
+  }, { eager: true });
+});
+
+/**
  * Renders payment methods with credit card integration - original regular checkout functionality
  * @param {HTMLElement} paymentMethodsContainer - DOM element to render payment methods in
  * @param {HTMLElement} placeOrderButtonContainer - DOM element express payment buttons mount into,
@@ -352,110 +364,114 @@ export const renderPaymentMethods = async (
   validateCheckoutForms,
 ) => renderContainer(
   CONTAINERS.PAYMENT_METHODS,
-  async () => CheckoutProvider.render(PaymentMethods, {
-    slots: {
-      Methods: {
-        [PaymentMethodCode.CREDIT_CARD]: {
-          render: (ctx) => {
-            const $creditCard = document.createElement('div');
+  async () => {
+    const availablePaymentServicesMethods = await getAvailablePaymentServicesMethods();
 
-            PaymentServices.render(CreditCard)($creditCard);
+    return CheckoutProvider.render(PaymentMethods, {
+      slots: {
+        Methods: {
+          [PaymentMethodCode.CREDIT_CARD]: {
+            render: (ctx) => {
+              const $creditCard = document.createElement('div');
 
-            ctx.replaceHTML($creditCard);
+              PaymentServices.render(CreditCard)($creditCard);
+
+              ctx.replaceHTML($creditCard);
+            },
+            enabled: availablePaymentServicesMethods.includes(PaymentMethodCode.CREDIT_CARD),
           },
-          enabled: false,
-        },
-        [PaymentMethodCode.FASTLANE]: {
-          enabled: false,
-        },
-        [PaymentMethodCode.PAYPAL_BUTTONS]: {
-          render: (ctx) => {
-            mountPlaceOrderSlot((el) => PaymentServices.render(PayPalButtons, {
-              onButtonClick: (showPaymentSheet) => {
-                if (validateCheckoutForms()) {
-                  showPaymentSheet();
-                }
-              },
-              onSuccess: ({ cartId }) => {
-                orderApi.placeOrder(cartId);
-              },
-              onError: (localizedError) => {
-                events.emit('checkout/error', {
-                  message: localizedError.message,
-                });
-              },
-            })(el), placeOrderButtonContainer);
-
-            ctx.replaceHTML(createExpressPaymentNotice('PayPal'));
+          [PaymentMethodCode.FASTLANE]: {
+            enabled: false,
           },
-          enabled: false,
-        },
-        [PaymentMethodCode.APPLE_PAY]: {
-          render: (ctx) => {
-            const checkoutData = events.lastPayload('checkout/updated')
-              || events.lastPayload('checkout/initialized')
-              || null;
+          [PaymentMethodCode.PAYPAL_BUTTONS]: {
+            render: (ctx) => {
+              mountPlaceOrderSlot((el) => PaymentServices.render(PayPalButtons, {
+                onButtonClick: (showPaymentSheet) => {
+                  if (validateCheckoutForms()) {
+                    showPaymentSheet();
+                  }
+                },
+                onSuccess: ({ cartId }) => {
+                  orderApi.placeOrder(cartId);
+                },
+                onError: (localizedError) => {
+                  events.emit('checkout/error', {
+                    message: localizedError.message,
+                  });
+                },
+              })(el), placeOrderButtonContainer);
 
-            if (checkoutData === null) {
-              console.error('Cannot render apple pay button without checkout data.');
-              unmountPlaceOrderSlot();
-              ctx.replaceHTML(document.createElement('div'));
-              return;
-            }
-
-            mountPlaceOrderSlot((el) => PaymentServices.render(ApplePay, {
-              location: PaymentLocation.CHECKOUT,
-              getCartId: () => ctx.cartId,
-              isVirtualCart: checkoutData.isVirtual,
-              onButtonClick: (showPaymentSheet) => {
-                if (validateCheckoutForms()) {
-                  showPaymentSheet();
-                }
-              },
-              onSuccess: ({ cartId }) => orderApi.placeOrder(cartId),
-              onError: (localizedError) => {
-                events.emit('checkout/error', {
-                  message: localizedError.message,
-                });
-              },
-            })(el), placeOrderButtonContainer);
-
-            ctx.replaceHTML(createExpressPaymentNotice('Apple Pay'));
+              ctx.replaceHTML(createExpressPaymentNotice('PayPal'));
+            },
+            enabled: availablePaymentServicesMethods.includes(PaymentMethodCode.PAYPAL_BUTTONS),
           },
-          enabled: false,
-        },
-        [PaymentMethodCode.APM]: {
-          enabled: false,
-        },
-        [PaymentMethodCode.GOOGLE_PAY]: {
-          render: (ctx) => {
-            mountPlaceOrderSlot((el) => PaymentServices.render(GooglePay, {
-              onButtonClick: (showPaymentSheet) => {
-                if (validateCheckoutForms()) {
-                  showPaymentSheet();
-                }
-              },
-              onSuccess: ({ cartId }) => orderApi.placeOrder(cartId),
-              onError: (localizedError) => {
-                events.emit('checkout/error', {
-                  message: localizedError.message,
-                });
-              },
-            })(el), placeOrderButtonContainer);
+          [PaymentMethodCode.APPLE_PAY]: {
+            render: (ctx) => {
+              const checkoutData = events.lastPayload('checkout/updated')
+                || events.lastPayload('checkout/initialized')
+                || null;
 
-            ctx.replaceHTML(createExpressPaymentNotice('Google Pay'));
+              if (checkoutData === null) {
+                console.error('Cannot render apple pay button without checkout data.');
+                unmountPlaceOrderSlot();
+                ctx.replaceHTML(document.createElement('div'));
+                return;
+              }
+
+              mountPlaceOrderSlot((el) => PaymentServices.render(ApplePay, {
+                location: PaymentLocation.CHECKOUT,
+                getCartId: () => ctx.cartId,
+                isVirtualCart: checkoutData.isVirtual,
+                onButtonClick: (showPaymentSheet) => {
+                  if (validateCheckoutForms()) {
+                    showPaymentSheet();
+                  }
+                },
+                onSuccess: ({ cartId }) => orderApi.placeOrder(cartId),
+                onError: (localizedError) => {
+                  events.emit('checkout/error', {
+                    message: localizedError.message,
+                  });
+                },
+              })(el), placeOrderButtonContainer);
+
+              ctx.replaceHTML(createExpressPaymentNotice('Apple Pay'));
+            },
+            enabled: availablePaymentServicesMethods.includes(PaymentMethodCode.APPLE_PAY),
           },
-          enabled: false,
-        },
-        [PaymentMethodCode.VAULT]: {
-          enabled: false,
-        },
-        [PaymentMethodCode.FASTLANE]: {
-          enabled: false,
+          [PaymentMethodCode.APM]: {
+            enabled: false,
+          },
+          [PaymentMethodCode.GOOGLE_PAY]: {
+            render: (ctx) => {
+              mountPlaceOrderSlot((el) => PaymentServices.render(GooglePay, {
+                onButtonClick: (showPaymentSheet) => {
+                  if (validateCheckoutForms()) {
+                    showPaymentSheet();
+                  }
+                },
+                onSuccess: ({ cartId }) => orderApi.placeOrder(cartId),
+                onError: (localizedError) => {
+                  events.emit('checkout/error', {
+                    message: localizedError.message,
+                  });
+                },
+              })(el), placeOrderButtonContainer);
+
+              ctx.replaceHTML(createExpressPaymentNotice('Google Pay'));
+            },
+            enabled: availablePaymentServicesMethods.includes(PaymentMethodCode.GOOGLE_PAY),
+          },
+          [PaymentMethodCode.VAULT]: {
+            enabled: false,
+          },
+          [PaymentMethodCode.FASTLANE]: {
+            enabled: false,
+          },
         },
       },
-    },
-  })(paymentMethodsContainer),
+    })(paymentMethodsContainer);
+  },
 );
 
 /**


### PR DESCRIPTION
## Context

We render `PaymentMethods` with every APS method as `enabled: false`, then flip the ones present in the `payment-services/initialized/checkout` event's `availablePaymentMethods` to `enabled: true` once the APS dropin reports which methods are enabled on the checkout page.

## Issue

If `PaymentMethods` renders before that report arrives, none of those methods are enabled yet, so the checkout dropin's own reconciliation falls back to the first already-enabled method, in our ACCS Barna Scouts QA instance, `checkmo`. By the time the APS dropin finishes initializing and we enable the real methods, it's too late: the cart's payment method has already been reset to `checkmo`, and whatever APS method was selected before the reload gets lost.

## How to reproduce

1. In your browser developer tab, activate network throttling. Slow 4G does the trick for me.
2. Navigate to the checkout page and select one of the APS methods, say, Apple Pay.
3. Reload the page. As soon as "Check / Money order" (`checkmo`) starts rendering, reload again.

| Expected behavior                               | Actual behavior                                                |
|-------------------------------------------------|----------------------------------------------------------------|
| Apple Pay stays selected even after the reload. | The selected payment method is reset to "Check / Money order". |

## Proposed fix

This PR fixes it by waiting for APS to finalize initializing _before_ rendering `PaymentMethods` at all, instead of rendering it upfront and patching the `enabled` flags in afterwards. That way, `PaymentMethods`'s very first render already has the complete, correct list of enabled methods, so the reconciliation never has an incomplete list to fall back against.

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://fix-aps-checkmo-reset--aem-boilerplate-commerce--hlxsites.aem.live/
