### PR TITLE
USF-3124 [Accessibility] - Programmatic label does not convey purpose of control - Product details (Product Details Page (PDP)) (Add to Cart button)

### DIFF
--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -255,7 +255,9 @@ export default async function decorate(block) {
   ]);
 
   // Configuration – Button - Add to Cart
+  const productName = product?.name || product?.sku;
   const addToCart = await UI.render(Button, {
+    'aria-label': `${labels.Global?.AddProductToCart} ${productName}`,
     children: labels.Global?.AddProductToCart,
     icon: h(Icon, { source: 'Cart' }),
     onClick: async () => {


### PR DESCRIPTION
## Summary
The Add to Cart button's accessible name was just "Add to Cart" with no product name, so screen reader users couldn't tell which product it applied to (WCAG 2.4.6). Added an aria-label with the product name, matching the pattern already used for the equivalent button on the product listing page. Visible button text is unchanged.

Test URLs
- Before: https://integration--aem-boilerplate-commerce--hlxsites.aem.page
- After: https://USF-3124--aem-boilerplate-commerce--hlxsites.aem.page