### PR TITLE
[DO NOT MERGE] A/B: eager-phase redirect for /customer/orders PSI (vs #1422)

### DIFF
--- a/blocks/commerce-orders-list/commerce-orders-list.js
+++ b/blocks/commerce-orders-list/commerce-orders-list.js
@@ -1,6 +1,3 @@
-import { render as accountRenderer } from '@dropins/storefront-account/render.js';
-import { OrdersList } from '@dropins/storefront-account/containers/OrdersList.js';
-import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 import {
   checkIsAuthenticated,
@@ -13,10 +10,12 @@ import {
   getProductLink,
 } from '../../scripts/commerce.js';
 
-// Initialize
-import '../../scripts/initializers/account.js';
-
 export default async function decorate(block) {
+  if (!checkIsAuthenticated()) {
+    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
+    return;
+  }
+
   const { 'minified-view': minifiedViewConfig = 'false' } = readBlockConfig(block);
   const createProductLink = (productData) => {
     // If product is null/undefined, it's been deleted from catalog
@@ -32,39 +31,47 @@ export default async function decorate(block) {
     return rootLink('#');
   };
 
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    await accountRenderer.render(OrdersList, {
-      minifiedView: minifiedViewConfig === 'true',
-      routeTracking: ({ carrier, number }) => {
-        if (carrier === 'ups') {
-          return `${UPS_TRACKING_URL}?tracknum=${number}`;
-        }
-        return '';
-      },
-      routeOrdersList: () => rootLink(CUSTOMER_ORDERS_PATH),
-      routeOrderDetails: (orderNumber) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
-      routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
-      routeOrderProduct: createProductLink,
-      slots: {
-        OrderItemImage: (ctx) => {
-          const { data, defaultImageProps } = ctx;
-          const anchor = document.createElement('a');
-          anchor.href = createProductLink(ctx.data);
+  // Load the drop-in lazily, after the guard, so logged-out users don't download it.
+  const [
+    { render: accountRenderer },
+    { OrdersList },
+    { tryRenderAemAssetsImage },
+  ] = await Promise.all([
+    import('@dropins/storefront-account/render.js'),
+    import('@dropins/storefront-account/containers/OrdersList.js'),
+    import('@dropins/tools/lib/aem/assets.js'),
+    import('../../scripts/initializers/account.js'),
+  ]);
 
-          tryRenderAemAssetsImage(ctx, {
-            alias: data.product.sku,
-            imageProps: defaultImageProps,
-            wrapper: anchor,
+  await accountRenderer.render(OrdersList, {
+    minifiedView: minifiedViewConfig === 'true',
+    routeTracking: ({ carrier, number }) => {
+      if (carrier === 'ups') {
+        return `${UPS_TRACKING_URL}?tracknum=${number}`;
+      }
+      return '';
+    },
+    routeOrdersList: () => rootLink(CUSTOMER_ORDERS_PATH),
+    routeOrderDetails: (orderNumber) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
+    routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
+    routeOrderProduct: createProductLink,
+    slots: {
+      OrderItemImage: (ctx) => {
+        const { data, defaultImageProps } = ctx;
+        const anchor = document.createElement('a');
+        anchor.href = createProductLink(ctx.data);
 
-            params: {
-              width: defaultImageProps.width,
-              height: defaultImageProps.height,
-            },
-          });
-        },
+        tryRenderAemAssetsImage(ctx, {
+          alias: data.product.sku,
+          imageProps: defaultImageProps,
+          wrapper: anchor,
+
+          params: {
+            width: defaultImageProps.width,
+            height: defaultImageProps.height,
+          },
+        });
       },
-    })(block);
-  }
+    },
+  })(block);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -20,6 +20,16 @@ import {
   decorateSections,
   IS_UE,
   IS_DA,
+  checkIsAuthenticated,
+  rootLink,
+  CUSTOMER_LOGIN_PATH,
+  CUSTOMER_ACCOUNT_PATH,
+  CUSTOMER_ORDERS_PATH,
+  CUSTOMER_ORDER_DETAILS_PATH,
+  CUSTOMER_RETURNS_PATH,
+  CUSTOMER_RETURN_DETAILS_PATH,
+  CUSTOMER_CREATE_RETURN_PATH,
+  CUSTOMER_ADDRESS_PATH,
 } from './commerce.js';
 
 /*
@@ -257,7 +267,33 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
+// Account routes that require a signed-in customer.
+const AUTH_GATED_PATHS = [
+  CUSTOMER_ACCOUNT_PATH,
+  CUSTOMER_ORDERS_PATH,
+  CUSTOMER_ORDER_DETAILS_PATH,
+  CUSTOMER_RETURNS_PATH,
+  CUSTOMER_RETURN_DETAILS_PATH,
+  CUSTOMER_CREATE_RETURN_PATH,
+  CUSTOMER_ADDRESS_PATH,
+];
+
+// Redirect logged-out visitors before the page renders, instead of after the block loads.
+function shouldRedirectToLogin() {
+  if (IS_UE || IS_DA) return false;
+  const { pathname } = window.location;
+  const gated = AUTH_GATED_PATHS.some((p) => {
+    const rp = rootLink(p);
+    return pathname === rp || pathname.startsWith(`${rp}/`);
+  });
+  return gated && !checkIsAuthenticated();
+}
+
 async function loadPage() {
+  if (shouldRedirectToLogin()) {
+    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
+    return;
+  }
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();


### PR DESCRIPTION
**Draft, A/B experiment vs #1422. Not for merge.**

Same base and same block-level change as #1422, plus one extra commit: an eager-phase redirect in `scripts.js` `loadPage()` that sends logged-out visitors to login before the page renders (guarded by `IS_UE || IS_DA` so it doesn't break Universal Editor / Document Authoring previews).

Purpose: measure whether redirecting in the eager phase moves mobile PSI on `/customer/orders`. #1422 (block-only) lands ~78 because the LCP element is the footer, which renders regardless of the dropin download. This version redirects before the footer renders, so Lighthouse should follow to `/customer/login` or capture an earlier state.

Diff vs #1422: `scripts/scripts.js` only (+36 lines).

Known limitation (from Codex review): `rootLink()` runs before commerce init, so localized routes like `/fr/customer/orders` are not matched by the eager guard and non-account pages may log config warnings. Left as-is here to keep the A/B isolated to the score effect; would be fixed before any real merge.

Test (logged out):
- This branch: https://orders-lcp-eager--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders
- Compare to #1422: https://fix-orders-lcp-guard--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders
