### PR TITLE
fix: correct enrichment block content matching

### DIFF
--- a/blocks/enrichment/enrichment.js
+++ b/blocks/enrichment/enrichment.js
@@ -3,7 +3,9 @@ import { getProductSku, fetchIndex, IS_UE } from '../../scripts/commerce.js';
 import { loadFragment } from '../fragment/fragment.js';
 
 export default async function decorate(block) {
-  const { type, position } = readBlockConfig(block);
+  const { type: rawType, position } = readBlockConfig(block);
+  // Authored values (e.g. from a select field) may not match the expected case exactly.
+  const type = rawType?.trim().toLowerCase();
 
   try {
     const filters = {};
@@ -17,9 +19,7 @@ export default async function decorate(block) {
         throw new Error('No product SKU found in URL');
       }
       filters.products = productSku;
-    }
-
-    if (type === 'category') {
+    } else if (type === 'category') {
       // Look for PLP block using "product-list-page" block selector
       const plpBlock = document.querySelector('.product-list-page');
       if (!plpBlock) {
@@ -31,6 +31,10 @@ export default async function decorate(block) {
         throw new Error('No category ID found in product list page block');
       }
       filters.categories = category;
+    } else {
+      // An unrecognized type must not fall through to matching on position alone,
+      // which would leak unrelated content onto every page.
+      throw new Error(`Unsupported enrichment type "${rawType}"`);
     }
 
     if (position) {

--- a/blocks/enrichment/enrichment.js
+++ b/blocks/enrichment/enrichment.js
@@ -40,8 +40,12 @@ export default async function decorate(block) {
     const index = await fetchIndex('enrichment/enrichment');
     const matchingFragments = index.data
       .filter((fragment) => Object.keys(filters).every((filterKey) => {
-        const values = JSON.parse(fragment[filterKey]);
-        return values.includes(filters[filterKey]);
+        const values = fragment[filterKey];
+        // An untagged position means "no restriction", so it matches any requested position.
+        if (filterKey === 'positions' && values.length === 0) return true;
+        // Comma-separated metadata values (e.g. "apparel, bags") aren't trimmed by the
+        // query index, so compare loosely rather than requiring an exact string match.
+        return values.some((value) => value.trim() === filters[filterKey]);
       }))
       .map((fragment) => fragment.path);
 


### PR DESCRIPTION
## What the changes intend

The `enrichment` block's fragment-matching logic has four compounding bugs — three that silently prevent any enrichment content from ever rendering, and one that leaks *unrelated* enrichment content onto every page — all with no visible error to the content author.

## How they change the existing code

`blocks/enrichment/enrichment.js`:

1. **`JSON.parse` crash on already-parsed data.** `fetchIndex()` returns already-parsed JSON, so `fragment.products` / `.categories` / `.positions` are already arrays (e.g. `["24-MB03"]`). The code ran `JSON.parse(fragment[filterKey])` on them — `JSON.parse` coerces its argument to a string first, so `JSON.parse(["24-MB03"])` becomes `JSON.parse("24-MB03")`, which throws `SyntaxError: Unexpected non-whitespace character after JSON`. An empty array (`[]`) throws `SyntaxError: Unexpected end of JSON input`. The exception is caught by `decorate()`'s `try/catch` and logged via `console.error`, but the `finally` block unconditionally removes `.enrichment-wrapper` regardless — so the block just silently disappears with only a console error to show for it.
2. **Untagged `positions` treated as "matches nothing."** When a block is authored with a `position` (e.g. `below-category`), the code requires the fragment's `positions` array to include it. Fragments that leave `enrichment-positions` blank get `positions: []`, so `[].includes('below-category')` is `false` — excluded even though they correctly matched on `products`/`categories`. An untagged position should mean "no restriction," not "excluded."
3. **Un-trimmed comma-separated metadata values.** The query index's extraction regex for `products`/`categories`/`positions` doesn't trim whitespace around comma-separated tokens, so authoring `enrichment-categories="apparel, bags"` (the natural way to type a list) produces `["apparel", " bags"]` — note the leading space. Exact-match comparison then fails for every token after the first.
4. **Case-sensitive `type` comparison lets unrelated content leak onto every page.** The code checks `type === 'product'` / `type === 'category'`, but an authored value of `"Product"` (capital P, produced by at least one authoring surface for a select-style field) matches neither branch. `filters` then never gets a `products`/`categories` constraint at all — only `positions`, if set — so the block matches purely on position and shows *any* enrichment fragment with a compatible (or blank) position, regardless of whether it has anything to do with the current product or category. Confirmed live: a plush-toy PDP was rendering a promo banner scoped to an unrelated SKU, and a separate promo banner scoped to unrelated categories (apparel/bags), because its `type` was authored as `"Product"`.

Commit 1 (`fix: correct enrichment block content matching`) fixes bugs 1 and 2 outright, and defends against bug 3 client-side (its root cause is upstream in the index config, out of scope for this PR). Commit 2 (`fix: normalize enrichment "type" comparison...`) fixes bug 4 by normalizing (`trim().toLowerCase()`) the authored `type` before comparing, and throwing on an unrecognized type instead of silently falling through to matching everything.

## If (and what) they break

Nothing observed. `npm run lint` passes on the changed file. Behavior is strictly more correct than before: previously 0% of enrichment content ever rendered where it should (bugs 1–3), or content rendered where it shouldn't (bug 4).

## Verification

Reproduced and verified against a live Edge Delivery Services + Adobe Commerce storefront project using this same boilerplate/block unmodified — confirmed the `JSON.parse` crash and the untagged-position/un-trimmed-value misses via Chrome DevTools (console + network), then confirmed the mis-cased `type` causing unrelated banners to render on an unrelated product page. After the fix: correct content renders on matching product/category pages, and no content renders on unrelated pages — all with zero console errors.
