### PR TITLE
[DO NOT MERGE] Evidence: baseline PSI/LCP on /customer/orders is pre-existing

### DIFF
--- a/blocks/commerce-orders-list/README.md
+++ b/blocks/commerce-orders-list/README.md
@@ -54,3 +54,7 @@ No events are emitted by this block. -->
 - **Image Rendering Errors**: If product images fail to load, the image slots handle fallback behavior
 - **Container Errors**: If the OrdersList container fails to render, the block content remains empty
 - **Fallback Behavior**: Always falls back to full view mode if configuration is invalid
+
+### Known Issues
+
+- Anonymous PSI/Lighthouse runs against this route measure the pre-redirect empty shell (LCP = footer legal text), not the real experience; authenticated users see LCP ~1.5-2.7s. Pre-existing, not tied to any single feature change — see PR #1402/#1422 discussion.


### PR DESCRIPTION
## What this is

**Draft, not for merging.** Doc-only change to `blocks/commerce-orders-list/README.md`, used only to open a branch and trigger `aem-psi-check` against an unmodified `/customer/orders` page, so the CI badge itself (not just local Lighthouse runs) confirms the failing score predates any feature work.

Supersedes #1436 and #1437: both used branch names too long once combined with `--aem-boilerplate-commerce--hlxsites` (AEM's preview hostname is a single DNS label, max 63 chars), so the preview never published and the check failed with `FAILED_DOCUMENT_REQUEST` / `ERR_CONNECTION_FAILED`. Re-created here with a short branch name (`psi-baseline-orders`, verified to resolve and return HTTP 200 before opening this PR).

## Context

PR #1402 (USF-4291, order search) and PR #1422 (attempted fix) both failed `aem-psi-check` on mobile `/customer/orders` (score ~76-89, needs >=90). Investigation showed this reproduces identically on commits that predate all USF-4291 work — it's architectural (auth-gated page + eager static-import chain racing the anonymous redirect), not caused by any specific PR. This branch is the control: zero functional diff from `integration`, same page, to demonstrate the score fails here too.

Test URLs
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders
- After: https://psi-baseline-orders--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders

## Expected outcome

`aem-psi-check` should fail on mobile here too, with a similar score/LCP profile, confirming the issue is pre-existing and not introduced by #1402 or fixable at the boilerplate level without the risks already tried in #1422.