### PR TITLE
fix(commerce): support static AC-Price-Book-ID pricing without full Commerce/ACO backend (USF-4366)

### DIFF
--- a/scripts/initializers/auth.js
+++ b/scripts/initializers/auth.js
@@ -1,7 +1,7 @@
 import { initializers } from '@dropins/tools/initializer.js';
 import { initialize, setEndpoint } from '@dropins/storefront-auth/api.js';
 import { getConfigValue } from '@dropins/tools/lib/aem/configs.js';
-import { initializeDropin } from './index.js';
+import { initializeDropin, isStaticPriceBookEnabled } from './index.js';
 import { CORE_FETCH_GRAPHQL, fetchPlaceholders } from '../commerce.js';
 
 await initializeDropin(async () => {
@@ -17,5 +17,9 @@ await initializeDropin(async () => {
   };
 
   // Initialize auth
-  return initializers.mountImmediately(initialize, { langDefinitions, adobeCommerceOptimizer: getConfigValue('adobe-commerce-optimizer') });
+  // Skip the Adobe Commerce Optimizer tenant lookup when a static price book is
+  // configured: catalog-service-only endpoints don't have a provisioned ACO
+  // tenant, so that lookup would fail and strip the static AC-Price-Book-ID header.
+  const adobeCommerceOptimizer = !isStaticPriceBookEnabled() && getConfigValue('adobe-commerce-optimizer');
+  return initializers.mountImmediately(initialize, { langDefinitions, adobeCommerceOptimizer });
 })();

--- a/scripts/initializers/index.js
+++ b/scripts/initializers/index.js
@@ -33,6 +33,17 @@ const setAdobeCommerceOptimizerHeader = (adobeCommerceOptimizer) => {
   }
 };
 
+// Storefronts backed only by a catalog-service endpoint (no full Commerce SaaS
+// instance and no provisioned Adobe Commerce Optimizer tenant) can price products
+// from a single, statically configured AC-Price-Book-ID header (config.json ->
+// headers.cs). Enable this mode explicitly instead of relying on the
+// Magento-Customer-Group or Adobe Commerce Optimizer tenant lookup, both of which
+// prevent that static price book from resolving prices.
+export const isStaticPriceBookEnabled = () => {
+  const value = getConfigValue('commerce-static-price-book-enabled');
+  return value === true || value === 'true';
+};
+
 const persistCartDataInSession = (data) => {
   if (data?.id) {
     sessionStorage.setItem('DROPINS_CART_ID', data.id);
@@ -58,7 +69,12 @@ const setupAemAssetsImageParams = () => {
 export default async function initializeDropins() {
   const init = async () => {
     // Set Customer-Group-ID header
-    if (getConfigValue('adobe-commerce-optimizer')) {
+    if (isStaticPriceBookEnabled()) {
+      // Keep the statically configured AC-Price-Book-ID header as-is: don't set
+      // Magento-Customer-Group (breaks static price book resolution) and don't
+      // look up an Adobe Commerce Optimizer tenant (unsupported on
+      // catalog-service-only endpoints).
+    } else if (getConfigValue('adobe-commerce-optimizer')) {
       events.on('auth/adobe-commerce-optimizer', setAdobeCommerceOptimizerHeader, { eager: true });
     } else {
       events.on('auth/group-uid', setCustomerGroupHeader, { eager: true });


### PR DESCRIPTION
## Summary

Storefronts configured with only a catalog-service endpoint and a static `AC-Price-Book-ID` header (no full Adobe Commerce SaaS instance, no provisioned Adobe Commerce Optimizer tenant) currently get `price: null` for every product, rendered as `$0.00` on PLP/search/PDP. Neither existing header-selection mode supports this setup:

- `adobe-commerce-optimizer: false` sets a `Magento-Customer-Group` header (from the `auth/group-uid` event, which is emitted unconditionally by the auth dropin regardless of this flag). Adding that header to a static-price-book request makes the price book return `null` for every item.
- `adobe-commerce-optimizer: true` looks up an Optimizer tenant via a `commerceOptimizer { priceBookId }` query, which fails with `tenant_not_found` on catalog-service-only tenants and removes the `AC-Price-Book-ID` header entirely.

## Change

Adds an opt-in `commerce-static-price-book-enabled` config flag:

- `scripts/initializers/index.js`: when enabled, skips both the `Magento-Customer-Group` and Adobe Commerce Optimizer header listeners, leaving the `AC-Price-Book-ID` header configured in `config.json`'s `headers.cs` untouched.
- `scripts/initializers/auth.js`: when enabled, passes `adobeCommerceOptimizer: false` to the auth dropin's `initialize`, so it never attempts the failing tenant lookup in the first place.

Default behavior (flag unset) is unchanged — existing full-Commerce and Adobe Commerce Optimizer setups are unaffected.

## Verification

This repo's default authored config uses a full Adobe Commerce backend (Magento headers, no price book), so this preview URL demonstrates there is no regression in the default flow:
https://USF-4366--aem-boilerplate-commerce--hlxsites.aem.page/search

The actual fix was verified locally with Playwright against a catalog-service-only sandbox (the exact repro from the ticket: `commerce-endpoint` pointing at a catalog-service sandbox, `AC-Price-Book-ID: global_visibility`, `adobe-commerce-optimizer: true`, no provisioned Optimizer tenant), on `/search?q=tyre`:

- Before (flag unset, matching current broken behavior): all prices `$0.00`.
- After (`commerce-static-price-book-enabled: true`): correct prices (e.g. `$750.00`, `$450.00`), `AC-Price-Book-ID: global_visibility` still sent, no `Magento-Customer-Group` header sent, and no Optimizer tenant lookup performed.

`npm run lint` passes.

Jira: https://jira.corp.adobe.com/browse/USF-4366
