### PR TITLE
[PoC] Consolidated account auth guard + eager login redirect

### DIFF
--- a/blocks/commerce-addresses/commerce-addresses.js
+++ b/blocks/commerce-addresses/commerce-addresses.js
@@ -3,8 +3,7 @@ import { render as accountRenderer } from '@dropins/storefront-account/render.js
 import { readBlockConfig } from '../../scripts/aem.js';
 import {
   CUSTOMER_ADDRESS_PATH,
-  CUSTOMER_LOGIN_PATH,
-  checkIsAuthenticated,
+  redirectIfUnauthenticated,
   rootLink,
 } from '../../scripts/commerce.js';
 
@@ -12,18 +11,16 @@ import {
 import '../../scripts/initializers/account.js';
 
 export default async function decorate(block) {
+  if (redirectIfUnauthenticated()) return;
+
   const {
     'minified-view': minifiedViewConfig = 'false',
   } = readBlockConfig(block);
 
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    await accountRenderer.render(Addresses, {
-      minifiedView: minifiedViewConfig === 'true',
-      withActionsInMinifiedView: false,
-      withActionsInFullSizeView: true,
-      routeAddressesPage: () => rootLink(CUSTOMER_ADDRESS_PATH),
-    })(block);
-  }
+  await accountRenderer.render(Addresses, {
+    minifiedView: minifiedViewConfig === 'true',
+    withActionsInMinifiedView: false,
+    withActionsInFullSizeView: true,
+    routeAddressesPage: () => rootLink(CUSTOMER_ADDRESS_PATH),
+  })(block);
 }

--- a/blocks/commerce-customer-information/commerce-customer-information.js
+++ b/blocks/commerce-customer-information/commerce-customer-information.js
@@ -1,18 +1,11 @@
 import CustomerInformation from '@dropins/storefront-account/containers/CustomerInformation.js';
 import { render as accountRenderer } from '@dropins/storefront-account/render.js';
-import {
-  CUSTOMER_LOGIN_PATH,
-  checkIsAuthenticated,
-  rootLink,
-} from '../../scripts/commerce.js';
+import { redirectIfUnauthenticated } from '../../scripts/commerce.js';
 
 // Initialize
 import '../../scripts/initializers/account.js';
 
 export default async function decorate(block) {
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    await accountRenderer.render(CustomerInformation, {})(block);
-  }
+  if (redirectIfUnauthenticated()) return;
+  await accountRenderer.render(CustomerInformation, {})(block);
 }

--- a/blocks/commerce-orders-list/commerce-orders-list.js
+++ b/blocks/commerce-orders-list/commerce-orders-list.js
@@ -1,10 +1,6 @@
-import { render as accountRenderer } from '@dropins/storefront-account/render.js';
-import { OrdersList } from '@dropins/storefront-account/containers/OrdersList.js';
-import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 import {
-  checkIsAuthenticated,
-  CUSTOMER_LOGIN_PATH,
+  redirectIfUnauthenticated,
   CUSTOMER_ORDER_DETAILS_PATH,
   CUSTOMER_ORDERS_PATH,
   CUSTOMER_RETURN_DETAILS_PATH,
@@ -13,10 +9,9 @@ import {
   getProductLink,
 } from '../../scripts/commerce.js';
 
-// Initialize
-import '../../scripts/initializers/account.js';
-
 export default async function decorate(block) {
+  if (redirectIfUnauthenticated()) return;
+
   const {
     'minified-view': minifiedViewConfig = 'false',
     search: searchConfig = 'true',
@@ -35,43 +30,52 @@ export default async function decorate(block) {
     return rootLink('#');
   };
 
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    await accountRenderer.render(OrdersList, {
-      minifiedView: minifiedViewConfig === 'true',
-      // OrdersList defaults search off; enable it here.
-      withSearch: searchConfig === 'true',
-      // Search all orders, not just the selected date range.
-      searchScope: 'allOrders',
-      routeTracking: ({ carrier, number }) => {
-        if (carrier === 'ups') {
-          return `${UPS_TRACKING_URL}?tracknum=${number}`;
-        }
-        return '';
-      },
-      routeOrdersList: () => rootLink(CUSTOMER_ORDERS_PATH),
-      routeOrderDetails: (orderNumber) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
-      routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
-      routeOrderProduct: createProductLink,
-      slots: {
-        OrderItemImage: (ctx) => {
-          const { data, defaultImageProps } = ctx;
-          const anchor = document.createElement('a');
-          anchor.href = createProductLink(ctx.data);
+  // Load the account drop-in only after the auth guard, so logged-out visitors
+  // don't download the storefront-account + tools + preact chain to be redirected.
+  const [
+    { render: accountRenderer },
+    { OrdersList },
+    { tryRenderAemAssetsImage },
+  ] = await Promise.all([
+    import('@dropins/storefront-account/render.js'),
+    import('@dropins/storefront-account/containers/OrdersList.js'),
+    import('@dropins/tools/lib/aem/assets.js'),
+    import('../../scripts/initializers/account.js'),
+  ]);
 
-          tryRenderAemAssetsImage(ctx, {
-            alias: data.product.sku,
-            imageProps: defaultImageProps,
-            wrapper: anchor,
+  await accountRenderer.render(OrdersList, {
+    minifiedView: minifiedViewConfig === 'true',
+    // OrdersList defaults search off; enable it here.
+    withSearch: searchConfig === 'true',
+    // Search all orders, not just the selected date range.
+    searchScope: 'allOrders',
+    routeTracking: ({ carrier, number }) => {
+      if (carrier === 'ups') {
+        return `${UPS_TRACKING_URL}?tracknum=${number}`;
+      }
+      return '';
+    },
+    routeOrdersList: () => rootLink(CUSTOMER_ORDERS_PATH),
+    routeOrderDetails: (orderNumber) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
+    routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
+    routeOrderProduct: createProductLink,
+    slots: {
+      OrderItemImage: (ctx) => {
+        const { data, defaultImageProps } = ctx;
+        const anchor = document.createElement('a');
+        anchor.href = createProductLink(ctx.data);
 
-            params: {
-              width: defaultImageProps.width,
-              height: defaultImageProps.height,
-            },
-          });
-        },
+        tryRenderAemAssetsImage(ctx, {
+          alias: data.product.sku,
+          imageProps: defaultImageProps,
+          wrapper: anchor,
+
+          params: {
+            width: defaultImageProps.width,
+            height: defaultImageProps.height,
+          },
+        });
       },
-    })(block);
-  }
+    },
+  })(block);
 }

--- a/blocks/commerce-returns-list/commerce-returns-list.js
+++ b/blocks/commerce-returns-list/commerce-returns-list.js
@@ -3,12 +3,11 @@ import ReturnsList from '@dropins/storefront-order/containers/ReturnsList.js';
 import { tryRenderAemAssetsImage } from '@dropins/tools/lib/aem/assets.js';
 import { readBlockConfig } from '../../scripts/aem.js';
 import {
-  CUSTOMER_LOGIN_PATH,
   CUSTOMER_ORDER_DETAILS_PATH,
   CUSTOMER_RETURN_DETAILS_PATH,
   CUSTOMER_RETURNS_PATH,
   UPS_TRACKING_URL,
-  checkIsAuthenticated,
+  redirectIfUnauthenticated,
   rootLink,
   getProductLink,
 } from '../../scripts/commerce.js';
@@ -17,39 +16,37 @@ import {
 import '../../scripts/initializers/order.js';
 
 export default async function decorate(block) {
+  if (redirectIfUnauthenticated()) return;
+
   const {
     'minified-view': minifiedViewConfig = 'false',
   } = readBlockConfig(block);
 
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    await orderRenderer.render(ReturnsList, {
-      minifiedView: minifiedViewConfig === 'true',
-      slots: {
-        ReturnListImage: (ctx) => {
-          const { data, defaultImageProps } = ctx;
-          tryRenderAemAssetsImage(ctx, {
-            alias: data.product.sku,
-            imageProps: defaultImageProps,
+  await orderRenderer.render(ReturnsList, {
+    minifiedView: minifiedViewConfig === 'true',
+    slots: {
+      ReturnListImage: (ctx) => {
+        const { data, defaultImageProps } = ctx;
+        tryRenderAemAssetsImage(ctx, {
+          alias: data.product.sku,
+          imageProps: defaultImageProps,
 
-            params: {
-              width: defaultImageProps.width,
-              height: defaultImageProps.height,
-            },
-          });
-        },
+          params: {
+            width: defaultImageProps.width,
+            height: defaultImageProps.height,
+          },
+        });
       },
-      routeTracking: ({ carrier, number }) => {
-        if (carrier?.toLowerCase() === 'ups') {
-          return `${UPS_TRACKING_URL}?tracknum=${number}`;
-        }
-        return '';
-      },
-      routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
-      routeOrderDetails: ({ orderNumber }) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
-      routeReturnsList: () => rootLink(CUSTOMER_RETURNS_PATH),
-      routeProductDetails: (productData) => (productData?.product ? getProductLink(productData.product.urlKey, productData.product.sku) : rootLink('#')),
-    })(block);
-  }
+    },
+    routeTracking: ({ carrier, number }) => {
+      if (carrier?.toLowerCase() === 'ups') {
+        return `${UPS_TRACKING_URL}?tracknum=${number}`;
+      }
+      return '';
+    },
+    routeReturnDetails: ({ orderNumber, returnNumber }) => rootLink(`${CUSTOMER_RETURN_DETAILS_PATH}?orderRef=${orderNumber}&returnRef=${returnNumber}`),
+    routeOrderDetails: ({ orderNumber }) => rootLink(`${CUSTOMER_ORDER_DETAILS_PATH}?orderRef=${orderNumber}`),
+    routeReturnsList: () => rootLink(CUSTOMER_RETURNS_PATH),
+    routeProductDetails: (productData) => (productData?.product ? getProductLink(productData.product.urlKey, productData.product.sku) : rootLink('#')),
+  })(block);
 }

--- a/blocks/commerce-seller-assisted-buying-activity/commerce-seller-assisted-buying-activity.js
+++ b/blocks/commerce-seller-assisted-buying-activity/commerce-seller-assisted-buying-activity.js
@@ -1,18 +1,16 @@
 import { render as accountRenderer } from '@dropins/storefront-account/render.js';
 import { SellerAssistedBuyingActivity } from '@dropins/storefront-account/containers/SellerAssistedBuyingActivity.js';
-import { CUSTOMER_LOGIN_PATH, checkIsAuthenticated, rootLink } from '../../scripts/commerce.js';
+import { redirectIfUnauthenticated } from '../../scripts/commerce.js';
 
 // Initialize
 import '../../scripts/initializers/account.js';
 
 export default async function decorate(block) {
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    const container = document.createElement('div');
-    await accountRenderer.render(SellerAssistedBuyingActivity, {
-      withWrapper: false,
-    })(container);
-    block.appendChild(container);
-  }
+  if (redirectIfUnauthenticated()) return;
+
+  const container = document.createElement('div');
+  await accountRenderer.render(SellerAssistedBuyingActivity, {
+    withWrapper: false,
+  })(container);
+  block.appendChild(container);
 }

--- a/blocks/commerce-seller-assisted-buying-settings/commerce-seller-assisted-buying-settings.js
+++ b/blocks/commerce-seller-assisted-buying-settings/commerce-seller-assisted-buying-settings.js
@@ -1,16 +1,14 @@
 import { render as accountRenderer } from '@dropins/storefront-account/render.js';
 import { SellerAssistedBuyingSettings } from '@dropins/storefront-account/containers/SellerAssistedBuyingSettings.js';
-import { CUSTOMER_LOGIN_PATH, checkIsAuthenticated, rootLink } from '../../scripts/commerce.js';
+import { redirectIfUnauthenticated } from '../../scripts/commerce.js';
 
 // Initialize
 import '../../scripts/initializers/account.js';
 
 export default async function decorate(block) {
-  if (!checkIsAuthenticated()) {
-    window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
-  } else {
-    const container = document.createElement('div');
-    await accountRenderer.render(SellerAssistedBuyingSettings, {})(container);
-    block.appendChild(container);
-  }
+  if (redirectIfUnauthenticated()) return;
+
+  const container = document.createElement('div');
+  await accountRenderer.render(SellerAssistedBuyingSettings, {})(container);
+  block.appendChild(container);
 }

--- a/scripts/commerce.js
+++ b/scripts/commerce.js
@@ -854,6 +854,44 @@ export function checkIsAuthenticated() {
   return !!getCookie('auth_dropin_user_token') ?? false;
 }
 
+// Guest-capable routes (order/return details, create-return) are excluded so
+// their guest-token flows still work.
+export const AUTH_GATED_PATHS = [
+  CUSTOMER_ACCOUNT_PATH,
+  CUSTOMER_ORDERS_PATH,
+  CUSTOMER_RETURNS_PATH,
+  CUSTOMER_ADDRESS_PATH,
+];
+
+/**
+ * Login URL for a logged-out visitor if `pathname` is an auth-gated account route,
+ * else null. Works before commerce init (no getRootPath) and handles localized
+ * stores (/fr/customer/orders -> /fr/customer/login). Splitting on `/` and `\` then
+ * rejoining keeps the result same-origin (no protocol-relative off-origin redirect).
+ * @param {string} [pathname]
+ * @returns {string|null}
+ */
+export function authGatedLoginRedirect(pathname = window.location.pathname) {
+  const segs = pathname.split(/[/\\]/).filter(Boolean);
+  const ci = segs.indexOf('customer');
+  const leaf = ci === -1 ? undefined : segs[ci + 1];
+  if (!leaf || !AUTH_GATED_PATHS.includes(`${CUSTOMER_PATH}/${leaf}`)) return null;
+  const localePrefix = ci > 0 ? `/${segs.slice(0, ci).join('/')}` : '';
+  return `${localePrefix}${CUSTOMER_LOGIN_PATH}`;
+}
+
+/**
+ * Block guard: redirect a logged-out visitor to login, returning true so the caller
+ * stops. No-op in UE/DA authoring (no auth cookie) so authors can edit the page.
+ * @returns {boolean}
+ */
+export function redirectIfUnauthenticated() {
+  if (IS_UE || IS_DA) return false;
+  if (checkIsAuthenticated()) return false;
+  window.location.href = rootLink(CUSTOMER_LOGIN_PATH);
+  return true;
+}
+
 /**
  * Check if consent was given for a specific topic.
  * @param {*} topic Topic identifier

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -20,6 +20,8 @@ import {
   decorateSections,
   IS_UE,
   IS_DA,
+  checkIsAuthenticated,
+  authGatedLoginRedirect,
 } from './commerce.js';
 
 /*
@@ -258,6 +260,15 @@ function loadDelayed() {
 }
 
 async function loadPage() {
+  // Redirect logged-out shoppers off account routes before render so they don't
+  // paint an account shell; block guards are the fallback. Skip UE/DA authoring.
+  if (!IS_UE && !IS_DA && !checkIsAuthenticated()) {
+    const loginUrl = authGatedLoginRedirect();
+    if (loginUrl) {
+      window.location.href = loginUrl;
+      return;
+    }
+  }
   await loadEager(document);
   await loadLazy(document);
   loadDelayed();


### PR DESCRIPTION
**PoC:** Consolidates account-page auth gating and fixes the anonymous LCP on `/customer/*` routes. 
Original discussion: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1402#issuecomment-5508488507

## What it does
- **`commerce.js`** gains two helpers:
  - `redirectIfUnauthenticated()` - block-level guard, no-op in Universal Editor / Document Authoring so authors can edit account pages.
  - `authGatedLoginRedirect()` - config-free, locale-safe path matcher for the eager phase (works before commerce init, covers `/fr/customer/...`, collapses leading slashes so it can't become an off-origin redirect).
  - `AUTH_GATED_PATHS` lists only always-authenticated routes; guest-capable routes (order/return details, create-return) are excluded so their token flows keep working.
- **`scripts.js`** redirects logged-out visitors off gated routes before `loadEager()`, so anonymous users and crawlers don't paint an account shell they can't see.
- **6 account blocks** migrated from the duplicated `if (!checkIsAuthenticated()) redirect` to the shared guard. `commerce-orders-list` also dynamic-imports the account drop-in after the guard.

## Why
Anonymous PSI on `/customer/orders` fails because the page renders a footer-LCP shell before the block-level redirect fires. Concurrent A/B: eager redirect lands 86-88 vs block-only's noisy ~78. This centralizes the pattern (one authoring-aware source), fixes the locale bug, and removes the per-block duplication.

## Review
Test (logged out): https://account-auth-guard--aem-boilerplate-commerce--hlxsites.aem.page/customer/orders

Note: this does not by itself guarantee PSI >=90 (caps ~88); the last points need a drop-in eager skeleton or a PSI-policy change for auth-gated routes. The failing ACO tests are not related to this PR.
