### PR TITLE
Fix payment button reverts to place order on shipping form edits

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -254,8 +254,10 @@ export default async function decorate(block) {
       removeOverlaySpinner(loaderRef, $loader, $loaderStatus);
       await displayCustomerAddressForms(data);
     }
-    if (!isExpressPaymentMethod(data.selectedPaymentMethod) && !isPlaceOrderRendered($placeOrder)) {
-      // Express payment methods replace the place order button; restore it for non-express methods
+    // Express payment methods replace the place order button; restore it for non-express methods
+    if (data.selectedPaymentMethod?.code
+      && !isExpressPaymentMethod(data.selectedPaymentMethod)
+      && !isPlaceOrderRendered($placeOrder)) {
       await renderPlaceOrder($placeOrder, { handleValidation, handlePlaceOrder });
     }
   }


### PR DESCRIPTION
How to reproduce
- Go to checkout page as a guest customer
- Before filling in any form, scroll down to payment and select Apple Pay, Google Pay, or PayPal
- Observe how the vanilla place order button is replaced with the selected express payment button
- Scroll back up to the shipping address and fill in a few fields but leave many required inputs open
- Scroll back down to the payment section

Expected behavior
- The selected payment method's branded checkout button is still visible instead of the place order button

Actual behavior
- The button reverted to the place order button after the page sent `checkout/updated` events with empty payment method codes, which the current code reads as "not an express payment method, so the place order button needs to be restored."

Test URLs:
- Before: https://payment-services--aem-boilerplate-commerce--hlxsites.aem.live/
- After: https://pay-7073-bug--aem-boilerplate-commerce--hlxsites.aem.live/
